### PR TITLE
Align `qos_enclave` build with mono + add reproduction instructions

### DIFF
--- a/src/images/common/Containerfile
+++ b/src/images/common/Containerfile
@@ -1,25 +1,18 @@
 FROM stagex/bash:5.2.21@sha256:cb58f55d268fbe7ef629cda86e3a8af893066e4af7f26ef54748b6ad47bdaa66 AS bash
 FROM stagex/binutils:2.43.1@sha256:30a1bd110273894fe91c3a4a2103894f53eaac43cf12a035008a6982cb0e6908 AS binutils
+FROM stagex/busybox:1.36.1@sha256:d34bfa56566aa72d605d6cbdc154de8330cf426cfea1bc4ba8013abcac594395 AS busybox
 FROM stagex/ca-certificates:sx2024.09.0@sha256:33787f1feb634be4232a6dfe77578c1a9b890ad82a2cf18c11dd44507b358803 AS ca-certificates
 FROM stagex/coreutils:9.4@sha256:1955f532d8923b5e17f60635c994bd9577bb3e6bccb5da702a69e79070bae0a9 AS coreutils
-FROM stagex/eif_build:0.2.2@sha256:291653f1ca528af48fd05858749c443300f6b24d2ffefa7f5a3a06c27c774566 AS eif_build
 FROM stagex/file:5.45@sha256:b43a7f0bd50419a39d91d77a316bb888ed87c94aeb6f9eb11f12efd275ca4ab8 AS file
 FROM stagex/filesystem:sx2024.11.0@sha256:d03195563f548c3ac8f34acf777b7e86f0d0d049a9430d715e5774eb7cc93302 AS filesystem
 FROM stagex/findutils:4.9.0@sha256:d92494daaf08999aac0a277327d240a0149494716707fbce93381df058f693e2 AS findutils
 FROM stagex/gcc:13.1.0@sha256:439bf36289ef036a934129d69dd6b4c196427e4f8e28bc1a3de5b9aab6e062f0 AS gcc
-FROM stagex/gen_initramfs:6.8@sha256:f5b9271cca6003e952cbbb9ef041ffa92ba328894f563d1d77942e6b5cdeac1a AS gen_initramfs
 FROM stagex/git:2.9.5@sha256:29a02c423a4b55fa72cf2fce89f3bbabd1defea86d251bb2aea84c056340ab22 AS git
 FROM stagex/grep:3.11@sha256:576288125a7ecda969285e5edfaedef479c4bc18cba8230c0502000fdf2586c1 AS grep
 FROM stagex/libunwind:1.7.2@sha256:97ee6068a8e8c9f1c74409f80681069c8051abb31f9559dedf0d0d562d3bfc82 AS libunwind
-# This is using an old version of linux-nitro on a recommendation from Lance
-# Once we've confirmed the new version work we should upgrade this again.
-FROM stagex/linux-nitro:sx2024.03.0@sha256:073c4603686e3bdc0ed6755fee3203f6f6f1512e0ded09eaea8866b002b04264 AS linux-nitro
-FROM stagex/llvm13:13.0.1@sha256:aa60e2883ecf2070c7591fc29622a578c8ea24a14a2b7fcce95d3e5d9c00b101 AS llvm13
 FROM stagex/llvm:18.1.8@sha256:30517a41af648305afe6398af5b8c527d25545037df9d977018c657ba1b1708f AS llvm
 FROM stagex/make:4.4@sha256:df43f0cf3ac1ad91bf91baefb539e8df42c11b0954a6e2498322a5467deb81e3 AS make
-FROM stagex/musl-fts:1.2.7@sha256:87edcc648085e8fd6cd8a6ebc94a9464181c3035a00266c621c6450f5d7c66d8 AS musl-fts
 FROM stagex/musl:1.2.4@sha256:ad351b875f26294562d21740a3ee51c23609f15e6f9f0310e0994179c4231e1d AS musl
-FROM stagex/musl-obstack:1.2.3@sha256:2a308833441b46a64a1fa5cf90d0bb75dec4807d5a15035776165db88ca661fd AS musl-obstack
 FROM stagex/openssl:3.0.12@sha256:2c1a9d8fcc6f52cb11a206f380b17d74c1079f04cbb08071a4176648b4df52c1 AS openssl
 # This is using an old version of pcsc-lite since upgrading to v2.2.3 broke
 # static builds. Once we have confirmed an updated pcsc-lite has fixed this
@@ -30,31 +23,52 @@ FROM stagex/rust:1.81.0@sha256:b7c834268a81bfcc473246995c55b47fe18414cc553e3293b
 FROM stagex/zlib:1.3.1@sha256:96b4100550760026065dac57148d99e20a03d17e5ee20d6b32cbacd61125dbb6 AS zlib
 
 FROM scratch AS base
-ENV TARGET=x86_64-unknown-linux-musl
-ENV RUSTFLAGS="-C target-feature=+crt-static"
-ENV CARGOFLAGS="--locked --no-default-features --release --target ${TARGET}"
-ENV OPENSSL_STATIC=true
-COPY --from=stagex/busybox . /
-COPY --from=stagex/bash . /
+
+COPY --from=bash . /
+COPY --from=binutils . /
+COPY --from=busybox . /
+COPY --from=ca-certificates . /
 COPY --from=coreutils . /
+COPY --from=file . /
+COPY --from=filesystem . /
 COPY --from=findutils . /
+COPY --from=gcc . /
+COPY --from=git . /
 COPY --from=grep . /
+COPY --from=make . /
 COPY --from=musl . /
 COPY --from=libunwind . /
 COPY --from=openssl . /
-COPY --from=zlib . /
-COPY --from=ca-certificates . /
-COPY --from=binutils . /
-COPY --from=pkgconf . /
-COPY --from=git . /
-COPY --from=rust . /
-COPY --from=gen_initramfs . /
-COPY --from=eif_build . /
-COPY --from=llvm . /
 COPY --from=pcsc-lite . /
-COPY --from=file . /
-COPY --from=gcc . /
-COPY --from=make . /
-COPY --from=linux-nitro /bzImage .
-COPY --from=linux-nitro /nsm.ko .
-COPY --from=linux-nitro /linux.config .
+COPY --from=pkgconf . /
+COPY --from=llvm . /
+COPY --from=rust . /
+COPY --from=zlib . /
+
+
+COPY --chmod=644 <<-EOF /etc/passwd
+	root:x:0:0:root:/root:/bin/sh
+	user:x:1000:1000::/home/user:/bin/sh
+EOF
+COPY --chmod=644 <<-EOF /etc/group
+	root:x:0:
+	user:x:1000:
+EOF
+
+RUN mkdir -p /rootfs/etc
+RUN mkdir -p /rootfs/home/user
+RUN chown -R user:user /rootfs/home/user
+
+RUN touch -hcd "@0" /etc/group /etc/hpasswd
+ENV TZ=UTC
+ENV LANG=C.UTF-8
+ENV LC_ALL=C
+ENV USER=user
+ENV HOME=/home/user
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+ENV TARGET=x86_64-unknown-linux-musl
+ENV RUSTFLAGS="-C target-feature=+crt-static"
+ENV CARGOFLAGS="--locked --no-default-features --release --target ${TARGET}"
+
+WORKDIR /src

--- a/src/images/qos_enclave/Containerfile
+++ b/src/images/qos_enclave/Containerfile
@@ -1,28 +1,41 @@
+FROM stagex/eif_build:0.2.2@sha256:291653f1ca528af48fd05858749c443300f6b24d2ffefa7f5a3a06c27c774566 AS eif_build
+FROM stagex/gen_initramfs:6.8@sha256:f5b9271cca6003e952cbbb9ef041ffa92ba328894f563d1d77942e6b5cdeac1a AS gen_initramfs
+FROM stagex/linux-nitro:sx2024.03.0@sha256:073c4603686e3bdc0ed6755fee3203f6f6f1512e0ded09eaea8866b002b04264 AS linux-nitro
+
 FROM common as base
-ADD . /src
 
-FROM base as build-qos_enclave
-RUN <<-EOF
-	set -eux
-	env -C /src/qos_enclave cargo build ${CARGOFLAGS}
-	cp /src/qos_enclave/target/${TARGET}/release/qos_enclave /
-	file /qos_enclave | grep "static-pie"
-EOF
+RUN mkdir -p /qos/src
+ADD . /qos/src
 
-FROM base as build-init
-RUN <<-EOF
-	set -eux
-	env -C /src/init cargo build ${CARGOFLAGS}
-	cp /src/init/target/${TARGET}/release/init /
-	file /init | grep "static-pie"
-EOF
+# pre-fetch all QOS deps
+RUN cd /qos/src && cargo fetch
+
+# pre-fetch all QOS deps even for crates excluded from the workspace
+# these dependencies are needed when building qos_enclave
+RUN cd /qos/src/init && cargo fetch
+RUN cd /qos/src/qos_enclave && cargo fetch
+
+FROM base AS build-qos_enclave
+WORKDIR /qos/src/qos_enclave
+RUN --network=none cargo build ${CARGOFLAGS}
+RUN cp target/x86_64-unknown-linux-musl/release/qos_enclave /
+RUN file /qos_enclave | grep "static-pie"
+
+FROM base AS build-init
+WORKDIR /qos/src/init
+RUN --network=none cargo build ${CARGOFLAGS}
+RUN cp target/x86_64-unknown-linux-musl/release/init /
+RUN file /init | grep "static-pie"
 
 FROM base as build-eif
 WORKDIR /build_cpio
+COPY --from=eif_build . /
+COPY --from=gen_initramfs . /
 COPY --from=build-init /init .
+COPY --from=linux-nitro /nsm.ko .
 COPY <<-EOF initramfs.list
 	file /init     init    0755 0 0
-	file /nsm.ko   /nsm.ko 0755 0 0
+	file /nsm.ko   nsm.ko  0755 0 0
 	dir  /run              0755 0 0
 	dir  /tmp              0755 0 0
 	dir  /etc              0755 0 0
@@ -42,14 +55,17 @@ ENV CPIO_TIMESTAMP=1
 ENV KBUILD_BUILD_TIMESTAMP=1
 RUN <<-EOF
 	find . -exec touch -hcd "@0" "{}" +
-	gen_init_cpio -t 1 initramfs.list > rootfs.cpio
+	mkdir /build_eif
+	gen_init_cpio -t 1 initramfs.list > /build_eif/rootfs.cpio
 	touch -hcd "@0" rootfs.cpio
 EOF
 WORKDIR /build_eif
+COPY --from=linux-nitro /bzImage .
+COPY --from=linux-nitro /linux.config .
 RUN eif_build \
-	--kernel /bzImage \
-	--kernel_config /linux.config \
-	--ramdisk /build_cpio/rootfs.cpio \
+	--ramdisk rootfs.cpio \
+	--kernel bzImage \
+	--kernel_config linux.config \
 	--pcrs_output /nitro.pcrs \
 	--output /nitro.eif \
 	--cmdline 'reboot=k initrd=0x2000000,3228672 root=/dev/ram0 panic=1 pci=off nomodules console=ttyS0 i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd'


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)
Currently our internal mono repo doesn't build qos_enclave in the exact same way than this repo does. Subtle differences lead to mismatch in digests, which means external users who do no have mono access cannot verify remote attestations meaningfully.

Something I didn't expect would have an impact on the final digest:
```
RUN mkdir -p /qos/src
ADD . /qos/src 
WORKDIR /qos/src/qos_enclave
...build...
```
yields a different digest than:
```
ADD . /src
WORKDIR /src/qos_enclave
...build...
````

And another surprising thing:
```
ENV USER=user
ENV HOME=/home/user
ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```
Adding these also alters the final digests.

Shoutout to @lrvick who put me on the right track and noticed, by using a combo of [andrcmdr/aws-nitro-enclaves-image-format-build-extract](https://github.com/andrcmdr/aws-nitro-enclaves-image-format-build-extract/blob/main/eif_extract/src/main.rs) and [diffoscope](https://diffoscope.org/), that the init binary was the thing causing the EIF file to be different.

## How I Tested These Changes
`make out/qos_enclave/index.json` like...100 times.
