### PR TITLE
Don't use mock a only feature in prod code

### DIFF
--- a/src/qos_core/src/protocol/services/key.rs
+++ b/src/qos_core/src/protocol/services/key.rs
@@ -48,7 +48,7 @@ pub(in crate::protocol) fn inject_key(
 	};
 	let decrypted_quorum_pair = P256Pair::from_master_seed(&quorum_master_seed)
 		.map_err(|_| ProtocolError::InvalidQuorumSecret)?;
-	if decrypted_quorum_pair.public_key() != quorum_public {
+	if decrypted_quorum_pair.public_key().to_bytes() != quorum_public.to_bytes() {
 		return Err(ProtocolError::WrongQuorumKey);
 	}
 	state.handles.put_quorum_key(&decrypted_quorum_pair)?;


### PR DESCRIPTION
`PartialEq` for `P256Public` is feature gated to mock 


https://github.com/tkhq/qos/blob/5f279f31941114141a6ba6fc3489c7763ff77458/src/qos_p256/src/lib.rs#L221-L224

This PR removes usage of `PartialEq` on `P256Public`  for production code. 