### PR TITLE
Change workflow name to StageX build for consistency with mono

### DIFF
--- a/.github/workflows/stagex.yml
+++ b/.github/workflows/stagex.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    name: build StageX artifacts
+    name: build artifacts
     # We use a special group that is configured to use github largest runner instance
     # This is charged by the minute, so if you want to reduce cost change back to `runs-on: ubuntu-latest`
     runs-on:


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)
Tiny PR to rename the workflow to Stagex, for consistency with mono. This was originally part of #457. 

## How I Tested These Changes
CI
