### PR TITLE
ENG-1693: Unit Testing for Borsh Serialization/Deserialization Behavior

### DIFF
--- a/src/integration/tests/borsh_serialize.rs
+++ b/src/integration/tests/borsh_serialize.rs
@@ -1,6 +1,6 @@
-use borsh::BorshSerialize;
+use borsh::{BorshSerialize, BorshDeserialize};
 
-#[derive(BorshSerialize, Debug, PartialEq)]
+#[derive(BorshSerialize, BorshDeserialize, Debug, PartialEq)]
 struct TestSerializable {
     a: u32,
     b: String,
@@ -13,14 +13,14 @@ mod tests {
 
     #[test]
     fn test_serializable_to_vec() {
-        let test_instance = TestSerializable {
+        let inst = TestSerializable {
             a: 42,
             b: "Hello, world!".to_string(),
             c: vec![1, 2, 3, 4, 5],
         };
 
         // Expected serialized output
-        let expected: Vec<u8> = vec![
+        let expected_serialized: Vec<u8> = vec![
             42, 0, 0, 0,               // a: u32 (little-endian)
             13, 0, 0, 0,               // Length of the string b (13)
             72, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100, 33, // "Hello, world!" as bytes
@@ -29,9 +29,16 @@ mod tests {
         ];
 
         // Serialize the instance
-        let serialized = borsh::to_vec(&test_instance).expect("Serialization failed");
+        let serialized = inst.try_to_vec().expect("Serialization failed");
 
         // Assert that the serialized output matches the expected value
-        assert_eq!(serialized, expected, "Serialized bytes differ from the expected value");
+        assert_eq!(serialized, expected_serialized, "Serialized bytes differ from the expected value");
+
+        // Deserialize the serialized data back to a new instance
+        let deserialized_inst: TestSerializable = borsh::BorshDeserialize::try_from_slice(&serialized)
+            .expect("Deserialization failed");
+
+        // Assert that the deserialized instance matches the original instance
+        assert_eq!(deserialized_inst, inst, "Deserialized instance differs from the original");
     }
 }


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)
This PR introdues a Unit Test which explicitly tests the serialization behavior of a `BorshSerialize` implementation.  The existence of this test will add an additional layer of confidence during the subsequent transition to `V1.0` of `borsh` by explicitly asserting that the serialization behavior does not change.

## Reference to Linear Issue (ENG-XXX)
[ENG-1693](https://linear.app/turnkey/issue/ENG-1693/qos-add-unit-test-for-borsh-serialization)

## How I Tested These Changes
NOTE: Given that the only change included with this PR is the introduction of a Unit Test, this PR can be considered "_self-testing_".

- [x] [**_New Unit Test_**](https://github.com/tkhq/qos/blob/c3f3fa888db63e8a848230e229b66f81ca86dda7/src/integration/tests/borsh_serialize.rs) Passes

## Pre merge check list
N/A
