### PR TITLE
qos_hex: Fix edge cases with short inputs to decode

### DIFF
--- a/src/qos_hex/src/lib.rs
+++ b/src/qos_hex/src/lib.rs
@@ -48,18 +48,16 @@ impl From<ParseIntError> for HexError {
 /// - if a character is invalid hex
 /// - if the input is too long.
 pub fn decode(raw_s: &str) -> Result<Vec<u8>, HexError> {
-	let sanitized_s = {
-		let raw_s_byte_len = raw_s.len();
-		if raw_s_byte_len == 0 {
-			// We can do an explicit exit early
-			return Ok(Vec::new());
-		} else if raw_s_byte_len == 1 {
-			return Err(HexError::LengthOne);
-		} else if &raw_s[..2] == "0x" {
-			// we know the s is at least len 2
-			&raw_s[2..]
-		} else {
-			raw_s
+	let sanitized_s = match raw_s.len() {
+		0 => return Ok(Vec::new()),
+		1 => return Err(HexError::LengthOne),
+		_ => {
+			// we know that s is at least len 2
+			if &raw_s[..2] == "0x" {
+				&raw_s[2..]
+			} else {
+				raw_s
+			}
 		}
 	};
 


### PR DESCRIPTION
This try's to address panics found from fuzzing users of `qos_hex`. We were getting issues of indexing out of bounds in this line:

https://github.com/tkhq/qos/blob/780176eec3d4ab52a33b638784d92935ddcc680f/src/qos_hex/src/lib.rs#L49

because slicing into a str with a length less then 2 panics.

This fixes errors like:

```
(lldb) r ../fuzzing/out_evm_parser.round2/default/crashes/id:000013,sig:06,src:000265+000210,time:9731995,execs:118583205,op:splice,rep:4 
Process 60555 launched: 'qos-main/src/target/debug/fuzz_evm_parser_replay' (x86_64)
thread 'main' panicked at 'byte index 2 is out of bounds of `
`', qos_hex/src/lib.rs:49:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Process 60555 exited with status = 101 (0x00000065)
```
