### PR TITLE
Fix qos_net's CLI to build correctly without default features

### DIFF
--- a/src/qos_net/src/main.rs
+++ b/src/qos_net/src/main.rs
@@ -1,5 +1,14 @@
+#[cfg(feature = "proxy")]
 use qos_net::cli::CLI;
 
+#[cfg(feature = "proxy")]
 pub fn main() {
 	CLI::execute();
 }
+
+
+#[cfg(not(feature = "proxy"))]
+pub fn main() {
+	panic!("Cannot run qos_net CLI without proxy feature enabled")
+}
+


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)
Discovered by @cr-tk in https://github.com/tkhq/qos/pull/502

This change introduces a no-op qos_net CLI when the default "proxy" feature isn't enabled. The CLI simply panics because there is nothing to do: the CLI _is_ the way to start the proxy, and does not make sense without the proxy feature.

## How I Tested These Changes
On this branch, `cargo build --locked --no-default-features --release` succeeds.
