### PR TITLE
Add cargo-fuzz test harnesses for qos_nsm

### DIFF
--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -18,6 +18,7 @@ exclude = [
   "qos_enclave",
   "qos_p256/fuzz",
   "qos_crypto/fuzz",
+  "qos_nsm/fuzz",
 ]
 # We need this to avoid issues with the mock feature uinintentionally being
 # enabled just because some tests need it.

--- a/src/qos_nsm/fuzz/Cargo.toml
+++ b/src/qos_nsm/fuzz/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "qos_nsm_fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+qos_hex = { path = "../../qos_hex" }
+
+# we need some of the mock code features
+qos_nsm = { path = "../", features = ["mock"] }
+
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[profile.release]
+# enable arithmetic checks at runtime
+overflow-check = 1
+
+[[bin]]
+name = "1_attestation_doc_from_der"
+path = "fuzz_targets/1_attestation_doc_from_der.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "2_verify_attestation_doc_against_user_input"
+path = "fuzz_targets/2_verify_attestation_doc_against_user_input.rs"
+test = false
+doc = false
+bench = false

--- a/src/qos_nsm/fuzz/IDEAS.md
+++ b/src/qos_nsm/fuzz/IDEAS.md
@@ -1,0 +1,4 @@
+# Fuzzing Ideas
+
+Special parameter requirements:
+* Valid inputs for attestation doc related testing harnesses can be fairly large. For example, src/static/mock_attestation_doc is over 5KB in size. Therefore a relatively large `-min_len=` length parameter value such as `-min_len=6000` is needed during fuzzing.

--- a/src/qos_nsm/fuzz/fuzz_targets/1_attestation_doc_from_der.rs
+++ b/src/qos_nsm/fuzz/fuzz_targets/1_attestation_doc_from_der.rs
@@ -1,0 +1,29 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use qos_nsm::nitro::{attestation_doc_from_der, cert_from_pem};
+// working root cert, use as example
+use qos_nsm::nitro::AWS_ROOT_CERT_PEM;
+// this is just an example timestamp
+use qos_nsm::mock::MOCK_SECONDS_SINCE_EPOCH;
+
+fuzz_target!(|data: &[u8]| {
+	let root_cert = cert_from_pem(AWS_ROOT_CERT_PEM).unwrap();
+	// test attestation conversion function
+	// this includes verification of signatures, and is unlikely to succeed
+	// unless on variants of a validly signed doc
+	let attestation_result = attestation_doc_from_der(
+		data,
+		&root_cert[..],
+		MOCK_SECONDS_SINCE_EPOCH,
+	);
+
+	match attestation_result {
+		Err(_) => {}
+		Ok(_reconstructed) => {
+			// debug print, signals how often this path is hit, remove later
+			println!("succeeded parsing, data length: {}", data.len());
+		}
+	}
+});

--- a/src/qos_nsm/fuzz/fuzz_targets/2_verify_attestation_doc_against_user_input.rs
+++ b/src/qos_nsm/fuzz/fuzz_targets/2_verify_attestation_doc_against_user_input.rs
@@ -1,0 +1,35 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use qos_nsm::nitro::unsafe_attestation_doc_from_der;
+use qos_nsm::nitro::verify_attestation_doc_against_user_input;
+
+// constants are copied from the mock system, and represent dummy values
+
+use qos_nsm::mock::{
+	MOCK_PCR0, MOCK_PCR1, MOCK_PCR2, MOCK_PCR3,
+	MOCK_USER_DATA_NSM_ATTESTATION_DOCUMENT,
+};
+
+fuzz_target!(|data: &[u8]| {
+	// use the unsafe conversion variant without verification of cryptographic properties
+	// this allows the fuzzer to more often generate a working attestation document
+	let attestation_result = unsafe_attestation_doc_from_der(data);
+
+	match attestation_result {
+		Err(_) => {}
+		Ok(reconstructed) => {
+			// test the intended target function
+			let _ = verify_attestation_doc_against_user_input(
+				&reconstructed,
+				&qos_hex::decode(MOCK_USER_DATA_NSM_ATTESTATION_DOCUMENT)
+					.unwrap(),
+				&qos_hex::decode(MOCK_PCR0).unwrap(),
+				&qos_hex::decode(MOCK_PCR1).unwrap(),
+				&qos_hex::decode(MOCK_PCR2).unwrap(),
+				&qos_hex::decode(MOCK_PCR3).unwrap(),
+			);
+		}
+	}
+});


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)
Add fuzz testing to cover some of our AWS Nitro NSM attestation related logic in `qos_nsm`.

## How I Tested These Changes
No changes to production code. Fuzzing tested locally.