### PR TITLE
Increase CI Test Suite timeout

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     name: Test Suite
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 45
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
Tests keep timing out in CI - I don't see any reason to have them time out right now so increasing the upper bound to 45 minutes.