### PR TITLE
Security patch for hickory crates

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1002,9 +1002,9 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hickory-proto"
-version = "0.24.2"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447afdcdb8afb9d0a852af6dc65d9b285ce720ed7a59e42a8bf2e931c67bc1b5"
+checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -1026,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.24.1"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28757f23aa75c98f254cf0405e6d8c25b831b32921b050a66692427679b1f243"
+checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
 dependencies = [
  "cfg-if",
  "futures-util",


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)
`hickory-resolver` and `hickory-proto` have two published security advisories:
* https://github.com/advisories/GHSA-37wc-h8xc-5hc4
* https://github.com/advisories/GHSA-v7pc-74h8-xq2h

Switch to patched crate versions.

## How I Tested These Changes
Local unit tests.

## Pre merge check list

- [ ] Update CHANGELOG.MD
