### PR TITLE
Implement `Drop` for `ProxyStream` and close proxy connections correctly

### DIFF
--- a/src/integration/src/bin/pivot_remote_tls.rs
+++ b/src/integration/src/bin/pivot_remote_tls.rs
@@ -68,9 +68,11 @@ impl RequestProcessor for Processor {
 				match read_to_end_result {
 					Ok(read_size) => {
 						assert!(read_size > 0);
-						// Close the connection
-						let closed = stream.close();
-						closed.unwrap();
+
+						// Assert the connection isn't closed yet, and close it.
+						assert!(!stream.is_closed());
+						stream.close().expect("unable to close stream");
+						assert!(stream.is_closed());
 					}
 					Err(e) => {
 						// Only EOF errors are expected. This means the

--- a/src/qos_host/src/lib.rs
+++ b/src/qos_host/src/lib.rs
@@ -226,10 +226,10 @@ impl HostServer {
 
 		let enc_status_req = borsh::to_vec(&ProtocolMsg::StatusRequest)
 			.expect("ProtocolMsg can always serialize. qed.");
-		let enc_status_resp = state.enclave_client.send(&enc_status_req)
-			.map_err(|e|
+		let enc_status_resp =
+			state.enclave_client.send(&enc_status_req).map_err(|e| {
 				Error(format!("error sending status request to enclave: {e:?}"))
-			)?;
+			})?;
 
 		let status_resp = match ProtocolMsg::try_from_slice(&enc_status_resp) {
 			Ok(status_resp) => status_resp,

--- a/src/qos_net/src/proxy_connection.rs
+++ b/src/qos_net/src/proxy_connection.rs
@@ -65,6 +65,17 @@ impl ProxyConnection {
 
 		Ok(ProxyConnection { id: connection_id, ip, tcp_stream })
 	}
+
+	/// Closes the underlying TCP connection (`Shutdown::Both`)
+	pub fn shutdown(&mut self) -> Result<(), QosNetError> {
+		if let Err(e) = self.tcp_stream.shutdown(std::net::Shutdown::Both) {
+			if e.kind() == std::io::ErrorKind::NotConnected {
+				return Ok(());
+			}
+			return Err(QosNetError::from(e));
+		}
+		Ok(())
+	}
 }
 
 impl Read for ProxyConnection {


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)
This PR implements the `Drop` trait for `ProxyStream` to ensure remote connections are always closed. Because closing a connection is a fallible operation I've opted to implement a `close()` method which is called on `Drop` but which can be called by the caller if necessary. This enables proper error handling if the caller cares, or if the caller doesn't care, the automatic cleanup will run. This method is idempotent and only runs once.

Second issue: I've uncovered that we never closed TCP connections on the proxy. We simply removed connection IDs! This is now fixed.

Third issue: we weren't closing connections or marking connections as closed on empty reads.

Fourth issue: empty reads weren't defined correctly. Instead of "a read where the buffer is empty" (aka `data.is_empty()`), it should be "a read where the returned size is 0" (aka `size == 0`). The difference is meaningful because the read buffer is never empty!

## How I Tested These Changes
Existing unit tests helped a ton.

Bonus: I fixed the `remote_tls.rs` test not to be flaky anymore: there was a race condition between the server startup and the first connection attempt. The test now waits for both sockets to be "up" before attempting to connect.