### PR TITLE
Build images in CI

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Run `make out/${{ matrix.target }}`
         shell: 'script -q -e -c "bash {0}"'
         run: |
-          make out/${{ matrix.target }}
+          make --assume-old=fetch/rust out/${{ matrix.target }}
 
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:


### PR DESCRIPTION
Reopening #363 but from in-repo rather than my fork.

This reverts commit 34be23042991fb95f01fb2b97cf51a3f06482ff1; introduced via https://github.com/tkhq/qos/pull/361

In CI we want to build the current contents of the repo; not repeatedly upload the contents of the dist folder; which may be from many commits ago, or something else entirely.

I've included some additional improvements that should help stream-line CI.