### PR TITLE
Remove local feature

### DIFF
--- a/qos-client/Cargo.toml
+++ b/qos-client/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-qos-core = { path = "../qos-core", default-features = false, features = ["local"] }
+qos-core = { path = "../qos-core", default-features = false }
 qos-crypto = { path = "../qos-crypto", default-features = false }
 
 # Third party
@@ -23,7 +23,7 @@ sample-app = { path = "../sample-app", optional = true }
 
 [dev-dependencies]
 # We need mock enabled to grab things related to the mock NSM.
-qos-core = { path = "../qos-core", features = ["mock", "local"], default-features = false }
+qos-core = { path = "../qos-core", features = ["mock"], default-features = false }
 
 [features]
 default = []

--- a/qos-core/Cargo.toml
+++ b/qos-core/Cargo.toml
@@ -15,9 +15,6 @@ aws-nitro-enclaves-nsm-api = { version = "0.2.1", default-features = false }
 serde_bytes = { version = "0.11", default-features = false }
 
 [features]
-default=["local"]
-# Support for unix sockets
-local = []
 # Support for VSOCK
 vm = []
 # Never use in production - support for mock NSM

--- a/qos-core/src/cli.rs
+++ b/qos-core/src/cli.rs
@@ -59,7 +59,6 @@ impl EnclaveOpts {
 				c.parse::<u32>().unwrap(),
 				p.parse::<u32>().unwrap(),
 			),
-			#[cfg(feature = "local")]
 			(None, None, Some(u)) => SocketAddress::new_unix(u),
 			_ => panic!("Invalid socket opts"),
 		}

--- a/qos-host/Cargo.toml
+++ b/qos-host/Cargo.toml
@@ -12,6 +12,4 @@ tokio = { version = "1.18", features = ["macros", "rt-multi-thread"], default-fe
 borsh = { version = "0.9" }
 
 [features]
-default = ["local"]
-local = ["qos-core/local"]
 vm = ["qos-core/vm"]

--- a/qos-host/src/cli.rs
+++ b/qos-host/src/cli.rs
@@ -109,7 +109,6 @@ impl HostOptions {
 				c.parse::<u32>().unwrap(),
 				p.parse::<u32>().unwrap(),
 			),
-			#[cfg(feature = "local")]
 			(None, None, Some(u)) => SocketAddress::new_unix(u),
 			_ => panic!("Invalid socket options"),
 		}

--- a/qos-test/Cargo.toml
+++ b/qos-test/Cargo.toml
@@ -5,15 +5,15 @@ edition = "2021"
 publish = false
 
 [dependencies]
-qos-core = { path = "../qos-core", features = ["local"], default-features = false }
-qos-host = { path = "../qos-host", features = ["local"], default-features = false }
+qos-core = { path = "../qos-core", default-features = false }
+qos-host = { path = "../qos-host", default-features = false }
 qos-client = { path = "../qos-client", features = ["sample"], default-features = false }
 qos-crypto = { path = "../qos-crypto" }
 sample-app = { path = "../sample-app" }
 tokio = { version = "1.18", features = ["macros", "rt-multi-thread"], default-features = false }
 
 [dev-dependencies]
-qos-core = { path = "../qos-core", features = ["mock","local"], default-features = false }
+qos-core = { path = "../qos-core", features = ["mock"], default-features = false }
 qos-client = { path = "../qos-client", features = ["mock"], default-features = false }
 borsh = { version = "0.9" }
 openssl = "0.10.40"

--- a/sample-app/Cargo.toml
+++ b/sample-app/Cargo.toml
@@ -9,10 +9,3 @@ qos-core = { path = "../qos-core", default-features = false }
 qos-crypto = { path = "../qos-crypto", default-features = false }
 
 borsh = { version = "0.9" }
-
-[features]
-default=["local"]
-# Support for unix sockets
-local = ["qos-core/local"]
-# Production settings
-vm = ["qos-core/vm"]


### PR DESCRIPTION
This removes the `local` feature, which feature gated the unix sockets. The secure app always uses unix sockets, so they no longer should be feature gated.