### PR TITLE
Increase connect retries for Stream

### DIFF
--- a/src/qos_core/src/io/stream.rs
+++ b/src/qos_core/src/io/stream.rs
@@ -16,8 +16,8 @@ use nix::{
 
 use super::IOError;
 
-// 25(retries) x 10(milliseconds) = 1/4 a second of retrying
-const MAX_RETRY: usize = 25;
+// 50(retries) x 10(milliseconds) = 1/2 a second of retrying
+const MAX_RETRY: usize = 50;
 const BACKOFF_MILLISECONDS: u64 = 10;
 const BACKLOG: usize = 128;
 


### PR DESCRIPTION
Saw a test was flaky in CI due to connect timing out. This increases doubles the total timeout time for connect from a quarter second to half a second.