### PR TITLE
expand Manifest with pool_size and client_timeout

### DIFF
--- a/src/init/init.rs
+++ b/src/init/init.rs
@@ -70,7 +70,7 @@ async fn main() {
 	);
 
 	const START_PORT: u32 = 3;
-	const INITIAL_POOL_SIZE: u32 = 1; // start at pool size 1, grow based on  manifest/args as necessary (see Reaper)
+	const INITIAL_POOL_SIZE: u8 = 1; // start at pool size 1, grow based on  manifest/args as necessary (see Reaper)
 	let core_pool = StreamPool::new(
 		SocketAddress::new_vsock(cid, START_PORT, VMADDR_NO_FLAGS),
 		INITIAL_POOL_SIZE,

--- a/src/integration/src/bin/pivot_pool_size.rs
+++ b/src/integration/src/bin/pivot_pool_size.rs
@@ -1,0 +1,9 @@
+use integration::PIVOT_POOL_SIZE_SUCCESS_FILE;
+
+fn main() {
+	if std::env::var("POOL_SIZE").is_err() {
+		panic!("invalid pool size specified")
+	}
+
+	integration::Cli::execute(PIVOT_POOL_SIZE_SUCCESS_FILE);
+}

--- a/src/integration/src/lib.rs
+++ b/src/integration/src/lib.rs
@@ -19,12 +19,16 @@ pub const PIVOT_OK_SUCCESS_FILE: &str = "./pivot_ok_works";
 pub const PIVOT_OK2_SUCCESS_FILE: &str = "./pivot_ok2_works";
 /// Path to the file `pivot_ok3` writes on success for tests.
 pub const PIVOT_OK3_SUCCESS_FILE: &str = "./pivot_ok3_works";
+/// Path to the file `pivot_pool_size` writes on success for tests.
+pub const PIVOT_POOL_SIZE_SUCCESS_FILE: &str = "./pivot_pool_size_works";
 /// Path to pivot_ok bin for tests.
 pub const PIVOT_OK_PATH: &str = "../target/debug/pivot_ok";
 /// Path to pivot_ok2 bin for tests.
 pub const PIVOT_OK2_PATH: &str = "../target/debug/pivot_ok2";
 /// Path to pivot_ok3 bin for tests.
 pub const PIVOT_OK3_PATH: &str = "../target/debug/pivot_ok3";
+/// Path to pivot_pool_size bin for tests.
+pub const PIVOT_POOL_SIZE_PATH: &str = "../target/debug/pivot_pool_size";
 /// Path to pivot loop bin for tests.
 pub const PIVOT_LOOP_PATH: &str = "../target/debug/pivot_loop";
 /// Path to pivot_abort bin for tests.

--- a/src/integration/src/lib.rs
+++ b/src/integration/src/lib.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use borsh::{BorshDeserialize, BorshSerialize};
 use qos_core::{
 	client::SocketClient,
-	io::{SocketAddress, StreamPool, TimeVal, TimeValLike},
+	io::{SocketAddress, StreamPool},
 	parser::{GetParserForOptions, OptionsParser, Parser, Token},
 };
 
@@ -136,7 +136,7 @@ pub struct AdditionProofPayload {
 pub async fn wait_for_usock(path: &str) {
 	let addr = SocketAddress::new_unix(path);
 	let pool = StreamPool::new(addr, 1).unwrap().shared();
-	let client = SocketClient::new(pool, TimeVal::milliseconds(50));
+	let client = SocketClient::new(pool, Duration::from_millis(50));
 
 	for _ in 0..50 {
 		if std::fs::exists(path).unwrap() && client.try_connect().await.is_ok()

--- a/src/integration/tests/boot.rs
+++ b/src/integration/tests/boot.rs
@@ -132,7 +132,6 @@ async fn standard_boot_e2e() {
 		hash: mock_pivot_hash,
 		restart: RestartPolicy::Never,
 		args: vec!["--msg".to_string(), msg.to_string()],
-		pool_size: None,
 	};
 	assert_eq!(manifest.pivot, pivot);
 	let manifest_set = ManifestSet { threshold: 2, members: members.clone() };

--- a/src/integration/tests/boot.rs
+++ b/src/integration/tests/boot.rs
@@ -132,6 +132,7 @@ async fn standard_boot_e2e() {
 		hash: mock_pivot_hash,
 		restart: RestartPolicy::Never,
 		args: vec!["--msg".to_string(), msg.to_string()],
+		pool_size: None,
 	};
 	assert_eq!(manifest.pivot, pivot);
 	let manifest_set = ManifestSet { threshold: 2, members: members.clone() };

--- a/src/integration/tests/client.rs
+++ b/src/integration/tests/client.rs
@@ -1,8 +1,8 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use qos_core::{
 	client::SocketClient,
-	io::{SocketAddress, StreamPool, TimeVal, TimeValLike},
+	io::{SocketAddress, StreamPool},
 	server::SocketServerError,
 	server::{RequestProcessor, SocketServer},
 };
@@ -37,7 +37,7 @@ async fn run_echo_server(
 async fn direct_connect_works() {
 	let socket_path = "/tmp/async_client_test_direct_connect_works.sock";
 	let socket = SocketAddress::new_unix(socket_path);
-	let timeout = TimeVal::milliseconds(500);
+	let timeout = Duration::from_millis(500);
 	let pool = StreamPool::new(socket, 1)
 		.expect("unable to create async pool")
 		.shared();
@@ -54,7 +54,7 @@ async fn direct_connect_works() {
 async fn times_out_properly() {
 	let socket_path = "/tmp/async_client_test_times_out_properly.sock";
 	let socket = SocketAddress::new_unix(socket_path);
-	let timeout = TimeVal::milliseconds(500);
+	let timeout = Duration::from_millis(500);
 	let pool = StreamPool::new(socket, 1)
 		.expect("unable to create async pool")
 		.shared();
@@ -68,7 +68,7 @@ async fn times_out_properly() {
 async fn repeat_connect_works() {
 	let socket_path = "/tmp/async_client_test_repeat_connect_works.sock";
 	let socket = SocketAddress::new_unix(socket_path);
-	let timeout = TimeVal::milliseconds(500);
+	let timeout = Duration::from_millis(500);
 	let pool = StreamPool::new(socket, 1)
 		.expect("unable to create async pool")
 		.shared();

--- a/src/integration/tests/enclave_app_client_socket_stress.rs
+++ b/src/integration/tests/enclave_app_client_socket_stress.rs
@@ -41,6 +41,7 @@ async fn enclave_app_client_socket_stress() {
 			hash: [1; 32],
 			restart: RestartPolicy::Always,
 			args: vec![APP_SOCK.to_string()],
+			pool_size: None,
 		},
 		manifest_set: ManifestSet { threshold: 0, members: vec![] },
 		share_set: ShareSet { threshold: 0, members: vec![] },

--- a/src/integration/tests/enclave_app_client_socket_stress.rs
+++ b/src/integration/tests/enclave_app_client_socket_stress.rs
@@ -41,7 +41,6 @@ async fn enclave_app_client_socket_stress() {
 			hash: [1; 32],
 			restart: RestartPolicy::Always,
 			args: vec![APP_SOCK.to_string()],
-			pool_size: None,
 		},
 		manifest_set: ManifestSet { threshold: 0, members: vec![] },
 		share_set: ShareSet { threshold: 0, members: vec![] },

--- a/src/integration/tests/enclave_app_client_socket_stress.rs
+++ b/src/integration/tests/enclave_app_client_socket_stress.rs
@@ -103,7 +103,7 @@ async fn enclave_app_client_socket_stress() {
 		StreamPool::single(SocketAddress::new_unix(ENCLAVE_SOCK)).unwrap();
 	let enclave_client = SocketClient::new(
 		enclave_client_pool.shared(),
-		INITIAL_CLIENT_TIMEOUT + Duration::from_secs(3), // needs to be bigger than the sdlow request below + some time for recovery
+		INITIAL_CLIENT_TIMEOUT + Duration::from_secs(3), // needs to be bigger than the slow request below + some time for recovery
 	);
 
 	let app_request =

--- a/src/integration/tests/enclave_app_client_socket_stress.rs
+++ b/src/integration/tests/enclave_app_client_socket_stress.rs
@@ -7,14 +7,14 @@ use integration::{
 use qos_core::{
 	client::SocketClient,
 	handles::Handles,
-	io::{SocketAddress, StreamPool, TimeVal, TimeValLike},
+	io::{SocketAddress, StreamPool},
 	protocol::{
 		msg::ProtocolMsg,
 		services::boot::{
 			Manifest, ManifestEnvelope, ManifestSet, Namespace, NitroConfig,
 			PivotConfig, RestartPolicy, ShareSet,
 		},
-		ProtocolError, ProtocolPhase, ENCLAVE_APP_SOCKET_CLIENT_TIMEOUT_SECS,
+		ProtocolError, ProtocolPhase, INITIAL_CLIENT_TIMEOUT,
 	},
 	reaper::{Reaper, REAPER_RESTART_DELAY},
 };
@@ -103,7 +103,7 @@ async fn enclave_app_client_socket_stress() {
 		StreamPool::single(SocketAddress::new_unix(ENCLAVE_SOCK)).unwrap();
 	let enclave_client = SocketClient::new(
 		enclave_client_pool.shared(),
-		TimeVal::seconds(ENCLAVE_APP_SOCKET_CLIENT_TIMEOUT_SECS + 3), // needs to be bigger than the slow request below + some time for recovery
+		INITIAL_CLIENT_TIMEOUT + Duration::from_secs(3), // needs to be bigger than the sdlow request below + some time for recovery
 	);
 
 	let app_request =

--- a/src/integration/tests/interleaving_socket_stress.rs
+++ b/src/integration/tests/interleaving_socket_stress.rs
@@ -6,8 +6,8 @@ use integration::{
 };
 use qos_core::{
 	client::{ClientError, SocketClient},
-	io::{SocketAddress, StreamPool, TimeVal, TimeValLike},
-	protocol::ENCLAVE_APP_SOCKET_CLIENT_TIMEOUT_SECS,
+	io::{SocketAddress, StreamPool},
+	protocol::INITIAL_CLIENT_TIMEOUT,
 };
 use qos_test_primitives::ChildWrapper;
 
@@ -27,12 +27,12 @@ async fn interleaving_socket_stress() {
 	wait_for_usock(SOCKET_STRESS_SOCK).await;
 
 	// needs to be long enough for process exit to register and not cause a timeout
-	let timeout = TimeVal::seconds(ENCLAVE_APP_SOCKET_CLIENT_TIMEOUT_SECS);
 	let app_pool =
 		StreamPool::new(SocketAddress::new_unix(SOCKET_STRESS_SOCK), pool_size)
 			.unwrap();
 
-	let enclave_client = SocketClient::new(app_pool.shared(), timeout);
+	let enclave_client =
+		SocketClient::new(app_pool.shared(), INITIAL_CLIENT_TIMEOUT);
 	let mut tasks = Vec::new();
 
 	// wait long enough for app to be running and listening

--- a/src/integration/tests/proofs.rs
+++ b/src/integration/tests/proofs.rs
@@ -4,8 +4,8 @@ use borsh::BorshDeserialize;
 use integration::{wait_for_usock, PivotProofMsg, PIVOT_PROOF_PATH};
 use qos_core::{
 	client::SocketClient,
-	io::{SocketAddress, StreamPool, TimeVal, TimeValLike},
-	protocol::ENCLAVE_APP_SOCKET_CLIENT_TIMEOUT_SECS,
+	io::{SocketAddress, StreamPool},
+	protocol::INITIAL_CLIENT_TIMEOUT,
 };
 
 use qos_p256::P256Public;
@@ -27,10 +27,8 @@ async fn fetch_and_verify_app_proof() {
 		StreamPool::single(SocketAddress::new_unix(PROOF_TEST_ENCLAVE_SOCKET))
 			.unwrap();
 
-	let enclave_client = SocketClient::new(
-		enclave_pool.shared(),
-		TimeVal::seconds(ENCLAVE_APP_SOCKET_CLIENT_TIMEOUT_SECS),
-	);
+	let enclave_client =
+		SocketClient::new(enclave_pool.shared(), INITIAL_CLIENT_TIMEOUT);
 
 	let app_request =
 		borsh::to_vec(&PivotProofMsg::AdditionRequest { a: 2, b: 2 }).unwrap();

--- a/src/integration/tests/reaper.rs
+++ b/src/integration/tests/reaper.rs
@@ -216,7 +216,7 @@ async fn reaper_handles_pool_size() {
 	manifest_envelope.manifest.pivot.args =
 		vec!["--msg".to_string(), msg.to_string()];
 	// set a pool size > 1
-	manifest_envelope.manifest.pivot.pool_size = Some(5);
+	manifest_envelope.manifest.pool_size = Some(5);
 
 	handles.put_manifest_envelope(&manifest_envelope).unwrap();
 	assert!(handles.pivot_exists());

--- a/src/integration/tests/reaper.rs
+++ b/src/integration/tests/reaper.rs
@@ -1,6 +1,9 @@
 use std::fs;
 
-use integration::{PIVOT_ABORT_PATH, PIVOT_OK_PATH, PIVOT_PANIC_PATH};
+use integration::{
+	wait_for_usock, PIVOT_ABORT_PATH, PIVOT_OK_PATH, PIVOT_PANIC_PATH,
+	PIVOT_POOL_SIZE_PATH,
+};
 use qos_core::{
 	handles::Handles,
 	io::{SocketAddress, StreamPool},
@@ -185,6 +188,72 @@ async fn reaper_handles_panic() {
 	tokio::time::sleep(REAPER_EXIT_DELAY * 2).await;
 
 	assert!(reaper_handle.is_finished());
+}
+
+#[tokio::test]
+async fn reaper_handles_pool_size() {
+	let secret_path: PathWrapper =
+		"/tmp/reaper_handles_pool_size.secret".into();
+	// let eph_path = "reaper_works.eph.key";
+	let usock: PathWrapper = "/tmp/reaper_handles_pool_size.sock".into();
+	let manifest_path: PathWrapper =
+		"/tmp/reaper_handles_pool_size.manifest".into();
+	let msg = "5"; // must match pool-size in manifest bellow (test thing)
+
+	// For our sanity, ensure the secret does not yet exist
+	drop(fs::remove_file(&*secret_path));
+
+	let handles = Handles::new(
+		"eph_path".to_string(),
+		(*secret_path).to_string(),
+		(*manifest_path).to_string(),
+		PIVOT_POOL_SIZE_PATH.to_string(),
+	);
+
+	// Make sure we have written everything necessary to pivot, except the
+	// quorum key
+	let mut manifest_envelope = ManifestEnvelope::default();
+	manifest_envelope.manifest.pivot.args =
+		vec!["--msg".to_string(), msg.to_string()];
+	// set a pool size > 1
+	manifest_envelope.manifest.pivot.pool_size = Some(5);
+
+	handles.put_manifest_envelope(&manifest_envelope).unwrap();
+	assert!(handles.pivot_exists());
+
+	let enclave_pool =
+		StreamPool::single(SocketAddress::new_unix(&usock)).unwrap();
+
+	let app_pool =
+		StreamPool::single(SocketAddress::new_unix("/tmp/never.sock")).unwrap();
+
+	let reaper_handle = tokio::spawn(async move {
+		Reaper::execute(
+			&handles,
+			Box::new(MockNsm),
+			enclave_pool,
+			app_pool,
+			None,
+		)
+		.await;
+	});
+
+	// wait for enclave to listen
+	wait_for_usock(&usock).await;
+
+	// Check that the reaper is still running, presumably waiting for
+	// the secret.
+	assert!(!reaper_handle.is_finished());
+
+	// Create the file with the secret, which should cause the reaper
+	// to start executable.
+	fs::write(&*secret_path, b"super dank tank secret tech").unwrap();
+
+	// Make the sure the reaper executed successfully.
+	reaper_handle.await.unwrap();
+	let contents = fs::read(integration::PIVOT_POOL_SIZE_SUCCESS_FILE).unwrap();
+	assert_eq!(std::str::from_utf8(&contents).unwrap(), msg);
+	assert!(fs::remove_file(integration::PIVOT_POOL_SIZE_SUCCESS_FILE).is_ok());
 }
 
 #[test]

--- a/src/integration/tests/reaper.rs
+++ b/src/integration/tests/reaper.rs
@@ -36,6 +36,7 @@ async fn reaper_works() {
 	let mut manifest_envelope = ManifestEnvelope::default();
 	manifest_envelope.manifest.pivot.args =
 		vec!["--msg".to_string(), msg.to_string()];
+	manifest_envelope.manifest.client_timeout_ms = Some(2000); // check if this gets applied
 
 	handles.put_manifest_envelope(&manifest_envelope).unwrap();
 	assert!(handles.pivot_exists());

--- a/src/integration/tests/reaper.rs
+++ b/src/integration/tests/reaper.rs
@@ -1,13 +1,17 @@
-use std::fs;
+use std::{fs, time::Duration};
 
 use integration::{
-	wait_for_usock, PIVOT_ABORT_PATH, PIVOT_OK_PATH, PIVOT_PANIC_PATH,
-	PIVOT_POOL_SIZE_PATH,
+	wait_for_usock, PivotSocketStressMsg, PIVOT_ABORT_PATH, PIVOT_OK_PATH,
+	PIVOT_PANIC_PATH, PIVOT_POOL_SIZE_PATH, PIVOT_SOCKET_STRESS_PATH,
 };
 use qos_core::{
+	client::SocketClient,
 	handles::Handles,
 	io::{SocketAddress, StreamPool},
-	protocol::services::boot::ManifestEnvelope,
+	protocol::{
+		msg::ProtocolMsg, services::boot::ManifestEnvelope, ProtocolError,
+		ProtocolPhase,
+	},
 	reaper::{Reaper, REAPER_EXIT_DELAY},
 };
 use qos_nsm::mock::MockNsm;
@@ -16,7 +20,6 @@ use qos_test_primitives::PathWrapper;
 #[tokio::test]
 async fn reaper_works() {
 	let secret_path: PathWrapper = "/tmp/reaper_works.secret".into();
-	// let eph_path = "reaper_works.eph.key";
 	let usock: PathWrapper = "/tmp/reaper_works.sock".into();
 	let manifest_path: PathWrapper = "/tmp/reaper_works.manifest".into();
 	let msg = "durp-a-durp";
@@ -36,16 +39,15 @@ async fn reaper_works() {
 	let mut manifest_envelope = ManifestEnvelope::default();
 	manifest_envelope.manifest.pivot.args =
 		vec!["--msg".to_string(), msg.to_string()];
-	manifest_envelope.manifest.client_timeout_ms = Some(2000); // check if this gets applied
 
 	handles.put_manifest_envelope(&manifest_envelope).unwrap();
 	assert!(handles.pivot_exists());
 
 	let enclave_pool =
-		StreamPool::new(SocketAddress::new_unix(&usock), 1).unwrap();
+		StreamPool::single(SocketAddress::new_unix(&usock)).unwrap();
 
 	let app_pool =
-		StreamPool::new(SocketAddress::new_unix("./never.sock"), 1).unwrap();
+		StreamPool::single(SocketAddress::new_unix("./never.sock")).unwrap();
 
 	let reaper_handle = tokio::spawn(async move {
 		Reaper::execute(
@@ -59,7 +61,7 @@ async fn reaper_works() {
 	});
 
 	// Give the enclave server time to bind to the socket
-	tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+	wait_for_usock(&usock).await;
 
 	// Check that the reaper is still running, presumably waiting for
 	// the secret.
@@ -74,6 +76,94 @@ async fn reaper_works() {
 	let contents = fs::read(integration::PIVOT_OK_SUCCESS_FILE).unwrap();
 	assert_eq!(std::str::from_utf8(&contents).unwrap(), msg);
 	assert!(fs::remove_file(integration::PIVOT_OK_SUCCESS_FILE).is_ok());
+}
+
+#[tokio::test]
+async fn reaper_timeout_works() {
+	let secret_path: PathWrapper = "/tmp/reaper_timeout_works.secret".into();
+	let enclave_sock: PathWrapper = "/tmp/reaper_timeout_works.sock".into();
+	let app_sock: PathWrapper = "/tmp/reaper_timeout_works_app.sock".into();
+	let manifest_path: PathWrapper =
+		"/tmp/reaper_timeout_works.manifest".into();
+
+	// clean up old manifest if it's left from a panic
+	drop(std::fs::remove_file(&*manifest_path));
+
+	// For our sanity, ensure the secret does not yet exist
+	drop(fs::remove_file(&*secret_path));
+
+	let handles = Handles::new(
+		"eph_path".to_string(),
+		(*secret_path).to_string(),
+		(*manifest_path).to_string(),
+		PIVOT_SOCKET_STRESS_PATH.to_string(),
+	);
+
+	// Make sure we have written everything necessary to pivot, except the
+	// quorum key
+	let mut manifest_envelope = ManifestEnvelope::default();
+	// Tell pivot where to open up the server app socket
+	manifest_envelope.manifest.pivot.args = vec![app_sock.to_string()];
+
+	// we'll be checking if this is set by passing slow and fast requests
+	manifest_envelope.manifest.client_timeout_ms = Some(2000);
+
+	handles.put_manifest_envelope(&manifest_envelope).unwrap();
+	assert!(handles.pivot_exists());
+
+	let enclave_pool =
+		StreamPool::single(SocketAddress::new_unix(&enclave_sock)).unwrap();
+
+	let app_pool =
+		StreamPool::single(SocketAddress::new_unix(&app_sock)).unwrap();
+
+	let reaper_handle = tokio::spawn(async move {
+		Reaper::execute(
+			&handles,
+			Box::new(MockNsm),
+			enclave_pool,
+			app_pool,
+			Some(ProtocolPhase::QuorumKeyProvisioned),
+		)
+		.await;
+	});
+
+	// Give the enclave server time to bind to the socket
+	wait_for_usock(&enclave_sock).await;
+
+	// Check that the reaper is still running, presumably waiting for
+	// the secret.
+	assert!(!reaper_handle.is_finished());
+
+	// Create the file with the secret, which should cause the reaper
+	// to start executable.
+	fs::write(&*secret_path, b"super dank tank secret tech").unwrap();
+
+	// Give the app server time to bind to the socket
+	wait_for_usock(&app_sock).await;
+
+	// create a "slow" app request longer than client timeout from `Manifest`, but longer than 5s timeout on our local client.
+	let app_request =
+		borsh::to_vec(&PivotSocketStressMsg::SlowRequest(3000)).unwrap();
+	let request =
+		borsh::to_vec(&ProtocolMsg::ProxyRequest { data: app_request })
+			.unwrap();
+
+	// ensure our client to the enclave has longer timeout than the configured 2s and the slow request 3s
+	let client = SocketClient::single(
+		SocketAddress::new_unix(&enclave_sock),
+		Duration::from_millis(5000),
+	)
+	.unwrap();
+
+	let response: ProtocolMsg =
+		borsh::from_slice(&client.call(&request).await.unwrap()).unwrap();
+
+	// The response should be AppClientRecvTimeout which indicates the enclave short-circuited the timeout
+	assert_eq!(
+		response,
+		ProtocolMsg::ProtocolErrorResponse(ProtocolError::AppClientRecvTimeout)
+	);
 }
 
 #[tokio::test]
@@ -117,7 +207,7 @@ async fn reaper_handles_non_zero_exits() {
 	});
 
 	// Give the enclave server time to bind to the socket
-	tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+	wait_for_usock(&usock).await;
 
 	// Check that the reaper is still running, presumably waiting for
 	// the secret.
@@ -174,7 +264,7 @@ async fn reaper_handles_panic() {
 	});
 
 	// Give the enclave server time to bind to the socket
-	tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+	wait_for_usock(&usock).await;
 
 	// Check that the reaper is still running, presumably waiting for
 	// the secret.
@@ -195,11 +285,10 @@ async fn reaper_handles_panic() {
 async fn reaper_handles_pool_size() {
 	let secret_path: PathWrapper =
 		"/tmp/reaper_handles_pool_size.secret".into();
-	// let eph_path = "reaper_works.eph.key";
 	let usock: PathWrapper = "/tmp/reaper_handles_pool_size.sock".into();
 	let manifest_path: PathWrapper =
 		"/tmp/reaper_handles_pool_size.manifest".into();
-	let msg = "5"; // must match pool-size in manifest bellow (test thing)
+	let msg = "5"; // must match pool-size in manifest below (test thing)
 
 	// For our sanity, ensure the secret does not yet exist
 	drop(fs::remove_file(&*secret_path));

--- a/src/integration/tests/remote_tls.rs
+++ b/src/integration/tests/remote_tls.rs
@@ -6,8 +6,8 @@ use integration::{
 };
 use qos_core::{
 	client::SocketClient,
-	io::{SocketAddress, StreamPool, TimeVal, TimeValLike},
-	protocol::ENCLAVE_APP_SOCKET_CLIENT_TIMEOUT_SECS,
+	io::{SocketAddress, StreamPool},
+	protocol::INITIAL_CLIENT_TIMEOUT,
 };
 
 use qos_test_primitives::ChildWrapper;
@@ -43,10 +43,8 @@ async fn fetch_async_remote_tls_content() {
 	)
 	.expect("unable to create enclave async pool");
 
-	let enclave_client = SocketClient::new(
-		enclave_pool.shared(),
-		TimeVal::seconds(ENCLAVE_APP_SOCKET_CLIENT_TIMEOUT_SECS),
-	);
+	let enclave_client =
+		SocketClient::new(enclave_pool.shared(), INITIAL_CLIENT_TIMEOUT);
 
 	let app_request = borsh::to_vec(&PivotRemoteTlsMsg::RemoteTlsRequest {
 		host: "api.turnkey.com".to_string(),

--- a/src/integration/tests/simple_socket_stress.rs
+++ b/src/integration/tests/simple_socket_stress.rs
@@ -22,8 +22,6 @@ async fn simple_socket_stress() {
 
 	wait_for_usock(SOCKET_STRESS_SOCK).await;
 
-	// needs to be long enough for process exit to register and not cause a timeout
-
 	let app_pool =
 		StreamPool::new(SocketAddress::new_unix(SOCKET_STRESS_SOCK), 1)
 			.unwrap();

--- a/src/integration/tests/simple_socket_stress.rs
+++ b/src/integration/tests/simple_socket_stress.rs
@@ -5,8 +5,8 @@ use integration::{
 };
 use qos_core::{
 	client::{ClientError, SocketClient},
-	io::{IOError, SocketAddress, StreamPool, TimeVal, TimeValLike},
-	protocol::ENCLAVE_APP_SOCKET_CLIENT_TIMEOUT_SECS,
+	io::{IOError, SocketAddress, StreamPool},
+	protocol::INITIAL_CLIENT_TIMEOUT,
 };
 use qos_test_primitives::ChildWrapper;
 
@@ -23,13 +23,13 @@ async fn simple_socket_stress() {
 	wait_for_usock(SOCKET_STRESS_SOCK).await;
 
 	// needs to be long enough for process exit to register and not cause a timeout
-	let timeout = TimeVal::seconds(ENCLAVE_APP_SOCKET_CLIENT_TIMEOUT_SECS);
 
 	let app_pool =
 		StreamPool::new(SocketAddress::new_unix(SOCKET_STRESS_SOCK), 1)
 			.unwrap();
 
-	let enclave_client = SocketClient::new(app_pool.shared(), timeout);
+	let enclave_client =
+		SocketClient::new(app_pool.shared(), INITIAL_CLIENT_TIMEOUT);
 
 	let app_request =
 		borsh::to_vec(&PivotSocketStressMsg::SlowRequest(5500)).unwrap();

--- a/src/qos_client/src/cli/mod.rs
+++ b/src/qos_client/src/cli/mod.rs
@@ -570,6 +570,21 @@ impl Command {
 			.takes_value(false)
 	}
 
+	fn pool_size() -> Token {
+		Token::new(POOL_SIZE, "Socket pool size for USOCK/VSOCK")
+			.required(false)
+			.takes_value(true)
+	}
+
+	fn client_timeout() -> Token {
+		Token::new(
+			CLIENT_TIMEOUT,
+			"Client timeout for enclave <-> app communication",
+		)
+		.required(false)
+		.takes_value(true)
+	}
+
 	fn base() -> Parser {
 		Parser::new()
 			.token(
@@ -654,6 +669,8 @@ impl Command {
 			.token(Self::patch_set_dir_token())
 			.token(Self::quorum_key_path_token())
 			.token(Self::pivot_args_token())
+			.token(Self::pool_size())
+			.token(Self::client_timeout())
 	}
 
 	fn approve_manifest() -> Parser {

--- a/src/qos_client/src/cli/mod.rs
+++ b/src/qos_client/src/cli/mod.rs
@@ -40,6 +40,7 @@ const PATCH_SET_DIR: &str = "patch-set-dir";
 const NAMESPACE_DIR: &str = "namespace-dir";
 const UNSAFE_AUTO_CONFIRM: &str = "unsafe-auto-confirm";
 const PUB_PATH: &str = "pub-path";
+const POOL_SIZE: &str = "pool-size";
 const YUBIKEY: &str = "yubikey";
 const SECRET_PATH: &str = "secret-path";
 const SHARE_PATH: &str = "share-path";
@@ -992,6 +993,12 @@ impl ClientOpts {
 		}
 	}
 
+	fn pool_size(&self) -> Option<u8> {
+		self.parsed.single(POOL_SIZE).map(|s| {
+			s.parse().expect("pool-size not valid integer in range <1..255>")
+		})
+	}
+
 	fn pub_path(&self) -> String {
 		self.parsed.single(PUB_PATH).expect("Missing `--pub-path`").to_string()
 	}
@@ -1517,6 +1524,7 @@ mod handlers {
 			manifest_set_dir: opts.manifest_set_dir(),
 			patch_set_dir: opts.patch_set_dir(),
 			quorum_key_path: opts.quorum_key_path(),
+			pool_size: opts.pool_size(),
 		}) {
 			println!("Error: {e:?}");
 			std::process::exit(1);

--- a/src/qos_client/src/cli/mod.rs
+++ b/src/qos_client/src/cli/mod.rs
@@ -41,6 +41,7 @@ const NAMESPACE_DIR: &str = "namespace-dir";
 const UNSAFE_AUTO_CONFIRM: &str = "unsafe-auto-confirm";
 const PUB_PATH: &str = "pub-path";
 const POOL_SIZE: &str = "pool-size";
+const CLIENT_TIMEOUT: &str = "client-timeout";
 const YUBIKEY: &str = "yubikey";
 const SECRET_PATH: &str = "secret-path";
 const SHARE_PATH: &str = "share-path";
@@ -999,6 +1000,13 @@ impl ClientOpts {
 		})
 	}
 
+	fn client_timeout_ms(&self) -> Option<u16> {
+		self.parsed.single(CLIENT_TIMEOUT).map(|s| {
+			s.parse()
+				.expect("client timeout invalid integer in range <0..65535>")
+		})
+	}
+
 	fn pub_path(&self) -> String {
 		self.parsed.single(PUB_PATH).expect("Missing `--pub-path`").to_string()
 	}
@@ -1525,6 +1533,7 @@ mod handlers {
 			patch_set_dir: opts.patch_set_dir(),
 			quorum_key_path: opts.quorum_key_path(),
 			pool_size: opts.pool_size(),
+			client_timeout_ms: opts.client_timeout_ms(),
 		}) {
 			println!("Error: {e:?}");
 			std::process::exit(1);

--- a/src/qos_client/src/cli/services.rs
+++ b/src/qos_client/src/cli/services.rs
@@ -701,6 +701,7 @@ pub(crate) struct GenerateManifestArgs<P: AsRef<Path>> {
 	pub quorum_key_path: P,
 	pub manifest_path: P,
 	pub pivot_args: Vec<String>,
+	pub pool_size: Option<u8>,
 }
 
 pub(crate) fn generate_manifest<P: AsRef<Path>>(
@@ -719,6 +720,7 @@ pub(crate) fn generate_manifest<P: AsRef<Path>>(
 		quorum_key_path,
 		manifest_path,
 		pivot_args,
+		pool_size,
 	} = args;
 
 	let nitro_config =
@@ -744,6 +746,7 @@ pub(crate) fn generate_manifest<P: AsRef<Path>>(
 			hash: pivot_hash.try_into().expect("pivot hash was not 256 bits"),
 			restart: restart_policy,
 			args: pivot_args,
+			pool_size,
 		},
 		manifest_set,
 		share_set,
@@ -1630,7 +1633,12 @@ pub(crate) fn dangerous_dev_boot<P: AsRef<Path>>(
 			qos_commit: "mock-qos-commit-ref".to_string(),
 			aws_root_certificate: cert_from_pem(AWS_ROOT_CERT_PEM).unwrap(),
 		},
-		pivot: PivotConfig { hash: sha_256(&pivot), restart, args },
+		pivot: PivotConfig {
+			hash: sha_256(&pivot),
+			restart,
+			args,
+			pool_size: None,
+		},
 		manifest_set: ManifestSet {
 			threshold: 1,
 			// The only member is the quorum member
@@ -2251,6 +2259,7 @@ mod tests {
 					.into_iter()
 					.map(String::from)
 					.collect(),
+				pool_size: None,
 			},
 			manifest_set: manifest_set.clone(),
 			share_set: share_set.clone(),

--- a/src/qos_client/src/cli/services.rs
+++ b/src/qos_client/src/cli/services.rs
@@ -702,6 +702,7 @@ pub(crate) struct GenerateManifestArgs<P: AsRef<Path>> {
 	pub manifest_path: P,
 	pub pivot_args: Vec<String>,
 	pub pool_size: Option<u8>,
+	pub client_timeout_ms: Option<u16>,
 }
 
 pub(crate) fn generate_manifest<P: AsRef<Path>>(
@@ -721,6 +722,7 @@ pub(crate) fn generate_manifest<P: AsRef<Path>>(
 		manifest_path,
 		pivot_args,
 		pool_size,
+		client_timeout_ms,
 	} = args;
 
 	let nitro_config =
@@ -752,6 +754,7 @@ pub(crate) fn generate_manifest<P: AsRef<Path>>(
 		patch_set,
 		enclave: nitro_config,
 		pool_size,
+		client_timeout_ms,
 	};
 
 	write_with_msg(
@@ -1646,6 +1649,7 @@ pub(crate) fn dangerous_dev_boot<P: AsRef<Path>>(
 		},
 		patch_set: PatchSet { threshold: 0, members: vec![] },
 		pool_size: None,
+		client_timeout_ms: None,
 	};
 
 	// Create and post the boot standard instruction
@@ -2261,6 +2265,7 @@ mod tests {
 			patch_set: patch_set.clone(),
 			enclave: nitro_config.clone(),
 			pool_size: None,
+			client_timeout_ms: None,
 		};
 
 		let manifest_envelope = ManifestEnvelope {

--- a/src/qos_client/src/cli/services.rs
+++ b/src/qos_client/src/cli/services.rs
@@ -746,12 +746,12 @@ pub(crate) fn generate_manifest<P: AsRef<Path>>(
 			hash: pivot_hash.try_into().expect("pivot hash was not 256 bits"),
 			restart: restart_policy,
 			args: pivot_args,
-			pool_size,
 		},
 		manifest_set,
 		share_set,
 		patch_set,
 		enclave: nitro_config,
+		pool_size,
 	};
 
 	write_with_msg(
@@ -1633,12 +1633,7 @@ pub(crate) fn dangerous_dev_boot<P: AsRef<Path>>(
 			qos_commit: "mock-qos-commit-ref".to_string(),
 			aws_root_certificate: cert_from_pem(AWS_ROOT_CERT_PEM).unwrap(),
 		},
-		pivot: PivotConfig {
-			hash: sha_256(&pivot),
-			restart,
-			args,
-			pool_size: None,
-		},
+		pivot: PivotConfig { hash: sha_256(&pivot), restart, args },
 		manifest_set: ManifestSet {
 			threshold: 1,
 			// The only member is the quorum member
@@ -1650,6 +1645,7 @@ pub(crate) fn dangerous_dev_boot<P: AsRef<Path>>(
 			members: vec![member.clone()],
 		},
 		patch_set: PatchSet { threshold: 0, members: vec![] },
+		pool_size: None,
 	};
 
 	// Create and post the boot standard instruction
@@ -2259,12 +2255,12 @@ mod tests {
 					.into_iter()
 					.map(String::from)
 					.collect(),
-				pool_size: None,
 			},
 			manifest_set: manifest_set.clone(),
 			share_set: share_set.clone(),
 			patch_set: patch_set.clone(),
 			enclave: nitro_config.clone(),
+			pool_size: None,
 		};
 
 		let manifest_envelope = ManifestEnvelope {

--- a/src/qos_core/src/client.rs
+++ b/src/qos_core/src/client.rs
@@ -76,7 +76,7 @@ impl SocketClient {
 	/// Expands the underlying `AsyncPool` to given `pool_size`
 	pub async fn expand_to(
 		&mut self,
-		pool_size: u32,
+		pool_size: u8,
 	) -> Result<(), ClientError> {
 		self.pool.write().await.expand_to(pool_size)?;
 

--- a/src/qos_core/src/handles.rs
+++ b/src/qos_core/src/handles.rs
@@ -432,6 +432,7 @@ mod test {
 				hash: sha_256(&pivot),
 				restart: RestartPolicy::Always,
 				args: vec![],
+				pool_size: None,
 			},
 			manifest_set: ManifestSet { threshold: 2, members: vec![] },
 			share_set: ShareSet { threshold: 2, members: vec![] },

--- a/src/qos_core/src/handles.rs
+++ b/src/qos_core/src/handles.rs
@@ -437,6 +437,7 @@ mod test {
 			share_set: ShareSet { threshold: 2, members: vec![] },
 			patch_set: PatchSet::default(),
 			pool_size: None,
+			client_timeout_ms: None,
 		};
 
 		let manifest_envelope = ManifestEnvelope {

--- a/src/qos_core/src/handles.rs
+++ b/src/qos_core/src/handles.rs
@@ -432,11 +432,11 @@ mod test {
 				hash: sha_256(&pivot),
 				restart: RestartPolicy::Always,
 				args: vec![],
-				pool_size: None,
 			},
 			manifest_set: ManifestSet { threshold: 2, members: vec![] },
 			share_set: ShareSet { threshold: 2, members: vec![] },
 			patch_set: PatchSet::default(),
+			pool_size: None,
 		};
 
 		let manifest_envelope = ManifestEnvelope {

--- a/src/qos_core/src/io/pool.rs
+++ b/src/qos_core/src/io/pool.rs
@@ -65,7 +65,7 @@ impl StreamPool {
 	/// Create a new `StreamPool` with given starting `SocketAddress`, timeout and number of addresses to populate.
 	pub fn new(
 		start_address: SocketAddress,
-		mut count: u32,
+		mut count: u8,
 	) -> Result<Self, IOError> {
 		eprintln!("StreamPool start address: {start_address}");
 

--- a/src/qos_core/src/io/pool.rs
+++ b/src/qos_core/src/io/pool.rs
@@ -157,7 +157,7 @@ impl StreamPool {
 	}
 
 	/// Expands the pool with new addresses using `SocketAddress::next_address`
-	pub fn expand_to(&mut self, size: u32) -> Result<(), IOError> {
+	pub fn expand_to(&mut self, size: u8) -> Result<(), IOError> {
 		eprintln!("StreamPool: expanding async pool to {size}");
 		let size = size as usize;
 
@@ -176,7 +176,7 @@ impl StreamPool {
 	}
 
 	/// Listen to new connections on added sockets on top of existing listeners, returning the list of new `Listener`
-	pub fn listen_to(&mut self, size: u32) -> Result<Vec<Listener>, IOError> {
+	pub fn listen_to(&mut self, size: u8) -> Result<Vec<Listener>, IOError> {
 		eprintln!("StreamPool: listening async pool to {size}");
 		let size = size as usize;
 		let mut listeners = Vec::new();

--- a/src/qos_core/src/io/stream.rs
+++ b/src/qos_core/src/io/stream.rs
@@ -351,13 +351,9 @@ async fn vsock_connect(
 #[cfg(test)]
 mod test {
 
-	use std::{str::from_utf8, time::Duration};
-
-	use nix::sys::time::{TimeVal, TimeValLike};
-
-	use crate::{client::SocketClient, io::StreamPool};
-
 	use super::*;
+	use crate::{client::SocketClient, io::StreamPool};
+	use std::{str::from_utf8, time::Duration};
 
 	/// Wait for a given usock file to exist and be connectible with a timeout of 5s.
 	///
@@ -366,7 +362,7 @@ mod test {
 	pub async fn wait_for_usock(path: &str) {
 		let addr = SocketAddress::new_unix(path);
 		let pool = StreamPool::new(addr, 1).unwrap().shared();
-		let client = SocketClient::new(pool, TimeVal::milliseconds(50));
+		let client = SocketClient::new(pool, Duration::from_millis(50));
 
 		for _ in 0..50 {
 			if std::fs::exists(path).unwrap()

--- a/src/qos_core/src/protocol/mod.rs
+++ b/src/qos_core/src/protocol/mod.rs
@@ -9,10 +9,11 @@ pub mod services;
 mod state;
 
 pub use error::ProtocolError;
+pub use state::ProtocolPhase;
 pub(crate) use state::ProtocolState;
-pub use state::{ProtocolPhase, ENCLAVE_APP_SOCKET_CLIENT_TIMEOUT_SECS};
 
 pub(crate) mod processor;
+pub use processor::INITIAL_CLIENT_TIMEOUT;
 
 /// 256bit hash
 pub type Hash256 = [u8; 32];

--- a/src/qos_core/src/protocol/processor.rs
+++ b/src/qos_core/src/protocol/processor.rs
@@ -57,7 +57,7 @@ impl ProtocolProcessor {
 	/// Expands the app pool to given pool size
 	pub async fn expand_to(
 		&mut self,
-		pool_size: u32,
+		pool_size: u8,
 	) -> Result<(), ClientError> {
 		self.app_client.expand_to(pool_size).await
 	}

--- a/src/qos_core/src/protocol/processor.rs
+++ b/src/qos_core/src/protocol/processor.rs
@@ -1,13 +1,11 @@
 //! Quorum protocol processor
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
-use crate::io::{TimeVal, TimeValLike};
 use borsh::BorshDeserialize;
 use tokio::sync::RwLock;
 
 use super::{
-	error::ProtocolError, msg::ProtocolMsg, state::ProtocolState,
-	ProtocolPhase, ENCLAVE_APP_SOCKET_CLIENT_TIMEOUT_SECS,
+	error::ProtocolError, msg::ProtocolMsg, state::ProtocolState, ProtocolPhase,
 };
 use crate::{
 	client::{ClientError, SocketClient},
@@ -17,6 +15,9 @@ use crate::{
 
 const MEGABYTE: usize = 1024 * 1024;
 const MAX_ENCODED_MSG_LEN: usize = 128 * MEGABYTE;
+
+/// Initial client timeout for the processor until the Manifest says otherwise
+pub const INITIAL_CLIENT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Helper type to keep `ProtocolState` shared using `Arc<Mutex<ProtocolState>>`
 type SharedProtocolState = Arc<RwLock<ProtocolState>>;
@@ -42,16 +43,18 @@ impl ProtocolProcessor {
 		state: SharedProtocolState,
 		app_pool: SharedStreamPool,
 	) -> Arc<RwLock<Self>> {
-		let app_client = SocketClient::new(
-			app_pool,
-			TimeVal::seconds(ENCLAVE_APP_SOCKET_CLIENT_TIMEOUT_SECS),
-		);
+		let app_client = SocketClient::new(app_pool, INITIAL_CLIENT_TIMEOUT);
 		Arc::new(RwLock::new(Self { app_client, state }))
 	}
 
 	/// Helper to get phase between locking the shared state
 	async fn get_phase(&self) -> ProtocolPhase {
 		self.state.read().await.get_phase()
+	}
+
+	/// Sets the client timeout value for the `app_client`
+	pub fn set_client_timeout(&mut self, timeout: Duration) {
+		self.app_client.set_timeout(timeout);
 	}
 
 	/// Expands the app pool to given pool size

--- a/src/qos_core/src/protocol/processor.rs
+++ b/src/qos_core/src/protocol/processor.rs
@@ -16,7 +16,7 @@ use crate::{
 const MEGABYTE: usize = 1024 * 1024;
 const MAX_ENCODED_MSG_LEN: usize = 128 * MEGABYTE;
 
-/// Initial client timeout for the processor until the Manifest says otherwise
+/// Initial client timeout for the processor until the Manifest says otherwise, see reaper.rs
 pub const INITIAL_CLIENT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Helper type to keep `ProtocolState` shared using `Arc<Mutex<ProtocolState>>`
@@ -52,8 +52,9 @@ impl ProtocolProcessor {
 		self.state.read().await.get_phase()
 	}
 
-	/// Sets the client timeout value for the `app_client`
+	/// Sets the client timeout value for the `app_client`, maximum allowed value is `u16::MAX` milliseconds
 	pub fn set_client_timeout(&mut self, timeout: Duration) {
+		assert!(timeout.as_millis() < u16::MAX.into(), "client timeout > 65s");
 		self.app_client.set_timeout(timeout);
 	}
 

--- a/src/qos_core/src/protocol/services/boot.rs
+++ b/src/qos_core/src/protocol/services/boot.rs
@@ -320,6 +320,8 @@ pub struct Manifest {
 	pub enclave: NitroConfig,
 	/// Patch set members and threshold
 	pub patch_set: PatchSet,
+	/// Client timeout for calls via the VSOCK/USOCK, defaults to 5s if not specified
+	pub client_timeout_ms: Option<u16>,
 	/// Pool size argument used to set up our socket pipes, defaults to 1 if not specified
 	pub pool_size: Option<u8>,
 }

--- a/src/qos_core/src/protocol/services/boot.rs
+++ b/src/qos_core/src/protocol/services/boot.rs
@@ -123,6 +123,8 @@ pub struct PivotConfig {
 	/// Arguments to invoke the binary with. Leave this empty if none are
 	/// needed.
 	pub args: Vec<String>,
+	/// Pool size argument used to set up our socket pipes, defaults to 1 if not specified
+	pub pool_size: Option<u8>,
 }
 
 impl fmt::Debug for PivotConfig {
@@ -131,6 +133,7 @@ impl fmt::Debug for PivotConfig {
 			.field("hash", &qos_hex::encode(&self.hash))
 			.field("restart", &self.restart)
 			.field("args", &self.args.join(" "))
+			.field("pool-size", &self.pool_size)
 			.finish()
 	}
 }
@@ -529,6 +532,7 @@ mod test {
 				hash: sha_256(&pivot),
 				restart: RestartPolicy::Always,
 				args: vec![],
+				pool_size: None,
 			},
 			manifest_set: ManifestSet { threshold: 2, members: quorum_members },
 			share_set: ShareSet { threshold: 2, members: vec![] },

--- a/src/qos_core/src/protocol/services/boot.rs
+++ b/src/qos_core/src/protocol/services/boot.rs
@@ -123,8 +123,6 @@ pub struct PivotConfig {
 	/// Arguments to invoke the binary with. Leave this empty if none are
 	/// needed.
 	pub args: Vec<String>,
-	/// Pool size argument used to set up our socket pipes, defaults to 1 if not specified
-	pub pool_size: Option<u8>,
 }
 
 impl fmt::Debug for PivotConfig {
@@ -133,7 +131,6 @@ impl fmt::Debug for PivotConfig {
 			.field("hash", &qos_hex::encode(&self.hash))
 			.field("restart", &self.restart)
 			.field("args", &self.args.join(" "))
-			.field("pool-size", &self.pool_size)
 			.finish()
 	}
 }
@@ -323,6 +320,8 @@ pub struct Manifest {
 	pub enclave: NitroConfig,
 	/// Patch set members and threshold
 	pub patch_set: PatchSet,
+	/// Pool size argument used to set up our socket pipes, defaults to 1 if not specified
+	pub pool_size: Option<u8>,
 }
 
 /// An approval by a Quorum Member.
@@ -532,7 +531,6 @@ mod test {
 				hash: sha_256(&pivot),
 				restart: RestartPolicy::Always,
 				args: vec![],
-				pool_size: None,
 			},
 			manifest_set: ManifestSet { threshold: 2, members: quorum_members },
 			share_set: ShareSet { threshold: 2, members: vec![] },

--- a/src/qos_core/src/protocol/services/key.rs
+++ b/src/qos_core/src/protocol/services/key.rs
@@ -346,6 +346,7 @@ mod test {
 				hash: sha_256(&pivot),
 				restart: RestartPolicy::Always,
 				args: vec![],
+				pool_size: None,
 			},
 			manifest_set: ManifestSet { threshold: 2, members: quorum_members },
 			share_set: ShareSet { threshold: 2, members: vec![] },

--- a/src/qos_core/src/protocol/services/key.rs
+++ b/src/qos_core/src/protocol/services/key.rs
@@ -346,7 +346,6 @@ mod test {
 				hash: sha_256(&pivot),
 				restart: RestartPolicy::Always,
 				args: vec![],
-				pool_size: None,
 			},
 			manifest_set: ManifestSet { threshold: 2, members: quorum_members },
 			share_set: ShareSet { threshold: 2, members: vec![] },

--- a/src/qos_core/src/protocol/services/provision.rs
+++ b/src/qos_core/src/protocol/services/provision.rs
@@ -201,7 +201,6 @@ mod test {
 				hash: sha_256(pivot),
 				restart: RestartPolicy::Always,
 				args: vec![],
-				pool_size: None,
 			},
 			manifest_set: ManifestSet {
 				threshold: threshold.try_into().unwrap(),
@@ -212,6 +211,7 @@ mod test {
 				members: members.clone().into_iter().map(|(m, _)| m).collect(),
 			},
 			patch_set: PatchSet::default(),
+			pool_size: None,
 		};
 
 		let approvals: Vec<_> = members

--- a/src/qos_core/src/protocol/services/provision.rs
+++ b/src/qos_core/src/protocol/services/provision.rs
@@ -212,6 +212,7 @@ mod test {
 			},
 			patch_set: PatchSet::default(),
 			pool_size: None,
+			client_timeout_ms: None,
 		};
 
 		let approvals: Vec<_> = members

--- a/src/qos_core/src/protocol/services/provision.rs
+++ b/src/qos_core/src/protocol/services/provision.rs
@@ -201,6 +201,7 @@ mod test {
 				hash: sha_256(pivot),
 				restart: RestartPolicy::Always,
 				args: vec![],
+				pool_size: None,
 			},
 			manifest_set: ManifestSet {
 				threshold: threshold.try_into().unwrap(),

--- a/src/qos_core/src/protocol/state.rs
+++ b/src/qos_core/src/protocol/state.rs
@@ -6,9 +6,6 @@ use super::{
 };
 use crate::handles::Handles;
 
-/// The timeout for the qos core when making requests to an enclave app.
-pub const ENCLAVE_APP_SOCKET_CLIENT_TIMEOUT_SECS: i64 = 5;
-
 /// Enclave phase
 #[derive(
 	Debug,

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -59,7 +59,7 @@ async fn run_server(
 
 		if let Ok(envelope) = handles.get_manifest_envelope() {
 			let pool_size =
-				envelope.manifest.pivot.pool_size.unwrap_or(DEFAULT_POOL_SIZE);
+				envelope.manifest.pool_size.unwrap_or(DEFAULT_POOL_SIZE);
 			// expand server to pool_size
 			server
 				.listen_to(pool_size, &processor)
@@ -146,17 +146,17 @@ impl Reaper {
 
 		println!("Reaper::execute about to spawn pivot");
 
-		let PivotConfig { args, restart, pool_size, .. } = handles
+		let manifest = handles
 			.get_manifest_envelope()
 			.expect("Checked above that the manifest exists.")
-			.manifest
-			.pivot;
+			.manifest;
+		let PivotConfig { args, restart, .. } = manifest.pivot;
 
 		let mut pivot = Command::new(handles.pivot_path());
 		// set the pool-size env var for pivots that use it
 		pivot.env(
 			"POOL_SIZE",
-			pool_size.unwrap_or(DEFAULT_POOL_SIZE).to_string(),
+			manifest.pool_size.unwrap_or(DEFAULT_POOL_SIZE).to_string(),
 		);
 		pivot.args(&args[..]);
 		match restart {

--- a/src/qos_core/src/server.rs
+++ b/src/qos_core/src/server.rs
@@ -85,7 +85,7 @@ impl SocketServer {
 	/// Expand the server with listeners up to pool size. This adds new tasks as needed.
 	pub fn listen_to<P>(
 		&mut self,
-		pool_size: u32,
+		pool_size: u8,
 		processor: &SharedProcessor<P>,
 	) -> Result<(), IOError>
 	where

--- a/src/qos_host/src/cli.rs
+++ b/src/qos_host/src/cli.rs
@@ -4,11 +4,12 @@ use std::{
 	env,
 	net::{IpAddr, Ipv4Addr, SocketAddr},
 	str::FromStr,
+	time::Duration,
 };
 
 use qos_core::{
 	cli::{CID, PORT, USOCK},
-	io::{SocketAddress, StreamPool, TimeVal, TimeValLike},
+	io::{SocketAddress, StreamPool},
 	parser::{GetParserForOptions, OptionsParser, Parser, Token},
 };
 
@@ -110,11 +111,11 @@ impl HostOpts {
 		SocketAddr::new(IpAddr::V4(ip), port)
 	}
 
-	pub(crate) fn socket_timeout(&self) -> TimeVal {
+	pub(crate) fn socket_timeout(&self) -> Duration {
 		let default_timeout = &qos_core::DEFAULT_SOCKET_TIMEOUT_MS.to_owned();
 		let timeout_str =
 			self.parsed.single(SOCKET_TIMEOUT).unwrap_or(default_timeout);
-		TimeVal::milliseconds(
+		Duration::from_millis(
 			timeout_str.parse().expect("invalid timeout value"),
 		)
 	}

--- a/src/qos_host/src/host.rs
+++ b/src/qos_host/src/host.rs
@@ -17,7 +17,7 @@
 #![warn(missing_docs, clippy::pedantic)]
 #![allow(clippy::missing_errors_doc)]
 
-use std::{net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use axum::{
 	body::Bytes,
@@ -30,7 +30,7 @@ use axum::{
 use borsh::BorshDeserialize;
 use qos_core::{
 	client::SocketClient,
-	io::{SharedStreamPool, TimeVal},
+	io::SharedStreamPool,
 	protocol::{msg::ProtocolMsg, ProtocolError, ProtocolPhase},
 };
 
@@ -49,7 +49,7 @@ struct QosHostState {
 #[allow(clippy::module_name_repetitions)]
 pub struct HostServer {
 	enclave_pool: SharedStreamPool,
-	timeout: TimeVal,
+	timeout: Duration,
 	addr: SocketAddr,
 	base_path: Option<String>,
 }
@@ -60,7 +60,7 @@ impl HostServer {
 	#[must_use]
 	pub fn new(
 		enclave_pool: SharedStreamPool,
-		timeout: TimeVal,
+		timeout: Duration,
 		addr: SocketAddr,
 		base_path: Option<String>,
 	) -> Self {

--- a/src/qos_net/src/cli.rs
+++ b/src/qos_net/src/cli.rs
@@ -37,7 +37,7 @@ impl ProxyOpts {
 	pub(crate) fn async_pool(
 		&self,
 	) -> Result<StreamPool, qos_core::io::IOError> {
-		let pool_size: u32 = self
+		let pool_size: u8 = self
 			.parsed
 			.single(POOL_SIZE)
 			.expect("invalid pool options")


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)
Expands the `Manifest` format and it's handling `qos-client` with `pool-size` and `client-timeout` parameters.

`pool-size` allows us to specify the number of internal USOCK/VSOCK connections for concurrency without impedeing app params list. It gets translated to an env var for the app.

`client-timeout` can now be used to specify the timeout for `call`s done by `SocketClient` inside the enclave.

There's also a minor refactor moving away from `TimeVal` to `Duration` in around `SocketClient` timeout type and params.

NOTE: hosts and proxy still need the timeout value handled explicitly of course, but that's out of scope for this PR.

WARNING: Please do NOT merge yet, as I want to test with a deploy in preprod first. Reviews are welcome.

## How I Tested These Changes
Locally so far
