### PR TITLE
Revert "upload existing images. Do not build in CI"

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -28,10 +28,17 @@ jobs:
         run: git lfs pull
         shell: bash
 
+      - name: Run `make images`
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+            make toolchain
+            rm -rf fetch/apt
+            make images
+
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
-          name: dist
-          path: dist/
+          name: out
+          path: out/
           retention-days: 1
 
   upload_to_ecr:
@@ -56,7 +63,7 @@ jobs:
       - name: Download Artifacts
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
-          name: dist
+          name: out
 
       - name: Upload images to ECR
         env:
@@ -95,7 +102,7 @@ jobs:
       - name: Download Artifacts
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
-          name: dist
+          name: out
 
       - name: Upload images to GHCR
         env:


### PR DESCRIPTION
This reverts commit 34be23042991fb95f01fb2b97cf51a3f06482ff1; introduced via https://github.com/tkhq/qos/pull/361

In CI we want to build the current contents of the repo; not repeatedly upload the contents of the dist folder; which may be from many commits ago, or something else entirely.