### PR TITLE
Remove probability of collision in connection IDs by auto-incrementing them in `Proxy`

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2159,7 +2159,6 @@ dependencies = [
  "httparse",
  "qos_core",
  "qos_test_primitives",
- "rand",
  "rustls",
  "serde",
  "serde_json",

--- a/src/qos_core/src/io/stream.rs
+++ b/src/qos_core/src/io/stream.rs
@@ -382,9 +382,7 @@ mod test {
 		os::{fd::AsRawFd, unix::net::UnixListener},
 		path::Path,
 		str::from_utf8,
-		sync::mpsc,
 		thread,
-		time::Duration,
 	};
 
 	use super::*;

--- a/src/qos_net/Cargo.toml
+++ b/src/qos_net/Cargo.toml
@@ -15,7 +15,6 @@ serde = { version = "1", features = ["derive"], default-features = false }
 hickory-resolver = { version = "0.24.1", features = [
     "tokio-runtime",
 ], default-features = false, optional = true }
-rand = { version = "0.8.5", default-features = false, optional = true }
 
 [dev-dependencies]
 qos_test_primitives = { path = "../qos_test_primitives" }
@@ -29,5 +28,5 @@ webpki-roots = { version = "0.26.1" }
 
 [features]
 default = ["proxy"]                  # keep this as a default feature ensures we lint by default
-proxy = ["rand", "hickory-resolver"]
+proxy = ["hickory-resolver"]
 vm = []

--- a/src/qos_net/src/error.rs
+++ b/src/qos_net/src/error.rs
@@ -23,8 +23,12 @@ pub enum QosNetError {
 	ParseError(String),
 	/// DNS Resolution error
 	DNSResolutionError(String),
-	/// Attempt to save a connection with a duplicate ID
+	/// Attempt to save a connection with a duplicate connection ID
 	DuplicateConnectionId(u32),
+	/// Error that should not happen: saving a connection overrode another
+	/// We take great care to ensure code prior to saving the connection checks
+	/// that it's not present in the connection map (and if it is, we return `DuplicateConnectionId`)
+	ConnectionOverridden(u32),
 	/// Attempt to send a message to a remote connection, but ID isn't found
 	ConnectionIdNotFound(u32),
 	/// Happens when a socket `read` returns too much data for the provided

--- a/src/qos_net/src/proxy_connection.rs
+++ b/src/qos_net/src/proxy_connection.rs
@@ -9,14 +9,11 @@ use hickory_resolver::{
 	config::{NameServerConfigGroup, ResolverConfig, ResolverOpts},
 	Resolver,
 };
-use rand::Rng;
 
 use crate::error::QosNetError;
 
 /// Struct representing a TCP connection held on our proxy
 pub struct ProxyConnection {
-	/// Unsigned integer with the connection ID (random positive int)
-	pub id: u32,
 	/// IP address of the remote host
 	pub ip: String,
 	/// TCP stream object
@@ -33,19 +30,10 @@ impl ProxyConnection {
 		dns_port: u16,
 	) -> Result<ProxyConnection, QosNetError> {
 		let ip = resolve_hostname(hostname, dns_resolvers, dns_port)?;
-
-		// Generate a new random u32 to get an ID. We'll use it to name our
-		// socket. This will be our connection ID.
-		let mut rng = rand::thread_rng();
-		let connection_id: u32 = rng.gen::<u32>();
-
 		let tcp_addr = SocketAddr::new(ip, port);
 		let tcp_stream = TcpStream::connect(tcp_addr)?;
-		Ok(ProxyConnection {
-			id: connection_id,
-			ip: ip.to_string(),
-			tcp_stream,
-		})
+
+		Ok(ProxyConnection { ip: ip.to_string(), tcp_stream })
 	}
 
 	/// Create a new `ProxyConnection` from an IP address. This results in a
@@ -54,16 +42,11 @@ impl ProxyConnection {
 		ip: String,
 		port: u16,
 	) -> Result<ProxyConnection, QosNetError> {
-		// Generate a new random u32 to get an ID. We'll use it to name our
-		// socket. This will be our connection ID.
-		let mut rng = rand::thread_rng();
-		let connection_id: u32 = rng.gen::<u32>();
-
 		let ip_addr = ip.parse()?;
 		let tcp_addr = SocketAddr::new(ip_addr, port);
 		let tcp_stream = TcpStream::connect(tcp_addr)?;
 
-		Ok(ProxyConnection { id: connection_id, ip, tcp_stream })
+		Ok(ProxyConnection { ip, tcp_stream })
 	}
 
 	/// Closes the underlying TCP connection (`Shutdown::Both`)


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)
Pretty trivial: I'm removing the random connection ID assignment and making connection IDs sequential, and wrap around. Otherwise there's a small chance they can collide given the space is u32::MAX sized.

## How I Tested These Changes
New unit tests + existing coverage.
