### PR TITLE
Add optional path to output manifest envelope

### DIFF
--- a/src/qos_client/src/cli/mod.rs
+++ b/src/qos_client/src/cli/mod.rs
@@ -418,7 +418,7 @@ impl Command {
 	fn manifest_envelope_path_token() -> Token {
 		Token::new(MANIFEST_ENVELOPE_PATH, "Path to a manifest envelope")
 			.takes_value(true)
-			.required(true)
+			.required(false)
 	}
 	fn approval_path_token() -> Token {
 		Token::new(APPROVAL_PATH, "Path to a approval of a manifest.")
@@ -695,6 +695,7 @@ impl Command {
 		Parser::new()
 			.token(Self::manifest_approvals_dir_token())
 			.token(Self::manifest_path_token())
+			.token(Self::manifest_envelope_path_token())
 	}
 
 	fn dangerous_dev_boot() -> Parser {
@@ -1007,6 +1008,10 @@ impl ClientOpts {
 			.single(MANIFEST_ENVELOPE_PATH)
 			.expect("Missing `--manifest-envelope-path`")
 			.to_string()
+	}
+
+	fn maybe_manifest_envelope_path(&self) -> Option<String> {
+		self.parsed.single(MANIFEST_ENVELOPE_PATH).map(String::to_owned)
 	}
 
 	fn approval_path(&self) -> String {
@@ -1579,6 +1584,7 @@ mod handlers {
 		if let Err(e) = services::generate_manifest_envelope(
 			opts.manifest_approvals_dir(),
 			opts.manifest_path(),
+			opts.maybe_manifest_envelope_path(),
 		) {
 			eprintln!("Error: {e:?}");
 			std::process::exit(1);

--- a/src/qos_client/src/cli/services.rs
+++ b/src/qos_client/src/cli/services.rs
@@ -970,6 +970,7 @@ where
 pub(crate) fn generate_manifest_envelope<P: AsRef<Path>>(
 	manifest_approvals_dir: P,
 	manifest_path: P,
+	maybe_manifest_envelope_path: Option<String>,
 ) -> Result<(), Error> {
 	let manifest = read_manifest(&manifest_path)?;
 	let approvals = find_approvals(&manifest_approvals_dir, &manifest);
@@ -986,7 +987,10 @@ pub(crate) fn generate_manifest_envelope<P: AsRef<Path>>(
 		std::process::exit(1);
 	}
 
-	let path = manifest_approvals_dir.as_ref().join(MANIFEST_ENVELOPE);
+	let path = maybe_manifest_envelope_path.map_or_else(
+		|| manifest_approvals_dir.as_ref().join(MANIFEST_ENVELOPE),
+		PathBuf::from,
+	);
 	write_with_msg(
 		&path,
 		&manifest_envelope


### PR DESCRIPTION
Add an option to specify the path to output the manifest. This change is backwards compatible because the new argument is optional and will fall back to the old default path