### PR TITLE
Client CLI: add `request-attestation-doc` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,13 @@ local-describe-pcr:
 		--host-ip 127.0.0.1 \
 		--host-port 3000
 
+.PHONY: local-req-att-doc
+local-req-att-doc:
+	cargo run --bin qos-client \
+		request-attestation-doc \
+		--host-ip 127.0.0.1 \
+		--host-port 3000
+
 .PHONY: gen-att-doc
 gen-att-doc:
 	OPENSSL_DIR=/usr cargo run --bin gen_att_doc

--- a/qos-client/src/cli/services.rs
+++ b/qos-client/src/cli/services.rs
@@ -808,7 +808,7 @@ fn find_attestation_doc<P: AsRef<Path>>(boot_dir: P) -> AttestationDoc {
 /// # Panics
 ///
 /// Panics if extraction or validation fails.
-fn extract_attestation_doc(cose_sign1_der: &[u8]) -> AttestationDoc {
+pub(crate) fn extract_attestation_doc(cose_sign1_der: &[u8]) -> AttestationDoc {
 	#[cfg(feature = "mock")]
 	let validation_time =
 		qos_core::protocol::attestor::mock::MOCK_SECONDS_SINCE_EPOCH;


### PR DESCRIPTION
Adds the `request-attestation-doc`, which is should be useful for debugging.

To run the command locally, you can run `make local-req-att-doc`.