### PR TITLE
Downgrade rust toolchain to 1.61

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions-rs/toolchain@568dc894a7f9e32ffd9bb7d7a6cebb784cdaa2b0 # v1.0.7
         with:
           profile: minimal
-          toolchain: 1.63.0
+          toolchain: 1.61
           override: true
           components: rustfmt, clippy
 
@@ -59,7 +59,7 @@ jobs:
         uses: actions-rs/toolchain@568dc894a7f9e32ffd9bb7d7a6cebb784cdaa2b0 # v1.0.7
         with:
           profile: minimal
-          toolchain: 1.63.0
+          toolchain: 1.61
           override: true
           components: clippy
 


### PR DESCRIPTION
In order to support deterministic builds with debian we need to use rustc 1.61. This PR downgrades CI to use 1.61.