### PR TITLE
Make yes/no prompts typo tolerant, and accept "y" or "n" as inputs

### DIFF
--- a/src/integration/tests/boot.rs
+++ b/src/integration/tests/boot.rs
@@ -189,21 +189,31 @@ async fn standard_boot_e2e() {
 
 		assert_eq!(
 			&stdout.next().unwrap().unwrap(),
-			"Is this the correct namespace name: quit-coding-to-vape? (yes/no)"
+			"Is this the correct namespace name: quit-coding-to-vape? (y/n)"
 		);
+		stdin.write_all("y\n".as_bytes()).expect("Failed to write to stdin");
+
+		assert_eq!(
+			&stdout.next().unwrap().unwrap(),
+			"Is this the correct namespace nonce: 2? (y/n)"
+		);
+		// On purpose, try to input a bad value, neither yes or no
+		stdin
+			.write_all("maybe\n".as_bytes())
+			.expect("Failed to write to stdin");
+
+		assert_eq!(
+			&stdout.next().unwrap().unwrap(),
+			"Please answer with either \"yes\" (y) or \"no\" (n)"
+		);
+		// Try the longer option ("yes" rather than "y")
 		stdin.write_all("yes\n".as_bytes()).expect("Failed to write to stdin");
 
 		assert_eq!(
 			&stdout.next().unwrap().unwrap(),
-			"Is this the correct namespace nonce: 2? (yes/no)"
+			"Is this the correct pivot restart policy: RestartPolicy::Never? (y/n)"
 		);
-		stdin.write_all("yes\n".as_bytes()).expect("Failed to write to stdin");
-
-		assert_eq!(
-			&stdout.next().unwrap().unwrap(),
-			"Is this the correct pivot restart policy: RestartPolicy::Never? (yes/no)"
-		);
-		stdin.write_all("yes\n".as_bytes()).expect("Failed to write to stdin");
+		stdin.write_all("y\n".as_bytes()).expect("Failed to write to stdin");
 
 		assert_eq!(
 			&stdout.next().unwrap().unwrap(),
@@ -213,8 +223,8 @@ async fn standard_boot_e2e() {
 			&stdout.next().unwrap().unwrap(),
 			"[\"--msg\", \"testing420\"]?"
 		);
-		assert_eq!(&stdout.next().unwrap().unwrap(), "(yes/no)");
-		stdin.write_all("yes\n".as_bytes()).expect("Failed to write to stdin");
+		assert_eq!(&stdout.next().unwrap().unwrap(), "(y/n)");
+		stdin.write_all("y\n".as_bytes()).expect("Failed to write to stdin");
 
 		// Wait for the command to write the approval and exit
 		assert!(child.wait().unwrap().success());
@@ -390,19 +400,19 @@ async fn standard_boot_e2e() {
 		// Answer prompts with yes
 		assert_eq!(
 			&stdout.next().unwrap().unwrap(),
-			"Is this the correct namespace name: quit-coding-to-vape? (yes/no)"
+			"Is this the correct namespace name: quit-coding-to-vape? (y/n)"
 		);
 		stdin.write_all("yes\n".as_bytes()).expect("Failed to write to stdin");
 
 		assert_eq!(
 			&stdout.next().unwrap().unwrap(),
-			"Is this the correct namespace nonce: 2? (yes/no)"
+			"Is this the correct namespace nonce: 2? (y/n)"
 		);
 		stdin.write_all("yes\n".as_bytes()).expect("Failed to write to stdin");
 
 		assert_eq!(
 				&stdout.next().unwrap().unwrap(),
-				"Does this AWS IAM role belong to the intended organization: arn:aws:iam::123456789012:role/Webserver? (yes/no)"
+				"Does this AWS IAM role belong to the intended organization: arn:aws:iam::123456789012:role/Webserver? (y/n)"
 			);
 		stdin.write_all("yes\n".as_bytes()).expect("Failed to write to stdin");
 

--- a/src/integration/tests/preprod_sharding.rs
+++ b/src/integration/tests/preprod_sharding.rs
@@ -88,9 +88,14 @@ fn preprod_reshard_ceremony() {
 	.unwrap();
 
 	// For each of the enclaves...
-	for enclave_name in
-		["ump", "evm-parser", "notarizer", "signer", "tls-fetcher", "deploy-test"]
-	{
+	for enclave_name in [
+		"ump",
+		"evm-parser",
+		"notarizer",
+		"signer",
+		"tls-fetcher",
+		"deploy-test",
+	] {
 		// Decrypt the old dev share and assert that the resulting quorum key
 		// has the right public key. Decrypted dev shares are _basically_ master
 		// seeds. They're just have a "01" prefix because it's the one and only

--- a/src/qos_client/src/cli/services.rs
+++ b/src/qos_client/src/cli/services.rs
@@ -2136,11 +2136,11 @@ where
 		while attempts > 0 {
 			let answer = self.prompt(prompt);
 
-			if ["yes", "Yes", "Y", "y"].contains(&answer.as_ref()) {
+			if ["yes", "Yes", "YES", "Y", "y"].contains(&answer.as_ref()) {
 				return true;
 			}
 
-			if ["no", "No", "N", "n"].contains(&answer.as_ref()) {
+			if ["no", "No", "NO", "N", "n"].contains(&answer.as_ref()) {
 				return false;
 			}
 
@@ -2575,7 +2575,7 @@ mod tests {
 			let Setup { manifest, .. } = setup();
 
 			let mut vec_out: Vec<u8> = vec![];
-			let vec_in = "ye\n".as_bytes();
+			let vec_in = "No\n".as_bytes();
 
 			let mut prompter =
 				Prompter { reader: vec_in, writer: &mut vec_out };
@@ -2781,7 +2781,8 @@ mod tests {
 			let Setup { manifest_envelope, .. } = setup();
 
 			let mut vec_out: Vec<u8> = vec![];
-			let vec_in = "y\nyes\nyea\ntes\nyes\nyes\n".as_bytes();
+			// Try all the accepted yes variants: y, yes, Yes, and YES!
+			let vec_in = "y\nyes\nyea\ntes\nYes\nYES\n".as_bytes();
 
 			let mut prompter =
 				Prompter { reader: vec_in, writer: &mut vec_out };


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)
Currently when we approve manifests or re-encrypt shares, a single typo aborts the whole process. This PR makes things a bit more resilient to typos by:
* accepting "y" or "Yes" or "YES" as valid "yes" values (and "n"/"No"/"NO" as valid "no" values)
* retrying if the answer isn't one of these options, up to 3 attempts

## How I Tested These Changes
Integration + unit tests
