### PR TITLE
Set opt-out flag for Rust crates to prevent accidental publishing

### DIFF
--- a/src/eif_build/Cargo.toml
+++ b/src/eif_build/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "eif_build"
 version = "0.1.0"
+publish = false
 
 [dependencies]
 sha2 = "0.9.5"

--- a/src/init/Cargo.toml
+++ b/src/init/Cargo.toml
@@ -2,6 +2,7 @@
 name = "init"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 libc = "0.2.148"

--- a/src/qos_aws/Cargo.toml
+++ b/src/qos_aws/Cargo.toml
@@ -2,6 +2,7 @@
 name = "qos_aws"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/qos_client/Cargo.toml
+++ b/src/qos_client/Cargo.toml
@@ -2,6 +2,7 @@
 name = "qos_client"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 qos_core = { path = "../qos_core", default-features = false }

--- a/src/qos_core/Cargo.toml
+++ b/src/qos_core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "qos_core"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 qos_crypto = { path = "../qos_crypto" }

--- a/src/qos_crypto/Cargo.toml
+++ b/src/qos_crypto/Cargo.toml
@@ -2,6 +2,7 @@
 name = "qos_crypto"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/qos_enclave/Cargo.toml
+++ b/src/qos_enclave/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.2.0"
 authors = [""]
 edition = "2018"
 rust-version = "1.61"
+publish = false
 
 [dependencies]
 nitro-cli = { git = "https://github.com/aws/aws-nitro-enclaves-cli", version = "1.2.2" }

--- a/src/qos_hex/Cargo.toml
+++ b/src/qos_hex/Cargo.toml
@@ -2,6 +2,7 @@
 name = "qos_hex"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 serde = {version = "1", optional = true, default-features = false }

--- a/src/qos_host/Cargo.toml
+++ b/src/qos_host/Cargo.toml
@@ -2,6 +2,7 @@
 name = "qos_host"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 qos_core = { path = "../qos_core", default-features = false }

--- a/src/qos_nsm/Cargo.toml
+++ b/src/qos_nsm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "qos_nsm"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 qos_hex = { path = "../qos_hex" }

--- a/src/qos_p256/Cargo.toml
+++ b/src/qos_p256/Cargo.toml
@@ -2,6 +2,7 @@
 name = "qos_p256"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 qos_hex = { path = "../qos_hex" }

--- a/src/qos_system/Cargo.toml
+++ b/src/qos_system/Cargo.toml
@@ -2,6 +2,7 @@
 name = "qos_system"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/qos_test_primitives/Cargo.toml
+++ b/src/qos_test_primitives/Cargo.toml
@@ -2,6 +2,7 @@
 name = "qos_test_primitives"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 rand = "0.8"


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)
TL;DR: developers with working cargo credentials may accidentally publish confidential Turnkey code/artifacts without additional chances to abort if cargo publish is run in the wrong context, since crates default to being publishable.

See https://github.com/rust-lang/cargo/issues/6153 for potential impact if `publish = false` is not set.

## How I Tested These Changes
No functional change outside of cargo expected.

## Pre merge check list
There is likely no CHANGELOG.md entry necessary.
