### PR TITLE
Selectively update dependencies, documentation, rework code

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -625,9 +625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
- "der_derive",
- "flagset",
- "pem-rfc7468",
+ "pem-rfc7468 0.6.0",
  "zeroize",
 ]
 
@@ -638,6 +636,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468 0.7.0",
  "zeroize",
 ]
 
@@ -657,14 +658,13 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.6.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef71ddb5b3a1f53dee24817c8f70dfa1cb29e804c18d88c228d4bc9c86ee3b9"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -723,7 +723,7 @@ checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
  "der 0.6.1",
  "elliptic-curve 0.12.3",
- "rfc6979",
+ "rfc6979 0.3.1",
  "signature 1.6.4",
 ]
 
@@ -735,8 +735,22 @@ checksum = "12844141594ad74185a926d030f3b605f6a903b4e3fec351f3ea338ac5b7637e"
 dependencies = [
  "der 0.6.1",
  "elliptic-curve 0.12.3",
- "rfc6979",
+ "rfc6979 0.3.1",
  "signature 2.0.0",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der 0.7.9",
+ "digest",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "signature 2.0.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -759,7 +773,7 @@ dependencies = [
  "generic-array 0.14.7",
  "group 0.12.1",
  "hkdf",
- "pem-rfc7468",
+ "pem-rfc7468 0.6.0",
  "pkcs8 0.9.0",
  "rand_core 0.6.4",
  "sec1 0.3.0",
@@ -1128,12 +1142,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1162,7 +1170,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ring",
  "rustls-pki-types",
  "thiserror 2.0.12",
@@ -1185,7 +1193,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.1",
+ "rand 0.9.2",
  "smallvec",
  "thiserror 2.0.12",
  "tokio",
@@ -1479,7 +1487,6 @@ dependencies = [
 name = "integration"
 version = "0.1.0"
 dependencies = [
- "aws-nitro-enclaves-nsm-api",
  "borsh",
  "nix",
  "qos_client",
@@ -1491,9 +1498,8 @@ dependencies = [
  "qos_nsm",
  "qos_p256",
  "qos_test_primitives",
- "rand 0.8.5",
+ "rand 0.9.2",
  "rustls",
- "serde",
  "tokio",
  "ureq",
  "webpki-roots",
@@ -1678,13 +1684,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1853,16 +1859,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "object"
 version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1921,7 +1917,7 @@ checksum = "49c124b3cbce43bcbac68c58ec181d98ed6cc7e6d0aa7c3ba97b2563410b0e55"
 dependencies = [
  "ecdsa 0.15.1",
  "elliptic-curve 0.12.3",
- "primeorder",
+ "primeorder 0.12.1",
  "sha2",
 ]
 
@@ -1938,13 +1934,13 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630a4a9b2618348ececfae61a4905f564b817063bf2d66cdfc2ced523fe1d2d4"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
- "ecdsa 0.15.1",
- "elliptic-curve 0.12.3",
- "primeorder",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
  "sha2",
 ]
 
@@ -2009,6 +2005,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2016,18 +2021,18 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2137,36 +2142,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve 0.13.8",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
  "toml_edit",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -2192,7 +2182,7 @@ dependencies = [
  "qos_nsm",
  "qos_p256",
  "qos_test_primitives",
- "rand_core 0.6.4",
+ "rand_core 0.9.3",
  "rpassword",
  "serde_json",
  "ureq",
@@ -2229,7 +2219,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_core 0.6.4",
  "sha2",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "vsss-rs",
 ]
 
@@ -2263,7 +2253,7 @@ dependencies = [
  "httparse",
  "qos_core",
  "qos_test_primitives",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rustls",
  "serde",
  "serde_json",
@@ -2279,9 +2269,8 @@ dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "borsh",
  "hex-literal",
- "p384 0.12.0",
+ "p384 0.13.1",
  "qos_hex",
- "rand 0.8.5",
  "serde_bytes",
  "sha2",
  "webpki",
@@ -2308,7 +2297,7 @@ dependencies = [
 name = "qos_test_primitives"
 version = "0.1.0"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -2345,9 +2334,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -2453,6 +2442,16 @@ dependencies = [
  "crypto-bigint 0.4.9",
  "hmac",
  "zeroize",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
@@ -3088,26 +3087,25 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.2"
+version = "1.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68722da18b0fc4a05fdc1120b302b82051265792a1e1b399086e9b204b10ad3d"
+checksum = "492a604e2fd7f814268a378409e6c92b5525d747d10db9a229723f55a417958c"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3415,9 +3413,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.10"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37493cadf42a2a939ed404698ded7fb378bf301b5011f973361779a3a74f8c93"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3581,6 +3579,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -3766,14 +3773,13 @@ dependencies = [
 
 [[package]]
 name = "x509-cert"
-version = "0.1.0"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd27a832a85efcf56cad058e4e3256d1781b927e113a9e37d96916d639e4af7"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
 dependencies = [
  "const-oid",
- "der 0.6.1",
- "flagset",
- "spki 0.6.0",
+ "der 0.7.9",
+ "spki 0.7.3",
 ]
 
 [[package]]

--- a/src/integration/Cargo.toml
+++ b/src/integration/Cargo.toml
@@ -15,15 +15,12 @@ qos_hex = { path = "../qos_hex" }
 qos_p256 = { path = "../qos_p256", features = ["mock"] }
 qos_test_primitives = { path = "../qos_test_primitives" }
 
-tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"], default-features = false }
+tokio = { version = "1.43.1", features = ["macros", "rt-multi-thread"], default-features = false }
 borsh = { version = "1.0", features = ["std", "derive"] , default-features = false}
 nix = { version = "0.26", features = ["socket"], default-features = false }
 rustls = { version = "0.23.5" }
-webpki-roots = { version = "0.26.1" }
+webpki-roots = { version = "1.0.2" }
 
 [dev-dependencies]
-qos_core = { path = "../qos_core", features = ["mock"], default-features = false }
-aws-nitro-enclaves-nsm-api = { version = "0.4", default-features = false }
-rand = "0.8"
+rand = "0.9"
 ureq = { version = "2.9", features = ["json"], default-features = false }
-serde = { version = "1", features = ["derive"] }

--- a/src/integration/tests/genesis.rs
+++ b/src/integration/tests/genesis.rs
@@ -12,7 +12,7 @@ use qos_crypto::{sha_512, shamir::shares_reconstruct};
 use qos_nsm::nitro::unsafe_attestation_doc_from_der;
 use qos_p256::{P256Pair, P256Public};
 use qos_test_primitives::{ChildWrapper, PathWrapper};
-use rand::{seq::SliceRandom, thread_rng};
+use rand::{seq::SliceRandom, rng};
 
 const DR_KEY_PUBLIC_PATH: &str = "./mock/mock_p256_dr.pub";
 const DR_KEY_PRIVATE_PATH: &str = "./mock/mock_p256_dr.secret.keep";
@@ -197,7 +197,7 @@ async fn genesis_e2e() {
 		.collect();
 
 	// Try recovering from a random permutation
-	decrypted_shares.shuffle(&mut thread_rng());
+	decrypted_shares.shuffle(&mut rng());
 	let master_secret: [u8; qos_p256::MASTER_SEED_LEN] =
 		shares_reconstruct(&decrypted_shares[0..threshold])
 			.unwrap()

--- a/src/qos_client/Cargo.toml
+++ b/src/qos_client/Cargo.toml
@@ -16,13 +16,14 @@ ureq = { version = "2.9", default-features = false }
 aws-nitro-enclaves-nsm-api = { version = "0.4", default-features = false }
 borsh = { version = "1.0", features = ["std", "derive"] , default-features = false}
 p256 = { version = "0.12.0", default-features = false }
-rand_core = { version = "0.6", default-features = false }
+rand_core = { version = "0.9", features = ["os_rng"], default-features = false }
 zeroize = { version = "1.6", default-features = false }
 rpassword = { version = "7", default-features = false }
 serde_json = { version = "1" }
 
 x509 = { version = "0.2", default-features = false, optional = true }
-yubikey = { version = "*", features = ["untested"], default-features = false, optional = true }
+# As of 7/2025, upgrading this to 0.8.0 is blocked due to dependency conflicts
+yubikey = { version = "0.7", features = ["untested"], default-features = false, optional = true }
 
 [dev-dependencies]
 # We need mock enabled to grab things related to the mock NSM.

--- a/src/qos_client/src/yubikey.rs
+++ b/src/qos_client/src/yubikey.rs
@@ -7,7 +7,7 @@ use p256::{
 	SecretKey,
 };
 use qos_p256::encrypt::Envelope;
-use rand_core::{OsRng, RngCore};
+use rand_core::{OsRng, TryRngCore};
 use x509::RelativeDistinguishedName;
 use yubikey::{
 	certificate::{Certificate, PublicKeyInfo},
@@ -70,6 +70,9 @@ pub enum YubiKeyError {
 /// Generate a signed certificate with a p256 key for the given `slot`.
 ///
 /// Returns the public key as an uncompressed encoded point.
+///
+/// # Panics
+/// Panics if the `OsRng` is unable to provide data, which shouldn't happen in normal operation.
 pub fn generate_signed_certificate(
 	yubikey: &mut YubiKey,
 	slot: SlotId,
@@ -95,7 +98,9 @@ pub fn generate_signed_certificate(
 
 	// Create a random serial number
 	let mut serial = [0u8; 20];
-	OsRng.fill_bytes(&mut serial);
+	OsRng.try_fill_bytes(&mut serial).expect(
+		"The OsRng was unable to provide data, which should never happen",
+	);
 
 	// Don't add any extensions
 	let extensions: &[x509::Extension<'_, &[u64]>] = &[];
@@ -117,6 +122,9 @@ pub fn generate_signed_certificate(
 
 /// Import the given `key_data` onto the `yubikey` and create a signed
 /// certificate for the key.
+///
+/// # Panics
+/// Panics if the `OsRng` is unable to provide data, which shouldn't happen in normal operation.
 pub fn import_key_and_generate_signed_certificate(
 	yubikey: &mut YubiKey,
 	key_data: &[u8],
@@ -156,7 +164,9 @@ pub fn import_key_and_generate_signed_certificate(
 
 	// Create a random serial number
 	let mut serial = [0u8; 20];
-	OsRng.fill_bytes(&mut serial);
+	OsRng.try_fill_bytes(&mut serial).expect(
+		"The OsRng was unable to provide data, which should never happen",
+	);
 
 	// Don't add any extensions
 	let extensions: &[x509::Extension<'_, &[u64]>] = &[];

--- a/src/qos_core/Cargo.toml
+++ b/src/qos_core/Cargo.toml
@@ -26,7 +26,7 @@ qos_test_primitives = { path = "../qos_test_primitives" }
 qos_p256 = { path = "../qos_p256", features = ["mock"] }
 qos_nsm = { path = "../qos_nsm", features = ["mock"], default-features = false }
 rustls = { version = "0.23.5" }
-webpki-roots = { version = "0.26.1" }
+webpki-roots = { version = "1.0.2" }
 
 [features]
 # Support for VSOCK

--- a/src/qos_crypto/Cargo.toml
+++ b/src/qos_crypto/Cargo.toml
@@ -4,14 +4,14 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 sha2 = { version = "0.10", default-features = false }
-rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
+thiserror = { version = "2.0.12",  features = ["std"], default-features = false }
 vsss-rs = { version = "5.1", default-features = false, features = ["std", "zeroize"] }
+# dependent on rand_core version used in vsss-rs
+rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
+# dependent on rand_core version used in vsss-rs
 rand_core = { version = "0.6.4", default-features = false }
-thiserror = "1.0.63"
 
 [dev-dependencies]
 qos_hex = { path = "../qos_hex" }

--- a/src/qos_enclave/Cargo.toml
+++ b/src/qos_enclave/Cargo.toml
@@ -7,6 +7,9 @@ rust-version = "1.61"
 publish = false
 
 [dependencies]
+# newer versions 1.4.1 and 1.4.2 available
+# as of 7/2025, AWS doesn't have a recent crate version of aws-nitro-enclaves-cli published
+# directly use the git version as a workaround
 nitro-cli = { git = "https://github.com/aws/aws-nitro-enclaves-cli", version = "1.4.0" }
 libc = "0.2.172" # NOTE: nitro-cli requires ^0.2.161
 

--- a/src/qos_hex/Cargo.toml
+++ b/src/qos_hex/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-serde = {version = "1", optional = true, default-features = false }
+serde = { version = "1", optional = true, default-features = false }
 
 [features]
-serde =["dep:serde"]
+serde = ["dep:serde"]

--- a/src/qos_host/Cargo.toml
+++ b/src/qos_host/Cargo.toml
@@ -10,7 +10,7 @@ qos_hex = { path = "../qos_hex", features = ["serde"], default-features = false 
 
 # Third party
 axum = { version = "0.6.20", features = ["http1", "tokio", "json"], default-features = false }
-tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"], default-features = false }
+tokio = { version = "1.43.1", features = ["macros", "rt-multi-thread"], default-features = false }
 borsh = { version = "1.0", features = ["std", "derive"] , default-features = false}
 serde_json = { version = "1" }
 serde = { version = "1", features = ["derive"], default-features = false }

--- a/src/qos_net/Cargo.toml
+++ b/src/qos_net/Cargo.toml
@@ -19,7 +19,7 @@ hickory-resolver = { version = "0.25.2", features = [
 rand = { version = "0.9.1", features = [
     "thread_rng",
 ], default-features = false, optional = true }
-tokio = { version = "1.38.0", default-features = false }
+tokio = { version = "1.43.1", default-features = false }
 
 [dev-dependencies]
 qos_test_primitives = { path = "../qos_test_primitives" }
@@ -29,7 +29,7 @@ serde_json = { version = "1.0.121", features = [
     "std",
 ], default-features = false }
 rustls = { version = "0.23.5" }
-webpki-roots = { version = "0.26.1" }
+webpki-roots = { version = "1.0.2" }
 
 [features]
 default = ["proxy"]                  # keep this as a default feature ensures we lint by default

--- a/src/qos_nsm/Cargo.toml
+++ b/src/qos_nsm/Cargo.toml
@@ -6,18 +6,19 @@ publish = false
 
 [dependencies]
 qos_hex = { path = "../qos_hex" }
-borsh = { version = "1.0", features = ["std", "derive"] , default-features = false}
+borsh = { version = "1.5", features = ["std", "derive"] , default-features = false}
 aws-nitro-enclaves-nsm-api = { version = "0.4", features = ["nix"], default-features = false }
 aws-nitro-enclaves-cose = { version = "0.5", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 webpki = { version =  "0.22.4", default-features = false }
 serde_bytes = { version = "0.11", default-features = false }
-p384 = { version = "0.12", features = ["sha384", "ecdsa", "ecdsa-core", "std"], default-features = false }
-x509-cert = { version = "=0.1.0", features = ["pem"], default-features = false }
+# as of 0.12.0, the "ecdsa" feature enables "sha384", some "ecdsa-core", and others
+p384 = { version = "0.13", features = ["ecdsa", "std"], default-features = false }
+x509-cert = { version = "0.2.5", features = ["pem"], default-features = false }
 
 [dev-dependencies]
-hex-literal = "0.4"
-rand = "0.8"
+# 1.0.0 requires Rust edition 2024
+hex-literal = "0.4.0"
 
 [features]
 # Never use in production - support for mock NSM

--- a/src/qos_p256/Cargo.toml
+++ b/src/qos_p256/Cargo.toml
@@ -8,14 +8,16 @@ publish = false
 qos_hex = { path = "../qos_hex" }
 
 borsh = { version = "1.0", features = ["std", "derive"] , default-features = false}
+# version related to p256 crate
 rand_core = { version = "0.6.4", default-features = false }
 
 sha2 = { version = "0.10", default-features = false }
-p256 = { version = "0.12.0", features = ["ecdh", "ecdsa", "ecdsa-core", "std"], default-features = false }
+# as of 0.12.0, the "ecdsa" feature enables "sha384", some "ecdsa-core", and others
+p256 = { version = "0.12.0", features = ["ecdh", "ecdsa", "std"], default-features = false }
 aes-gcm = { version = "0.10.3", features = ["aes", "alloc"], default-features = false }
 hmac = { version = "0.12", default-features = false }
 hkdf = { version = "0.12", default-features = false }
-zeroize = { version = "1.6", features = ["derive"], default-features = false }
+zeroize = { version = "1.8", features = ["derive"], default-features = false }
 
 [dev-dependencies]
 qos_test_primitives = { path = "../qos_test_primitives" }

--- a/src/qos_test_primitives/Cargo.toml
+++ b/src/qos_test_primitives/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-rand = "0.8"
+rand = "0.9"

--- a/src/qos_test_primitives/src/lib.rs
+++ b/src/qos_test_primitives/src/lib.rs
@@ -83,9 +83,9 @@ impl<'a> Deref for PathWrapper<'a> {
 /// Get a bind-able TCP port on the local system.
 #[must_use]
 pub fn find_free_port() -> Option<u16> {
-	let mut rng = rand::thread_rng();
+	let mut rng = rand::rng();
 	for _ in 0..MAX_PORT_SEARCH_ATTEMPTS {
-		let port = rng.gen_range(SERVER_PORT_RANGE);
+		let port = rng.random_range(SERVER_PORT_RANGE);
 		if port_is_available(port) {
 			return Some(port);
 		}


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

Perform maintenance on the used QOS dependencies and switch to newer versions.

This PR focuses on changes that are relatively simple individually, and can be implemented with minimal code changes.

Additionally, perform some formatting changes and removal of non-needed dependencies, and adjust version pinning to reflect the actually used version range.

Some notable changes:
* `tokio` `1.38.2` to `1.43.1`, switch from old LTS to new LTS branch
* Switch to `rand` / `rand_core` `0.9` where easily possible
* webpki-roots `0.26.1` to `1.0.2`  - this crate has now been marked 1.0 stable with relatively little changes, update to get new TLS root certificate information
* p384 `0.12.0` to `0.13.1` - update cryptography library
* x509-cert `0.1.0` to `0.2.5` - update cryptography library

Some of these changes are in preparation of future updates of cryptography libraries `p256` and `yubikey`.

## How I Tested These Changes
Local tests.

## Pre merge check list
No functional changes expected.

- [ ] Update CHANGELOG.MD
