### PR TITLE
Make enclave CID dynamic

### DIFF
--- a/src/init/init.rs
+++ b/src/init/init.rs
@@ -62,10 +62,7 @@ fn main() {
 	boot();
 	dmesg("QuorumOS Booted".to_string());
 
-	let cid = match get_local_cid() {
-		Ok(cid) => cid,
-		Err(e) => panic!(),
-	};
+	let cid = get_local_cid().unwrap();
 	dmesg(format!("CID is {}", cid));
 
 	let handles = Handles::new(

--- a/src/qos_system/src/lib.rs
+++ b/src/qos_system/src/lib.rs
@@ -8,6 +8,7 @@ use std::{
 
 use libc::{c_int, c_ulong, c_void};
 
+#[derive(Debug)]
 pub struct SystemError {
 	pub message: String,
 }


### PR DESCRIPTION
This change lets us dynamically pick the correct CID in the `init` binary rather than hard-coding `16`.

Implementation inspired by https://github.com/rust-vsock/vsock-rs/pull/19/files#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R522