### PR TITLE
add make list helper

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,7 +27,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Run cargo test
-        run: make -C src test-all
+        run: make -C src test
 
   rustfmt:
     name: rustfmt

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,3 +1,6 @@
+ROOT := $(shell git rev-parse --show-toplevel)
+include $(ROOT)/tools.mk
+
 REGISTRY := 339735964233.dkr.ecr.us-east-1.amazonaws.com
 BUCKET := tkhq-development-qos_resources
 
@@ -59,9 +62,6 @@ vm-host:
 		--host-port 3000 \
 		--cid 16 \
 		--port 6969
-
-.DEFAULT_GOAL := all
-default: all
 
 .PHONY: all
 all: host client core
@@ -152,8 +152,8 @@ fmt:
 	cargo +nightly version
 	cargo +nightly fmt
 
-.PHONY: test-all
-test-all:
+.PHONY: test
+test:
 	@# The integration tests rely on binaries from other crates being built, so
 	@# we build all the workspace targets.
 	cargo build --all

--- a/tools.mk
+++ b/tools.mk
@@ -1,0 +1,4 @@
+# Lists all make commands in a Makefile
+.PHONY: list
+list:
+	@LC_ALL=C $(MAKE) -pRrq -f $(firstword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/(^|\n)# Files(\n|$$)/,/(^|\n)# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$'


### PR DESCRIPTION
### Motivation
While it's conventional for `make` to default to `make all`, I find discovery infinitely easier when `make` lists the available commands instead. Not a hill I'll die on, but it's worked well in the mono so far

### Changes
- adds `make list` as default make command
- `make test-all` -> `make test`