### PR TITLE
Fix typo in container registry name

### DIFF
--- a/kustomize/components/qos_host/deployment.yaml
+++ b/kustomize/components/qos_host/deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
         - name: qos-host
-          image: ghrc.io/tkhq/qos_host
+          image: ghcr.io/tkhq/qos_host
           command:
             - /qos_host
           args:


### PR DESCRIPTION
s/ghrc/ghcr 

## Summary & Motivation (Problem vs. Solution)
ghrc.io appears to be a potential credential stealing proxy See: https://bmitch.net/blog/2025-08-22-ghrc-appears-malicious/

## How I Tested These Changes
I haven't

## Pre merge check list

- [ ] Update CHANGELOG.MD
