### PR TITLE
init: update libc version to match the rest

### DIFF
--- a/src/init/Cargo.toml
+++ b/src/init/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-libc = "0.2.149"
+libc = "0.2.172"
 qos_aws = { path = "../qos_aws"}
 qos_system = { path = "../qos_system"}
 qos_core = { path = "../qos_core", features = ["vm"], default-features = false }


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)
Just a minor dependency fix to bring up `libc` to latest in `init`'s `Cargo.toml` as well. Lockfile was already bumped previously.
## How I Tested These Changes

## Pre merge check list

- [ ] Update CHANGELOG.MD
