### PR TITLE
Remove unused nsm`ProtocolMsg` variant

### DIFF
--- a/src/qos_core/src/protocol/msg.rs
+++ b/src/qos_core/src/protocol/msg.rs
@@ -1,6 +1,6 @@
 //! Enclave executor message types.
 
-use qos_nsm::types::{NsmResponse};
+use qos_nsm::types::NsmResponse;
 
 use crate::protocol::{
 	services::{


### PR DESCRIPTION
This PR removes an unused variant of a protocol message.