### PR TITLE
Add key forwarding boot planning doc

### DIFF
--- a/src/qos_core/KEY_FORWARDING.MD
+++ b/src/qos_core/KEY_FORWARDING.MD
@@ -76,7 +76,7 @@ The details for how QOS nodes communicate with each other can vary, but for the 
       }
     ```
 
-6) The New Node processes the request by performing the following requests:
+6) The New Node processes the request by performing the following steps:
     1) Verify the signature over the `encrypted_quorum_key` against the Quorum Key specified in the New Manifest.
     1) Decrypt the encrypted Quorum Key in the request with the Ephemeral Key.
     1) Check that the decrypted Quorum Key public key matches the one specified in the New Manifest.


### PR DESCRIPTION
This PR adds a markdown document that describes critical aspects of the sub-routines for for forwarding a quorum key to a QOS node for bootstrapping.

This document is mean to be a high level description, focusing on the types of checks/validation necessary to securely forward the key. Any mentioned implementation details are mostly for the sake of having something concrete to talk about.

I am not sure if we should merge this in, but was thinking discussion on PR here would be a good way to talk about in the open.