### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @tkhq/qos-operators


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)
This PR sets `@tkhq/qos-operators` as the default owner of the QOS repo. After this merges I'll adjust branch protection to require approvals by code owners. This will have the effect of requiring an approval from tkhq/qos-operators instead of an approval by anyone with access to this repo.
