### PR TITLE
Template the underlying write error when `fs::write` fails

### DIFF
--- a/src/qos_client/src/cli/services.rs
+++ b/src/qos_client/src/cli/services.rs
@@ -2104,8 +2104,8 @@ fn split_file_name(p: &Path) -> Vec<String> {
 /// `item_name` was written to `path`.
 fn write_with_msg(path: &Path, buf: &[u8], item_name: &str) {
 	let path_str = path.as_os_str().to_string_lossy();
-	fs::write(path, buf).unwrap_or_else(|_| {
-		panic!("Failed writing {} to file", path_str.clone())
+	fs::write(path, buf).unwrap_or_else(|e| {
+		panic!("Failed writing {} to file: {:?}", path_str.clone(), e)
 	});
 	println!("{item_name} written to: {path_str}");
 }


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)
Had to do this to debug a local write failure: turns out I was trying to write (within Docker) into a read-only volume. Couldn't have figured this out if I hadn't templated the error!

## How I Tested These Changes
Used this for my own debugging!
