### PR TITLE
[RFC] qos_nsm: refactor nsm_init and nsm_exit

### DIFF
--- a/src/qos_core/src/protocol/services/attestation.rs
+++ b/src/qos_core/src/protocol/services/attestation.rs
@@ -31,6 +31,5 @@ pub(super) fn get_post_boot_attestation_doc(
 		public_key: Some(ephemeral_public_key),
 	};
 
-	let fd = attestor.nsm_init();
-	attestor.nsm_process_request(fd, request)
+	attestor.nsm_process_request(request)
 }

--- a/src/qos_core/src/protocol/services/genesis.rs
+++ b/src/qos_core/src/protocol/services/genesis.rs
@@ -180,9 +180,7 @@ pub(in crate::protocol) fn boot_genesis(
 			nonce: None,
 			public_key: None,
 		};
-		let fd = state.attestor.nsm_init();
-
-		state.attestor.nsm_process_request(fd, request)
+		state.attestor.nsm_process_request(request)
 	};
 
 	Ok((genesis_output, nsm_response))

--- a/src/qos_core/src/protocol/state.rs
+++ b/src/qos_core/src/protocol/state.rs
@@ -369,10 +369,8 @@ mod handlers {
 		state: &mut ProtocolState,
 	) -> ProtocolRouteResponse {
 		if let ProtocolMsg::NsmRequest { nsm_request } = req {
-			let nsm_response = {
-				let fd = state.attestor.nsm_init();
-				state.attestor.nsm_process_request(fd, nsm_request.clone())
-			};
+			let nsm_response =
+				state.attestor.nsm_process_request(nsm_request.clone());
 			let result = Ok(ProtocolMsg::NsmResponse { nsm_response });
 			Some(result)
 		} else {

--- a/src/qos_nsm/src/mock.rs
+++ b/src/qos_nsm/src/mock.rs
@@ -40,11 +40,7 @@ pub const MOCK_NSM_ATTESTATION_DOCUMENT: &[u8] =
 /// Mock Nitro Secure Module endpoint that should only ever be used for testing.
 pub struct MockNsm;
 impl NsmProvider for MockNsm {
-	fn nsm_process_request(
-		&self,
-		_fd: i32,
-		request: NsmRequest,
-	) -> NsmResponse {
+	fn nsm_process_request(&self, request: NsmRequest) -> NsmResponse {
 		match request {
 			NsmRequest::Attestation {
 				user_data: _,
@@ -74,16 +70,6 @@ impl NsmProvider for MockNsm {
 				NsmResponse::DescribePCR { lock: false, data: vec![3, 4, 7, 4] }
 			}
 		}
-	}
-
-	fn nsm_init(&self) -> i32 {
-		33
-	}
-
-	fn nsm_exit(&self, fd: i32) {
-		// Should be hardcoded to value returned by nsm_init
-		assert_eq!(fd, 33);
-		println!("nsm_exit");
 	}
 
 	fn timestamp_ms(&self) -> Result<u64, nitro::AttestError> {

--- a/src/qos_nsm/src/nsm.rs
+++ b/src/qos_nsm/src/nsm.rs
@@ -12,23 +12,12 @@ pub trait NsmProvider {
 	/// Create a message with input data and output capacity from a given
 	/// request, then send it to the NSM driver via `ioctl()` and wait
 	/// for the driver's response.
-	/// *Argument 1 (input)*: The descriptor to the NSM device file.
-	/// *Argument 2 (input)*: The NSM request.
+	/// *Argument 1 (input)*: The NSM request.
 	/// *Returns*: The corresponding NSM response from the driver.
 	fn nsm_process_request(
 		&self,
-		fd: i32,
 		request: types::NsmRequest,
 	) -> types::NsmResponse;
-
-	/// NSM library initialization function.
-	/// *Returns*: A descriptor for the opened device file.
-	fn nsm_init(&self) -> i32;
-
-	/// NSM library exit function.
-	/// *Argument 1 (input)*: The descriptor for the opened device file, as
-	/// obtained from `nsm_init()`.
-	fn nsm_exit(&self, fd: i32);
 
 	/// requests an attestation document and returns its timestamp in
 	/// milliseconds
@@ -40,18 +29,13 @@ pub struct Nsm;
 impl NsmProvider for Nsm {
 	fn nsm_process_request(
 		&self,
-		fd: i32,
 		request: types::NsmRequest,
 	) -> types::NsmResponse {
-		nsm::driver::nsm_process_request(fd, request.into()).into()
-	}
-
-	fn nsm_init(&self) -> i32 {
-		nsm::driver::nsm_init()
-	}
-
-	fn nsm_exit(&self, fd: i32) {
+		let fd = nsm::driver::nsm_init();
+		let response =
+			nsm::driver::nsm_process_request(fd, request.into()).into();
 		nsm::driver::nsm_exit(fd);
+		response
 	}
 
 	fn timestamp_ms(&self) -> Result<u64, nitro::AttestError> {
@@ -61,19 +45,14 @@ impl NsmProvider for Nsm {
 			public_key: None,
 		};
 
-		let fd = self.nsm_init();
-		let nsm_response = self.nsm_process_request(fd, nsm_request);
-
-		let result = match nsm_response {
+		let nsm_response = self.nsm_process_request(nsm_request);
+		match nsm_response {
 			types::NsmResponse::Attestation { document } => {
 				let attestation_document =
 					nitro::unsafe_attestation_doc_from_der(&document)?;
 				Ok(attestation_document.timestamp)
 			}
 			resp => Err(nitro::AttestError::UnexpectedNsmResponse(resp)),
-		};
-
-		self.nsm_exit(fd);
-		result
+		}
 	}
 }


### PR DESCRIPTION
### Changes
- removes `nsm_init` and `nsm_exit` from `NsmProvider` trait

### Notes
- I'm not sure what happens if we fail to call `nsm_exit` properly
- Also not sure the extra overhead of [opening the same file](https://github.com/aws/aws-nitro-enclaves-nsm-api/blob/main/src/driver/mod.rs#L113) is worth it