### PR TITLE
Add chunked decoding and JSON parsing to stream test

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -407,6 +407,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1796,12 +1802,15 @@ name = "qos_net"
 version = "0.1.0"
 dependencies = [
  "borsh",
+ "chunked_transfer",
  "hickory-resolver",
+ "httparse",
  "qos_core",
  "qos_test_primitives",
  "rand",
  "rustls",
  "serde",
+ "serde_json",
  "webpki-roots",
 ]
 
@@ -2139,11 +2148,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.118"
+version = "1.0.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d947f6b3163d8857ea16c4fa0dd4840d52f3041039a85decd46867eb1abef2e4"
+checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]

--- a/src/qos_client/src/lib.rs
+++ b/src/qos_client/src/lib.rs
@@ -19,10 +19,11 @@ pub mod request {
 	const MAX_SIZE: u64 = u32::MAX as u64;
 
 	/// Post a [`qos_core::protocol::msg::ProtocolMsg`] to the given host `url`.
-	/// 
+	///
 	/// # Panics
 	/// Panics if the `msg` cannot be Borsh serialized.
-	/// Should never happen in practice because all protocol messages are Borsh-serializable.
+	/// Should never happen in practice because all protocol messages are
+	/// Borsh-serializable.
 	pub fn post(url: &str, msg: &ProtocolMsg) -> Result<ProtocolMsg, String> {
 		let mut buf: Vec<u8> = vec![];
 

--- a/src/qos_client/src/yubikey.rs
+++ b/src/qos_client/src/yubikey.rs
@@ -177,7 +177,7 @@ pub fn import_key_and_generate_signed_certificate(
 }
 
 /// Sign data with the yubikey and return the signature as a raw bytes.
-/// 
+///
 /// # Panics
 /// Panics if `piv::sign_data` doesn't return a valid DER signature
 pub fn sign_data(

--- a/src/qos_core/src/protocol/processor.rs
+++ b/src/qos_core/src/protocol/processor.rs
@@ -48,7 +48,7 @@ impl server::RequestProcessor for Processor {
 			return borsh::to_vec(&ProtocolMsg::ProtocolErrorResponse(
 				ProtocolError::ProtocolMsgDeserialization,
 			))
-			.expect("ProtocolMsg can always be serialized. qed.")
+			.expect("ProtocolMsg can always be serialized. qed.");
 		};
 
 		self.state.handle_msg(&msg_req)

--- a/src/qos_crypto/src/shamir.rs
+++ b/src/qos_crypto/src/shamir.rs
@@ -160,7 +160,7 @@ fn gf256_interpolate(xs: &[u8], ys: &[u8]) -> u8 {
 }
 
 /// Generate n shares requiring k shares to reconstruct.
-/// 
+///
 /// # Panics
 /// Panics if the number of shares exceeds 255
 #[must_use]

--- a/src/qos_net/Cargo.toml
+++ b/src/qos_net/Cargo.toml
@@ -14,6 +14,9 @@ rand = { version = "0.8.5", default-features = false, optional = true }
 
 [dev-dependencies]
 qos_test_primitives = { path = "../qos_test_primitives" }
+httparse = { version = "1.9.4", default-features = false }
+chunked_transfer = { version = "1.5.0", default-features = false }
+serde_json = { version = "1.0.121", features = ["std"], default-features = false }
 rustls = { version = "0.23.5" }
 webpki-roots = { version = "0.26.1" }
 

--- a/src/qos_p256/src/encrypt.rs
+++ b/src/qos_p256/src/encrypt.rs
@@ -356,9 +356,10 @@ impl AesGcm256Secret {
 	/// Encrypt the given `msg`.
 	///
 	/// Returns a serialized [`SymmetricEnvelope`].
-	/// 
+	///
 	/// # Panics
-	/// Panics if `self.secret` is an invalid AES256 secret. This should never happen in practice.
+	/// Panics if `self.secret` is an invalid AES256 secret. This should never
+	/// happen in practice.
 	pub fn encrypt(&self, msg: &[u8]) -> Result<Vec<u8>, P256Error> {
 		let nonce = {
 			let random_bytes = bytes_os_rng::<{ BITS_96_AS_BYTES as usize }>();
@@ -381,7 +382,7 @@ impl AesGcm256Secret {
 	/// Decrypt the given serialized [`SymmetricEnvelope`].
 	///
 	/// Returns the plaintext.
-	/// 
+	///
 	/// # Panics
 	/// Panics if the secret is invalid. This should never happen in practice.
 	pub fn decrypt(


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)
I wrote this to explore parsing chunked streams, I think it's valuable to keep! It's a much stronger set of assertions, and it tests that the response is actually a valid JSON structure instead of asserting that the word "keys" is in it.

The other whitespace / stylistic changes are from running `make lint` locally.

## How I Tested These Changes
Unit test
