### PR TITLE
Containers: save space by deleting apt lists

### DIFF
--- a/src/images/core/Dockerfile
+++ b/src/images/core/Dockerfile
@@ -5,7 +5,9 @@ RUN cargo build --manifest-path ./qos_core/Cargo.toml --bin qos_core --features 
 # We don't need the Rust toolchain to run the binary!
 FROM debian:bullseye-slim AS runtime
 WORKDIR app
-RUN apt-get update \
-  && apt-get install -y libssl-dev
+RUN apt-get update && \
+  apt-get install -y libssl-dev && \
+  rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /target/debug/qos_core /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/qos_core", "--port", "6969", "--cid", "16"]

--- a/src/images/sample-app/Dockerfile
+++ b/src/images/sample-app/Dockerfile
@@ -5,6 +5,8 @@ RUN cargo build --bin sample_app --features vm --no-default-features
 # We don't need the Rust toolchain to run the binary!
 FROM debian:bullseye-slim AS runtime
 WORKDIR app
-RUN apt-get update \
-  && apt-get install -y libssl-dev
+RUN apt-get update && \
+  apt-get install -y libssl-dev && \
+  rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /target/debug/sample_app /usr/local/bin


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

Save ~18 MB per container by not storing unnecessary apt lists.

## How I Tested These Changes

Building the Dockerfile.

## Pre merge check list

No functional changes, no changelog entry required.