### PR TITLE
Avoid allocating more than `MAX_PAYLOAD_SIZE` on `recv`

### DIFF
--- a/src/qos_core/src/io/mod.rs
+++ b/src/qos_core/src/io/mod.rs
@@ -6,8 +6,8 @@
 mod stream;
 
 pub use stream::{
-	Listener, SocketAddress, Stream, TimeVal, TimeValLike, VMADDR_FLAG_TO_HOST,
-	VMADDR_NO_FLAGS,
+	Listener, SocketAddress, Stream, TimeVal, TimeValLike, MAX_PAYLOAD_SIZE,
+	VMADDR_FLAG_TO_HOST, VMADDR_NO_FLAGS,
 };
 
 /// QOS I/O error
@@ -31,6 +31,8 @@ pub enum IOError {
 	SendNixError(nix::Error),
 	/// A nix error encountered while calling `recv`.
 	RecvNixError(nix::Error),
+	/// Reading the response size resulted in a size which exceeds the max payload size.
+	OversizedPayload(usize),
 }
 
 impl From<nix::Error> for IOError {

--- a/src/qos_core/src/protocol/processor.rs
+++ b/src/qos_core/src/protocol/processor.rs
@@ -5,11 +5,8 @@ use qos_nsm::NsmProvider;
 use super::{
 	error::ProtocolError, msg::ProtocolMsg, state::ProtocolState, ProtocolPhase,
 };
+use crate::io::MAX_PAYLOAD_SIZE;
 use crate::{handles::Handles, io::SocketAddress, server};
-
-const MEGABYTE: usize = 1024 * 1024;
-const MAX_ENCODED_MSG_LEN: usize = 128 * MEGABYTE;
-
 /// Enclave state machine that executes when given a `ProtocolMsg`.
 pub struct Processor {
 	state: ProtocolState,
@@ -37,7 +34,7 @@ impl Processor {
 
 impl server::RequestProcessor for Processor {
 	fn process(&mut self, req_bytes: Vec<u8>) -> Vec<u8> {
-		if req_bytes.len() > MAX_ENCODED_MSG_LEN {
+		if req_bytes.len() > MAX_PAYLOAD_SIZE {
 			return borsh::to_vec(&ProtocolMsg::ProtocolErrorResponse(
 				ProtocolError::OversizedPayload,
 			))

--- a/src/qos_net/src/main.rs
+++ b/src/qos_net/src/main.rs
@@ -6,9 +6,7 @@ pub fn main() {
 	CLI::execute();
 }
 
-
 #[cfg(not(feature = "proxy"))]
 pub fn main() {
 	panic!("Cannot run qos_net CLI without proxy feature enabled")
 }
-


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)
This was a good finding by Trail of Bits in their most recent audit: we allocate a buffer of arbitrary size on `recv`, without checking that the length is appropriate first. This PR adds a check and a test for it.

## How I Tested These Changes
New unit test!
