### PR TITLE
Use dtolnay/rust-toolchain to build rust in github workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Install stable toolchain
         id: toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
+        uses: dtolnay/rust-toolchain@ce8f65846d7180d2ce63b1e74483d981800b9e22
         with:
           profile: minimal
           toolchain: 1.61
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install nightly toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
+        uses: dtolnay/rust-toolchain@ce8f65846d7180d2ce63b1e74483d981800b9e22
         with:
           profile: minimal
           toolchain: nightly


### PR DESCRIPTION
"The GitHub workflows use the @actions-rs/toolchain in version 1.0.7. While this is the newest tagged version, it appears that the package itself is more or less unmaintained: https://github.com/actions-rs/toolchain/issues/216.
Looking at https://github.com/actions-rs , development on the other packages stopped Mid-2020 to Late-2020 as well."