### PR TITLE
Remove non const time in rand number gen

### DIFF
--- a/src/qos_client/tests/yubikey.rs
+++ b/src/qos_client/tests/yubikey.rs
@@ -11,7 +11,7 @@ use qos_client::yubikey::{
 };
 use qos_p256::{
 	encrypt::{Envelope, P256EncryptPair, P256EncryptPublic},
-	non_zero_bytes_os_rng,
+	bytes_os_rng,
 	sign::{P256SignPair, P256SignPublic},
 	P256Pair, P256Public, P256_SECRET_LEN,
 };
@@ -132,7 +132,7 @@ fn signing_works(yubikey: &mut YubiKey) {
 }
 
 fn import_signing_works(yubikey: &mut YubiKey) {
-	let secret = non_zero_bytes_os_rng::<P256_SECRET_LEN>();
+	let secret = bytes_os_rng::<P256_SECRET_LEN>();
 	let pair = P256SignPair::from_bytes(&secret).unwrap();
 	let public = pair.public_key();
 
@@ -152,7 +152,7 @@ fn import_signing_works(yubikey: &mut YubiKey) {
 }
 
 fn import_key_agreement_works(yubikey: &mut YubiKey) {
-	let secret = non_zero_bytes_os_rng::<32>();
+	let secret = bytes_os_rng::<32>();
 	let pair = P256EncryptPair::from_bytes(&secret).unwrap();
 	let public = pair.public_key();
 

--- a/src/qos_p256/src/encrypt.rs
+++ b/src/qos_p256/src/encrypt.rs
@@ -14,7 +14,7 @@ use rand_core::OsRng;
 use sha2::Sha512;
 use zeroize::ZeroizeOnDrop;
 
-use crate::{non_zero_bytes_os_rng, P256Error, PUB_KEY_LEN_UNCOMPRESSED};
+use crate::{bytes_os_rng, P256Error, PUB_KEY_LEN_UNCOMPRESSED};
 
 const AES256_KEY_LEN: usize = 32;
 const BITS_96_AS_BYTES: u8 = 12;
@@ -148,7 +148,7 @@ impl P256EncryptPublic {
 
 		let nonce = {
 			let random_bytes =
-				crate::non_zero_bytes_os_rng::<{ BITS_96_AS_BYTES as usize }>();
+				crate::bytes_os_rng::<{ BITS_96_AS_BYTES as usize }>();
 			*Nonce::from_slice(&random_bytes)
 		};
 
@@ -331,7 +331,7 @@ impl AesGcm256Secret {
 	/// Generate a secret
 	#[must_use]
 	pub fn generate() -> Self {
-		Self { secret: non_zero_bytes_os_rng::<AES256_KEY_LEN>() }
+		Self { secret: bytes_os_rng::<AES256_KEY_LEN>() }
 	}
 
 	/// The secret as bytes.
@@ -351,7 +351,7 @@ impl AesGcm256Secret {
 	pub fn encrypt(&self, msg: &[u8]) -> Result<Vec<u8>, P256Error> {
 		let nonce = {
 			let random_bytes =
-				non_zero_bytes_os_rng::<{ BITS_96_AS_BYTES as usize }>();
+				bytes_os_rng::<{ BITS_96_AS_BYTES as usize }>();
 			*Nonce::from_slice(&random_bytes)
 		};
 		let payload = Payload { aad: AES_GCM_256_HMAC_SHA512_TAG, msg };

--- a/src/qos_p256/src/lib.rs
+++ b/src/qos_p256/src/lib.rs
@@ -106,17 +106,11 @@ pub fn derive_secret(
 
 /// Helper function to generate a `N` length byte buffer.
 #[must_use]
-pub fn non_zero_bytes_os_rng<const N: usize>() -> [u8; N] {
-	loop {
-		let mut key = [0u8; N];
-		OsRng.fill_bytes(&mut key);
+pub fn bytes_os_rng<const N: usize>() -> [u8; N] {
+	let mut key = [0u8; N];
+	OsRng.fill_bytes(&mut key);
 
-		if key.iter().all(|bit| *bit == 0) {
-			// try again if we got all zeros
-		} else {
-			return key;
-		}
-	}
+	key
 }
 
 /// P256 private key pair for signing and encryption. Internally this uses a
@@ -133,7 +127,7 @@ pub struct P256Pair {
 impl P256Pair {
 	/// Generate a new private key using the OS randomness source.
 	pub fn generate() -> Result<Self, P256Error> {
-		let master_seed = non_zero_bytes_os_rng::<MASTER_SEED_LEN>();
+		let master_seed = bytes_os_rng::<MASTER_SEED_LEN>();
 
 		let p256_encrypt_secret =
 			derive_secret(&master_seed, P256_ENCRYPT_DERIVE_PATH)?;


### PR DESCRIPTION
problem: "The non_zero_bytes_os_rng random number generator checks if the generated bytes are not all zero. It does that with the short-circuiting method all. Because of this, an attacker able to perform timing attacks would be able to deduce the number of leading zero bytes."

solution: remove check for all zeros. We are confident that the chance of having all zeros is so low that the check is not necessary.
