### PR TITLE
Print enclave client error in qos host

### DIFF
--- a/src/qos_host/src/lib.rs
+++ b/src/qos_host/src/lib.rs
@@ -145,10 +145,7 @@ impl HostServer {
 			Err(e) => {
 				let msg = format!("Enclave request failed {e:?}");
 				println!("{msg}");
-				return (
-					StatusCode::INTERNAL_SERVER_ERROR,
-					Html(msg),
-				)
+				return (StatusCode::INTERNAL_SERVER_ERROR, Html(msg));
 			}
 		};
 


### PR DESCRIPTION
This just adds a more granular error message in qos host