### PR TITLE
Remove outdated directory from Cargo.toml

### DIFF
--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -16,7 +16,6 @@ exclude = [
   "qos_aws",
   "qos_system",
   "qos_enclave",
-  "eif_build",
   "qos_p256/fuzz",
   "qos_crypto/fuzz",
 ]


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)
Simple PR to remove an outdated directory from the `Cargo.toml` workspace exclusion list.

The dependency-reviewers group is technically needed since this PR touches Cargo definitions, but there is no change in dependencies to review.

## How I Tested These Changes
Local build tests. We don't expect any effects on the code or build behavior.