### PR TITLE
Let renovate ignore stagex container file

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "ignorePaths": [
+    "src/images/common/Containerfile"
   ]
 }


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)
The renovate bot mechanism does not understand the stagex version format and creates unnecessary noise.

## How I Tested These Changes
No functional change, except for renovate behavior.

No changelog edit necessary.