### PR TITLE
Improve `proxy-re-encrypt-share` verifications 

### DIFF
--- a/src/integration/tests/boot.rs
+++ b/src/integration/tests/boot.rs
@@ -295,7 +295,7 @@ async fn boot_e2e() {
 	// -- Make sure the enclave and host have time to boot
 	qos_test_primitives::wait_until_port_is_bound(host_port);
 
-	// -- CLIENT broadcast boot standard instruction
+	// -- CLIENT generate the manifest envelope
 	assert!(Command::new("../target/debug/qos_client")
 		.args(["generate-manifest-envelope", "--manifest-dir", &*boot_dir,])
 		.spawn()
@@ -353,6 +353,8 @@ async fn boot_e2e() {
 				"proxy-re-encrypt-share",
 				"--attestation-dir",
 				&*attestation_dir,
+				"--manifest-dir",
+				&*boot_dir,
 				"--personal-dir",
 				&personal_dir(user),
 				"--pcr3-preimage-path",

--- a/src/qos_client/src/cli/mod.rs
+++ b/src/qos_client/src/cli/mod.rs
@@ -732,6 +732,7 @@ impl Command {
 			.token(Self::personal_dir_token())
 			.token(Self::pcr3_preimage_path_token())
 			.token(Self::manifest_set_dir_token())
+			.token(Self::manifest_dir_token())
 			.token(Self::alias_token())
 			.token(Self::unsafe_skip_attestation_token())
 			.token(Self::unsafe_eph_path_override_token())
@@ -1219,6 +1220,7 @@ mod handlers {
 		services::proxy_re_encrypt_share(ProxyReEncryptShareArgs {
 			attestation_dir: opts.attestation_dir(),
 			personal_dir: opts.personal_dir(),
+			manifest_dir: opts.manifest_dir(),
 			pcr3_preimage_path: opts.pcr3_preimage_path(),
 			alias: opts.alias(),
 			manifest_set_dir: opts.manifest_set_dir(),


### PR DESCRIPTION
- [x] add both programmatic and human checks for `proxy-re-encrypt-share` command
- [x] pull out generate manifest envelope logic from `boot-genesis` and put into its own command. The intent here is that the manifest envelope will get recorded in the org's `namespaces` repo. When performing `proxy-re-encrypt-share`, that manifest envelope will be referenced for manifest approvals.
-  [x] `proxy-re-encrypt-share` reads the manifest from the `--manifest-dir`, which should be the sub folder in the `namespaces` repo where the specific manifest belongs. The command used to rely on the manifest envelope that `get-attestation-doc` returned. We want to rely on the manifest from the `namespaces` repo because it makes it more clear which version of the manifest we are using. If we simply rely on the manifest the enclave returns, we might be more likely to run into issues of accidentally posting a share to enclave with an older manifest.

TODO

- [x] Unit tests for proxy-re-encrypt-share verifications

I recommend viewing this with the whitespace changes hidden:

<img width="438" alt="Screen Shot 2022-10-20 at 3 09 26 PM" src="https://user-images.githubusercontent.com/32168567/197036778-c70d3765-0dce-436e-b577-bc28cd316b5f.png">
