### PR TITLE
unify and bump libc version

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1503,9 +1503,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"

--- a/src/init/Cargo.lock
+++ b/src/init/Cargo.lock
@@ -727,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "lock_api"

--- a/src/qos_aws/Cargo.lock
+++ b/src/qos_aws/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "qos_aws"

--- a/src/qos_aws/Cargo.toml
+++ b/src/qos_aws/Cargo.toml
@@ -7,5 +7,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libc = "0.2.149"
+libc = "0.2.172"
 qos_system = { path = "../qos_system"}

--- a/src/qos_core/Cargo.toml
+++ b/src/qos_core/Cargo.toml
@@ -11,7 +11,7 @@ qos_p256 = { path = "../qos_p256" }
 qos_nsm = { path = "../qos_nsm", default-features = false }
 
 nix = { version = "0.26", features = ["socket"], default-features = false }
-libc = "=0.2.155"
+libc = "=0.2.172"
 borsh = { version = "1.0", features = ["std", "derive"] , default-features = false}
 vsss-rs = { version = "5.1", default-features = false, features = ["std", "zeroize"] }
 

--- a/src/qos_enclave/Cargo.toml
+++ b/src/qos_enclave/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 nitro-cli = { git = "https://github.com/aws/aws-nitro-enclaves-cli", version = "1.4.0" }
-libc = "0.2.149"
+libc = "0.2.172" # NOTE: nitro-cli requires ^0.2.161
 
 [features]
 default = []

--- a/src/qos_system/Cargo.lock
+++ b/src/qos_system/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "qos_system"

--- a/src/qos_system/Cargo.toml
+++ b/src/qos_system/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libc = "=0.2.155"
+libc = "=0.2.172"


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)
Unifies and locks all `libc` dependencies in the workspace to use the same exact version. Bumps the version to `v0.2.158` specifically to allow use of [tokio-vsock](https://crates.io/crates/tokio-vsock) in the future.

