### PR TITLE
Remove stale docs for `qos_client CLI`

### DIFF
--- a/src/qos_client/src/cli/mod.rs
+++ b/src/qos_client/src/cli/mod.rs
@@ -7,7 +7,6 @@
 //! ```shell
 //! cargo run --bin qos_client <command-name> --help
 //! ```
-//!
 
 use std::env;
 


### PR DESCRIPTION
The docs for the qos client CLI are stale and misleading. This PR removes them.