### PR TITLE
Simplify pivot build artifact usage

### DIFF
--- a/src/integration/tests/enclave_app_client_socket_stress.rs
+++ b/src/integration/tests/enclave_app_client_socket_stress.rs
@@ -34,7 +34,6 @@ fn enclave_app_client_socket_stress() {
 			quorum_key: vec![],
 		},
 		pivot: PivotConfig {
-			commit: String::default(),
 			hash: [1; 32],
 			restart: RestartPolicy::Always,
 			args: vec![APP_SOCK.to_string()],

--- a/src/integration/tests/key.rs
+++ b/src/integration/tests/key.rs
@@ -13,8 +13,7 @@ const ALL_PERSONAL_DIR: &str = "./mock/boot-e2e/all-personal-dir";
 const BOOT_DIR: &str = "/tmp/key-fwd-e2e/boot-dir";
 const TMP_DIR: &str = "/tmp/key-fwd-e2e";
 const ATTESTATION_DOC_PATH: &str = "/tmp/key-fwd-e2e/attestation_doc";
-const PIVOT_BUILD_FINGERPRINTS_PATH: &str =
-	"/tmp/key-fwd-e2e/pivot-build-fingerprints.txt";
+const PIVOT_HASH_PATH: &str = "/tmp/key-fwd-e2e/pivot-hash-path.txt";
 const USERS: &[&str] = &["user1", "user2", "user3"];
 const TEST_MSG: &str = "test-msg";
 const NEW_ATTESTATION_DOC_PATH: &str = "/tmp/key-fwd-e2e/new_attestation_doc";
@@ -160,8 +159,8 @@ fn generate_manifest_envelope() {
 			"always",
 			"--pcr3-preimage-path",
 			"./mock/namespaces/pcr3-preimage.txt",
-			"--pivot-build-fingerprints",
-			PIVOT_BUILD_FINGERPRINTS_PATH,
+			"--pivot-hash-path",
+			PIVOT_HASH_PATH,
 			"--qos-release-dir",
 			QOS_DIST_DIR,
 			"--manifest-path",
@@ -196,8 +195,8 @@ fn generate_manifest_envelope() {
 				BOOT_DIR,
 				"--pcr3-preimage-path",
 				"./mock/namespaces/pcr3-preimage.txt",
-				"--pivot-build-fingerprints",
-				PIVOT_BUILD_FINGERPRINTS_PATH,
+				"--pivot-hash-path",
+				PIVOT_HASH_PATH,
 				"--qos-release-dir",
 				QOS_DIST_DIR,
 				"--manifest-set-dir",
@@ -388,12 +387,6 @@ fn personal_dir(user: &str) -> String {
 fn build_pivot_fingerprints() {
 	let pivot = fs::read(PIVOT_LOOP_PATH).unwrap();
 	let mock_pivot_hash = sha_256(&pivot);
-	let build_fingerprints = {
-		let mut build_fingerprints =
-			qos_hex::encode(&mock_pivot_hash).as_bytes().to_vec();
-		build_fingerprints.extend_from_slice(b"\n");
-		build_fingerprints.extend_from_slice(b"mock-pivot-commit");
-		build_fingerprints
-	};
-	std::fs::write(PIVOT_BUILD_FINGERPRINTS_PATH, build_fingerprints).unwrap();
+	let mock_pivot_hash_hex = qos_hex::encode(&mock_pivot_hash);
+	std::fs::write(PIVOT_HASH_PATH, mock_pivot_hash_hex).unwrap();
 }

--- a/src/qos_core/src/protocol/services/boot.rs
+++ b/src/qos_core/src/protocol/services/boot.rs
@@ -89,8 +89,6 @@ impl TryFrom<String> for RestartPolicy {
 )]
 #[cfg_attr(any(feature = "mock", test), derive(Default))]
 pub struct PivotConfig {
-	/// Reference to the commit the pivot was built off of.
-	pub commit: String,
 	/// Hash of the pivot binary, taken from the binary as a `Vec<u8>`.
 	pub hash: Hash256,
 	/// Restart policy for running the pivot binary.
@@ -103,7 +101,6 @@ pub struct PivotConfig {
 impl fmt::Debug for PivotConfig {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		f.debug_struct("PivotConfig")
-			.field("commit", &self.commit)
 			.field("hash", &qos_hex::encode(&self.hash))
 			.field("restart", &self.restart)
 			.field("args", &self.args.join(" "))
@@ -382,7 +379,6 @@ mod test {
 				qos_commit: "mock qos commit".to_string(),
 			},
 			pivot: PivotConfig {
-				commit: "commit lord".to_string(),
 				hash: sha_256(&pivot),
 				restart: RestartPolicy::Always,
 				args: vec![],

--- a/src/qos_core/src/protocol/services/key.rs
+++ b/src/qos_core/src/protocol/services/key.rs
@@ -274,7 +274,6 @@ mod test {
 				qos_commit: "mock qos commit".to_string(),
 			},
 			pivot: PivotConfig {
-				commit: "mock commit".to_string(),
 				hash: sha_256(&pivot),
 				restart: RestartPolicy::Always,
 				args: vec![],

--- a/src/qos_core/src/protocol/services/provision.rs
+++ b/src/qos_core/src/protocol/services/provision.rs
@@ -188,7 +188,6 @@ mod test {
 				qos_commit: "mock qos commit".to_string(),
 			},
 			pivot: PivotConfig {
-				commit: "commit lord".to_string(),
 				hash: sha_256(pivot),
 				restart: RestartPolicy::Always,
 				args: vec![],


### PR DESCRIPTION
This simplifies the pivot build fingerprint to simply just use the pivot hash. Previously we where tracking the commit, but this overly complicated things

Note, this is a breaking change to the manifest format because we remove the pivot commit field. This field was not being cryptographically verified anywhere and made usage unnecessarily more complicated.