### PR TITLE
README.md: add release process section

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,4 +152,21 @@ make toolchain-shell
 make toolchain-update
 ```
 
+
+### Release Process
+
+ 1. Create a branch for your release e.g.
+    `git checkout -b release/v1.0.0`
+ 2. Run `make dist` as described in ["Release" section](#release)
+ 3. Commit the new dist folder `git commit -m "Release v1.0.0" -- dist/`
+ 4. Push up your branch to github, and make a pull request.
+ 5. You may also create and push a signed `-rcX` git tag where the number after `rc` doesn't already exist.
+    `git tag -S v1.0.0-rc0 -m v1.0.0-rc0`
+    `git push origin v1.0.0-rc0`
+ 6. Wait for others to replicate your build, see ["Verify" section](#verify)
+ 7. Once the release has enough `git sig` signatures, make the final tag and merge the pull request.
+    `git tag -S v1.0.0 -m v1.0.0`
+    `git push origin v1.0.0`
+
+
 [gs]: https://codeberg.org/distrust/git-sig


### PR DESCRIPTION
To be able to easily track versions, we need to start using git tags for releases.

This PR adds my suggested release flow that includes creating git tags.