### PR TITLE
implement fully async reaper

### DIFF
--- a/src/init/init.rs
+++ b/src/init/init.rs
@@ -83,7 +83,7 @@ async fn main() {
 	)
 	.expect("unable to create app pool");
 
-	Reaper::execute(&handles, Box::new(Nsm), core_pool, app_pool, None);
+	Reaper::execute(&handles, Box::new(Nsm), core_pool, app_pool, None).await;
 
 	reboot();
 }

--- a/src/integration/examples/boot_enclave.rs
+++ b/src/integration/examples/boot_enclave.rs
@@ -437,7 +437,7 @@ async fn main() {
 	}
 
 	// Give the enclave time to start the pivot
-	std::thread::sleep(std::time::Duration::from_secs(2));
+	tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
 	let enclave_info_url =
 		format!("http://{LOCAL_HOST}:{}/qos/enclave-info", host_port);

--- a/src/integration/src/bin/pivot_socket_stress.rs
+++ b/src/integration/src/bin/pivot_socket_stress.rs
@@ -21,7 +21,7 @@ impl Processor {
 impl RequestProcessor for Processor {
 	async fn process(&self, request: &[u8]) -> Vec<u8> {
 		// Simulate just some baseline lag for all requests
-		std::thread::sleep(std::time::Duration::from_secs(1));
+		tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
 		let msg = PivotSocketStressMsg::try_from_slice(request)
 			.expect("Received invalid message - test is broken");

--- a/src/integration/tests/boot.rs
+++ b/src/integration/tests/boot.rs
@@ -452,7 +452,7 @@ async fn standard_boot_e2e() {
 	assert_eq!(enclave_info.phase, ProtocolPhase::QuorumKeyProvisioned);
 
 	// Give the enclave time to start the pivot
-	std::thread::sleep(std::time::Duration::from_secs(2));
+	tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
 	// Check that the pivot executed
 	let contents = std::fs::read(PIVOT_OK2_SUCCESS_FILE).unwrap();

--- a/src/integration/tests/boot.rs
+++ b/src/integration/tests/boot.rs
@@ -445,18 +445,18 @@ async fn standard_boot_e2e() {
 			.success());
 	}
 
+	let enclave_info_url =
+		format!("http://{LOCAL_HOST}:{}/qos/enclave-info", host_port);
+	let enclave_info: EnclaveInfo =
+		ureq::get(&enclave_info_url).call().unwrap().into_json().unwrap();
+	assert_eq!(enclave_info.phase, ProtocolPhase::QuorumKeyProvisioned);
+
 	// Give the enclave time to start the pivot
 	std::thread::sleep(std::time::Duration::from_secs(2));
 
 	// Check that the pivot executed
 	let contents = std::fs::read(PIVOT_OK2_SUCCESS_FILE).unwrap();
 	assert_eq!(std::str::from_utf8(&contents).unwrap(), msg);
-
-	let enclave_info_url =
-		format!("http://{LOCAL_HOST}:{}/qos/enclave-info", host_port);
-	let enclave_info: EnclaveInfo =
-		ureq::get(&enclave_info_url).call().unwrap().into_json().unwrap();
-	assert_eq!(enclave_info.phase, ProtocolPhase::QuorumKeyProvisioned);
 
 	fs::remove_file(PIVOT_OK2_SUCCESS_FILE).unwrap();
 }

--- a/src/integration/tests/dev_boot.rs
+++ b/src/integration/tests/dev_boot.rs
@@ -77,7 +77,7 @@ async fn dev_boot_e2e() {
 		.unwrap();
 
 	// Give the coordinator time to pivot
-	std::thread::sleep(std::time::Duration::from_secs(2));
+	tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
 	// Make sure pivot ran
 	assert!(Path::new(PIVOT_OK3_SUCCESS_FILE).exists());

--- a/src/integration/tests/enclave_app_client_socket_stress.rs
+++ b/src/integration/tests/enclave_app_client_socket_stress.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use borsh::BorshDeserialize;
 use integration::{
 	wait_for_usock, PivotSocketStressMsg, PIVOT_SOCKET_STRESS_PATH,
@@ -14,7 +16,7 @@ use qos_core::{
 		},
 		ProtocolError, ProtocolPhase, ENCLAVE_APP_SOCKET_CLIENT_TIMEOUT_SECS,
 	},
-	reaper::{Reaper, REAPER_RESTART_DELAY_IN_SECONDS},
+	reaper::{Reaper, REAPER_RESTART_DELAY},
 };
 use qos_nsm::mock::MockNsm;
 use qos_p256::P256Pair;
@@ -119,10 +121,7 @@ async fn enclave_app_client_socket_stress() {
 		)
 	);
 
-	tokio::time::sleep(std::time::Duration::from_secs(
-		REAPER_RESTART_DELAY_IN_SECONDS + 1,
-	))
-	.await;
+	tokio::time::sleep(REAPER_RESTART_DELAY + Duration::from_secs(1)).await;
 	// The pivot panicked and should have been restarted.
 	let app_request =
 		borsh::to_vec(&PivotSocketStressMsg::OkRequest(1)).unwrap();

--- a/src/integration/tests/reaper.rs
+++ b/src/integration/tests/reaper.rs
@@ -5,7 +5,7 @@ use qos_core::{
 	handles::Handles,
 	io::{SocketAddress, StreamPool},
 	protocol::services::boot::ManifestEnvelope,
-	reaper::{Reaper, REAPER_EXIT_DELAY_IN_SECONDS},
+	reaper::{Reaper, REAPER_EXIT_DELAY},
 };
 use qos_nsm::mock::MockNsm;
 use qos_test_primitives::PathWrapper;
@@ -125,10 +125,7 @@ async fn reaper_handles_non_zero_exits() {
 
 	// Ensure the reaper has enough time to detect the secret, launch the
 	// pivot, and let the pivot exit.
-	tokio::time::sleep(std::time::Duration::from_secs(
-		REAPER_EXIT_DELAY_IN_SECONDS * 2,
-	))
-	.await;
+	tokio::time::sleep(REAPER_EXIT_DELAY * 2).await;
 
 	assert!(reaper_handle.is_finished());
 }
@@ -185,10 +182,7 @@ async fn reaper_handles_panic() {
 
 	// Ensure the reaper has enough time to detect the secret, launch the
 	// pivot, and let the pivot exit.
-	tokio::time::sleep(std::time::Duration::from_secs(
-		REAPER_EXIT_DELAY_IN_SECONDS * 2,
-	))
-	.await;
+	tokio::time::sleep(REAPER_EXIT_DELAY * 2).await;
 
 	assert!(reaper_handle.is_finished());
 }

--- a/src/integration/tests/reaper.rs
+++ b/src/integration/tests/reaper.rs
@@ -55,7 +55,7 @@ async fn reaper_works() {
 	});
 
 	// Give the enclave server time to bind to the socket
-	std::thread::sleep(std::time::Duration::from_secs(1));
+	tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
 	// Check that the reaper is still running, presumably waiting for
 	// the secret.
@@ -113,7 +113,7 @@ async fn reaper_handles_non_zero_exits() {
 	});
 
 	// Give the enclave server time to bind to the socket
-	std::thread::sleep(std::time::Duration::from_secs(1));
+	tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
 	// Check that the reaper is still running, presumably waiting for
 	// the secret.
@@ -125,9 +125,10 @@ async fn reaper_handles_non_zero_exits() {
 
 	// Ensure the reaper has enough time to detect the secret, launch the
 	// pivot, and let the pivot exit.
-	std::thread::sleep(std::time::Duration::from_secs(
+	tokio::time::sleep(std::time::Duration::from_secs(
 		REAPER_EXIT_DELAY_IN_SECONDS * 2,
-	));
+	))
+	.await;
 
 	assert!(reaper_handle.is_finished());
 }
@@ -172,7 +173,7 @@ async fn reaper_handles_panic() {
 	});
 
 	// Give the enclave server time to bind to the socket
-	std::thread::sleep(std::time::Duration::from_secs(1));
+	tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
 	// Check that the reaper is still running, presumably waiting for
 	// the secret.
@@ -184,9 +185,10 @@ async fn reaper_handles_panic() {
 
 	// Ensure the reaper has enough time to detect the secret, launch the
 	// pivot, and let the pivot exit.
-	std::thread::sleep(std::time::Duration::from_secs(
+	tokio::time::sleep(std::time::Duration::from_secs(
 		REAPER_EXIT_DELAY_IN_SECONDS * 2,
-	));
+	))
+	.await;
 
 	assert!(reaper_handle.is_finished());
 }

--- a/src/qos_core/Cargo.toml
+++ b/src/qos_core/Cargo.toml
@@ -21,7 +21,7 @@ serde_bytes = { workspace = true }
 serde = { workspace = true }
 
 futures = { workspace = true }
-tokio = { workspace = true, features = ["io-util", "macros", "net", "rt-multi-thread", "time", "signal"], default-features = false }
+tokio = { workspace = true, features = ["io-util", "macros", "net", "rt-multi-thread", "time", "signal", "process"], default-features = false }
 tokio-vsock = { workspace = true }
 
 [dev-dependencies]

--- a/src/qos_core/src/cli.rs
+++ b/src/qos_core/src/cli.rs
@@ -151,8 +151,8 @@ impl CLI {
 		} else if opts.parsed.help() {
 			println!("{}", opts.parsed.info());
 		} else {
-			// start reaper in a thread so we can terminate on ctrl+c properly
-			std::thread::spawn(move || {
+			// start reaper in a task so we can terminate on ctrl+c properly
+			tokio::spawn(async move {
 				Reaper::execute(
 					&Handles::new(
 						opts.ephemeral_file(),
@@ -165,7 +165,8 @@ impl CLI {
 						.expect("Unable to create enclave socket pool"),
 					opts.app_pool().expect("Unable to create enclave app pool"),
 					None,
-				);
+				)
+				.await;
 			});
 
 			eprintln!("qos_core: Reaper running, press ctrl+c to quit");

--- a/src/qos_core/src/client.rs
+++ b/src/qos_core/src/client.rs
@@ -85,6 +85,7 @@ impl SocketClient {
 
 	/// Attempt a one-off connection, used for tests
 	pub async fn try_connect(&self) -> Result<(), IOError> {
+		eprintln!("TRY C");
 		let pool = self.pool.read().await;
 		let mut stream = pool.get().await;
 

--- a/src/qos_core/src/client.rs
+++ b/src/qos_core/src/client.rs
@@ -85,7 +85,6 @@ impl SocketClient {
 
 	/// Attempt a one-off connection, used for tests
 	pub async fn try_connect(&self) -> Result<(), IOError> {
-		eprintln!("TRY C");
 		let pool = self.pool.read().await;
 		let mut stream = pool.get().await;
 

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -87,7 +87,6 @@ async fn run_server(
 	}
 
 	eprintln!("Reaper::server shutdown");
-	*server_state.write().unwrap() = InterState::Quitting;
 }
 
 /// Primary entry point for running the enclave. Coordinates spawning the server

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -24,10 +24,10 @@ use crate::{
 };
 
 /// Delay for restarting the pivot app if the process exits.
-pub const REAPER_RESTART_DELAY_IN_SECONDS: u64 = 1;
+pub const REAPER_RESTART_DELAY: Duration = Duration::from_millis(50);
 /// Delay until the reaper exits after pivot app with a Never restart policy
 /// exits.
-pub const REAPER_EXIT_DELAY_IN_SECONDS: u64 = 3;
+pub const REAPER_EXIT_DELAY: Duration = Duration::from_secs(3);
 
 const REAPER_STATE_CHECK_DELAY: Duration = Duration::from_millis(100);
 
@@ -143,7 +143,7 @@ impl Reaper {
 			}
 
 			eprintln!("Reaper::execute waiting for pivot and manifest");
-			tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+			tokio::time::sleep(REAPER_STATE_CHECK_DELAY).await;
 		}
 
 		println!("Reaper::execute about to spawn pivot");
@@ -169,10 +169,7 @@ impl Reaper {
 
 				// pause to ensure OS has enough time to clean up resources
 				// before restarting
-				tokio::time::sleep(std::time::Duration::from_secs(
-					REAPER_RESTART_DELAY_IN_SECONDS,
-				))
-				.await;
+				tokio::time::sleep(REAPER_RESTART_DELAY).await;
 
 				println!("Restarting pivot ...");
 			},
@@ -189,10 +186,7 @@ impl Reaper {
 
 		*inter_state.write().unwrap() = InterState::Quitting;
 
-		tokio::time::sleep(std::time::Duration::from_secs(
-			REAPER_EXIT_DELAY_IN_SECONDS,
-		))
-		.await;
+		tokio::time::sleep(REAPER_EXIT_DELAY).await;
 
 		if let Err(err) = server_worker.await {
 			eprintln!("Reaper::execute server_worker join error: {err:?}");

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -41,8 +41,6 @@ async fn run_server(
 	app_pool: StreamPool,
 	test_only_init_phase_override: Option<ProtocolPhase>,
 ) {
-	// run the state processor inside a tokio runtime in this thread
-	// create the state
 	let protocol_state =
 		ProtocolState::new(nsm, handles.clone(), test_only_init_phase_override);
 	// send a shared version of state and the async pool to each processor

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -31,6 +31,67 @@ pub const REAPER_EXIT_DELAY_IN_SECONDS: u64 = 3;
 
 const REAPER_STATE_CHECK_DELAY: Duration = Duration::from_millis(100);
 
+// runs the enclave and app servers, waiting for manifest/pivot
+// executed as a task from `Reaper::execute`
+async fn run_server(
+	server_state: Arc<RwLock<InterState>>,
+	handles: Handles,
+	nsm: Box<dyn NsmProvider + Send>,
+	pool: StreamPool,
+	app_pool: StreamPool,
+	test_only_init_phase_override: Option<ProtocolPhase>,
+) {
+	// run the state processor inside a tokio runtime in this thread
+	// create the state
+	let protocol_state =
+		ProtocolState::new(nsm, handles.clone(), test_only_init_phase_override);
+	// send a shared version of state and the async pool to each processor
+	let processor =
+		ProtocolProcessor::new(protocol_state.shared(), app_pool.shared());
+	// listen_all will multiplex the processor accross all sockets
+	let mut server = SocketServer::listen_all(pool, &processor)
+		.expect("unable to get listen task list");
+
+	loop {
+		// see if we got interrupted
+		if *server_state.read().unwrap() == InterState::Quitting {
+			return;
+		}
+
+		let (manifest_present, pool_size) =
+			get_pool_size_from_pivot_args(&handles);
+
+		if manifest_present {
+			let pool_size = pool_size.unwrap_or(1);
+			// expand server to pool_size
+			server
+				.listen_to(pool_size, &processor)
+				.expect("unable to listen_to on the running server");
+			// expand app connections to pool_size
+			processor
+				.write()
+				.await
+				.expand_to(pool_size)
+				.await
+				.expect("unable to expand_to on the processor app pool");
+
+			*server_state.write().unwrap() = InterState::PivotReady;
+			eprintln!("Reaper::server manifest is present, breaking out of server check loop");
+			break;
+		}
+
+		tokio::time::sleep(REAPER_STATE_CHECK_DELAY).await;
+	}
+
+	eprintln!("Reaper::server post-expansion, waiting for shutdown");
+	while *server_state.read().unwrap() != InterState::Quitting {
+		tokio::time::sleep(REAPER_STATE_CHECK_DELAY).await;
+	}
+
+	eprintln!("Reaper::server shutdown");
+	*server_state.write().unwrap() = InterState::Quitting;
+}
+
 /// Primary entry point for running the enclave. Coordinates spawning the server
 /// and pivot binary.
 pub struct Reaper;
@@ -44,7 +105,6 @@ impl Reaper {
 	/// - If spawning the pivot errors.
 	/// - If waiting for the pivot errors.
 	#[allow(dead_code)]
-	#[allow(clippy::too_many_lines)]
 	pub async fn execute(
 		handles: &Handles,
 		nsm: Box<dyn NsmProvider + Send>,
@@ -52,63 +112,19 @@ impl Reaper {
 		app_pool: StreamPool,
 		test_only_init_phase_override: Option<ProtocolPhase>,
 	) {
-		let handles2 = handles.clone();
+		// state switch to communicate between pivot run task (here) and run_server task
+		// we need to establish
 		let inter_state = Arc::new(RwLock::new(InterState::Booting));
 		let server_state = inter_state.clone();
 
-		let worker = tokio::spawn(async move {
-			// run the state processor inside a tokio runtime in this thread
-			// create the state
-			let protocol_state = ProtocolState::new(
-				nsm,
-				handles2.clone(),
-				test_only_init_phase_override,
-			);
-			// send a shared version of state and the async pool to each processor
-			let processor = ProtocolProcessor::new(
-				protocol_state.shared(),
-				app_pool.shared(),
-			);
-			// listen_all will multiplex the processor accross all sockets
-			let mut server = SocketServer::listen_all(pool, &processor)
-				.expect("unable to get listen task list");
-
-			loop {
-				// see if we got interrupted
-				if *server_state.read().unwrap() == InterState::Quitting {
-					return;
-				}
-
-				let (manifest_present, pool_size) =
-					get_pool_size_from_pivot_args(&handles2);
-
-				if manifest_present {
-					let pool_size = pool_size.unwrap_or(1);
-					// expand server to pool_size
-					server
-						.listen_to(pool_size, &processor)
-						.expect("unable to listen_to on the running server");
-					// expand app connections to pool_size
-					processor.write().await.expand_to(pool_size).await.expect(
-						"unable to expand_to on the processor app pool",
-					);
-
-					*server_state.write().unwrap() = InterState::PivotReady;
-					eprintln!("Reaper::server manifest is present, breaking out of server check loop");
-					break;
-				}
-
-				tokio::time::sleep(REAPER_STATE_CHECK_DELAY).await;
-			}
-
-			eprintln!("Reaper::server post-expansion, waiting for shutdown");
-			while *server_state.read().unwrap() != InterState::Quitting {
-				tokio::time::sleep(REAPER_STATE_CHECK_DELAY).await;
-			}
-
-			eprintln!("Reaper::server shutdown");
-			*server_state.write().unwrap() = InterState::Quitting;
-		});
+		let server_worker = tokio::spawn(run_server(
+			server_state,
+			handles.clone(),
+			nsm,
+			pool,
+			app_pool,
+			test_only_init_phase_override,
+		));
 
 		loop {
 			let server_state = *inter_state.read().unwrap();
@@ -180,8 +196,8 @@ impl Reaper {
 		))
 		.await;
 
-		if let Err(err) = worker.await {
-			eprintln!("Worker join error: {err:?}");
+		if let Err(err) = server_worker.await {
+			eprintln!("Reaper::execute server_worker join error: {err:?}");
 		}
 
 		println!("Reaper exiting ... ");


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)
Refactor qos_core `Reaper` to use async tokio spawning directly without threads to lower unnecessary load.

Also fixes a bunch of tests with forgotten `std::thread::sleep` which shouldn't be  used with tokio as it blocks the main task.

## How I Tested These Changes
Tested on preprod by deploying from this PR with a temporary mono PR.