### PR TITLE
BREAKING: Migrate hash and wire schemas to json

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Continued reading for attesting with nitro enclaves:
 
 ## Enclave Data Flow
 
-Nitro enclaves have a single socket for communicating to their parent EC2 instance. When QuorumOS initially starts up, it starts listening on a [socket server](./src/qos_core/src/server.rs) for [`ProtocolMsg`s](./src/qos_core/src/protocol/msg.rs) (the routing logic for the enclave server is [here](./src/qos_core/src/protocol/mod.rs)) that are sent over a single VSOCK connection with the EC2 instance. The enclave server only supports simple request/response communication with a client on the EC2 instance end of the VSOCK connection.
+Nitro enclaves have a single socket for communicating to their parent EC2 instance. When QuorumOS initially starts up, it starts listening on a [socket server](./src/qos_core/src/server.rs) for [`ProtocolMsg`s](./src/qos_core/src/protocol/msg.rs) (the routing logic for the enclave server is [here](./src/qos_core/src/protocol/mod.rs)) that are sent over a single VSOCK connection with the EC2 instance. Messages are serialized using canonical JSON for deterministic hashing and cross-language compatibility. See the [Canonical JSON Specification](./src/qos_json/SPEC.md) for details. The enclave server only supports simple request/response communication with a client on the EC2 instance end of the VSOCK connection.
 
 For communicating just with the QuorumOS enclave server, we have [`qos_host`](./src/qos_host/src/lib.rs), a simple HTTP service that allows for `GET`ing health checks and `POST`ing `ProtocolMsg`s.
 

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2025,6 +2025,7 @@ dependencies = [
  "nix 0.29.0",
  "qos_crypto",
  "qos_hex",
+ "qos_json",
  "qos_nsm",
  "qos_p256",
  "qos_test_primitives",
@@ -2079,6 +2080,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "qos_json"
+version = "0.1.0"
+dependencies = [
+ "qos_hex",
+ "serde",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
 name = "qos_net"
 version = "0.1.0"
 dependencies = [
@@ -2113,10 +2124,10 @@ version = "0.1.0"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "aws-nitro-enclaves-nsm-api",
- "borsh",
  "hex-literal",
  "p384",
  "qos_hex",
+ "serde",
  "serde_bytes",
  "sha2",
  "webpki",
@@ -2143,6 +2154,7 @@ dependencies = [
  "p256",
  "qos_hex",
  "qos_test_primitives",
+ "serde",
  "sha2",
  "zeroize",
 ]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "qos_crypto",
   "qos_host",
   "qos_hex",
+  "qos_json",
   "qos_net",
   "qos_test_primitives",
   "qos_p256",
@@ -23,6 +24,7 @@ default-members = [
   "qos_crypto",
   "qos_host",
   "qos_hex",
+  "qos_json",
   "qos_net",
   "qos_test_primitives",
   "qos_p256",
@@ -102,6 +104,7 @@ qos_core = { path = "qos_core", default-features = false }
 qos_crypto = { path = "qos_crypto", default-features = false }
 qos_hex = { path = "qos_hex", default-features = false }
 qos_host = { path = "qos_host", default-features = false }
+qos_json = { path = "qos_json" }
 qos_net = { path = "qos_net", default-features = false }
 qos_nsm = { path = "qos_nsm", default-features = false }
 qos_p256 = { path = "qos_p256" }

--- a/src/qos_client/src/cli/services.rs
+++ b/src/qos_client/src/cli/services.rs
@@ -1076,7 +1076,7 @@ pub(crate) fn export_key<P: AsRef<Path>>(
 
 	write_with_msg(
 		encrypted_quorum_key_path.as_ref(),
-		&serde_json::to_vec(&encrypted_quorum_key).expect("valid borsh. qed."),
+		&serde_json::to_vec(&encrypted_quorum_key).expect("valid json. qed."),
 		"Encrypted Quorum Key",
 	);
 

--- a/src/qos_core/Cargo.toml
+++ b/src/qos_core/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 [dependencies]
 qos_crypto = { workspace = true }
 qos_hex = { workspace = true, features = ["serde"] }
+qos_json = { workspace = true }
 qos_p256 = { workspace = true }
 qos_nsm = { workspace = true, default-features = false }
 

--- a/src/qos_core/src/client.rs
+++ b/src/qos_core/src/client.rs
@@ -10,8 +10,8 @@ use crate::io::{IOError, SharedStreamPool, SocketAddress, StreamPool};
 pub enum ClientError {
 	/// [`io::IOError`] wrapper.
 	IOError(IOError),
-	/// `borsh::io::Error` wrapper.
-	BorshError(borsh::io::Error),
+	/// Deserialization error
+	DeserializationError(String),
 	/// Invalid enclave response to a request (e.g. mismatch)
 	ResponseMismatch,
 }
@@ -22,9 +22,9 @@ impl From<IOError> for ClientError {
 	}
 }
 
-impl From<borsh::io::Error> for ClientError {
-	fn from(err: borsh::io::Error) -> Self {
-		Self::BorshError(err)
+impl From<serde_json::Error> for ClientError {
+	fn from(err: serde_json::Error) -> Self {
+		Self::DeserializationError(err.to_string())
 	}
 }
 /// Client for communicating with the enclave `crate::server::SocketServer`.

--- a/src/qos_core/src/protocol/error.rs
+++ b/src/qos_core/src/protocol/error.rs
@@ -9,7 +9,17 @@ use crate::{
 };
 
 /// A error from protocol execution.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+#[derive(
+	Debug,
+	Clone,
+	PartialEq,
+	Eq,
+	BorshSerialize,
+	BorshDeserialize,
+	serde::Serialize,
+	serde::Deserialize,
+)]
+#[serde(rename_all = "camelCase")]
 pub enum ProtocolError {
 	/// A encrypted quorum key share sent to the enclave was invalid.
 	InvalidShare,

--- a/src/qos_core/src/protocol/mod.rs
+++ b/src/qos_core/src/protocol/mod.rs
@@ -2,8 +2,8 @@
 
 use std::{sync::Arc, time::Duration};
 
-use borsh::BorshSerialize;
 use qos_crypto::sha_256;
+use serde::Serialize;
 
 mod error;
 pub mod msg;
@@ -26,16 +26,22 @@ pub const INITIAL_CLIENT_TIMEOUT: Duration = Duration::from_secs(5);
 /// 256bit hash
 pub type Hash256 = [u8; 32];
 
-/// Canonical hash of `QuorumOS` types.
-pub trait QosHash: BorshSerialize {
-	/// Get the canonical hash.
-	fn qos_hash(&self) -> Hash256 {
-		sha_256(&borsh::to_vec(self).expect("Implements borsh serialize"))
+/// Canonical hash of `QuorumOS` types using JSON serialization.
+///
+/// This trait provides deterministic hashing via canonical JSON format.
+/// See `qos_json::SPEC.md` for the canonical JSON specification.
+pub trait QosHash: Serialize {
+	/// Get the canonical hash using JSON serialization.
+	fn qos_hash(&self) -> Hash256
+	where
+		Self: Sized,
+	{
+		sha_256(&qos_json::to_vec(self).expect("Implements serde serialize"))
 	}
 }
 
-// Blanket implement QosHash for any type that implements BorshSerialize.
-impl<T: BorshSerialize> QosHash for T {}
+// Blanket implement QosHash for any type that implements Serialize.
+impl<T: Serialize> QosHash for T {}
 
 /// Helper type to keep `ProtocolState` shared using `Arc<Mutex<ProtocolState>>`
 type SharedProtocolState = Arc<RwLock<ProtocolState>>;
@@ -44,5 +50,54 @@ impl ProtocolState {
 	/// Wrap this `ProtocolState` into a `Mutex` in an `Arc`.
 	pub fn shared(self) -> SharedProtocolState {
 		Arc::new(RwLock::new(self))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn qos_hash_produces_expected_sha256() {
+		#[derive(serde::Serialize)]
+		struct Example {
+			name: &'static str,
+			threshold: &'static str,
+			version: &'static str,
+		}
+
+		let example = Example { name: "test", threshold: "3", version: "1" };
+
+		// Get the canonical JSON
+		let canonical_json = qos_json::to_string(&example).expect("serializes");
+		assert_eq!(
+			canonical_json,
+			r#"{"name":"test","threshold":"3","version":"1"}"#
+		);
+
+		let hash = example.qos_hash();
+		let expected_hex =
+			"898eaf2263b3ca34a9fb0b59615a16e5819b43c53fabc44396f92128f72ccc7e";
+		let actual_hex = qos_hex::encode(&hash);
+		assert_eq!(actual_hex, expected_hex);
+	}
+
+	#[test]
+	fn qos_hash_deterministic() {
+		#[derive(serde::Serialize)]
+		struct Data {
+			z: u32,
+			a: u32,
+		}
+
+		let data = Data { z: 2, a: 1 };
+
+		let hash1 = data.qos_hash();
+		let hash2 = data.qos_hash();
+		assert_eq!(hash1, hash2);
+
+		// Sorts keys alphabetically
+		let canonical = qos_json::to_string(&data).unwrap();
+		assert_eq!(canonical, r#"{"a":1,"z":2}"#);
 	}
 }

--- a/src/qos_core/src/protocol/processor.rs
+++ b/src/qos_core/src/protocol/processor.rs
@@ -2,7 +2,6 @@
 
 use std::sync::Arc;
 
-use borsh::BorshDeserialize;
 use tokio::sync::RwLock;
 
 use super::{
@@ -27,14 +26,15 @@ impl ProtocolProcessor {
 impl RequestProcessor for ProtocolProcessor {
 	async fn process(&self, req_bytes: &[u8]) -> Vec<u8> {
 		if req_bytes.len() > MAX_ENCODED_MSG_LEN {
-			return borsh::to_vec(&ProtocolMsg::ProtocolErrorResponse(
+			return serde_json::to_vec(&ProtocolMsg::ProtocolErrorResponse(
 				ProtocolError::OversizedPayload,
 			))
 			.expect("ProtocolMsg can always be serialized. qed.");
 		}
 
-		let Ok(msg_req) = ProtocolMsg::try_from_slice(req_bytes) else {
-			return borsh::to_vec(&ProtocolMsg::ProtocolErrorResponse(
+		let Ok(msg_req) = serde_json::from_slice::<ProtocolMsg>(req_bytes)
+		else {
+			return serde_json::to_vec(&ProtocolMsg::ProtocolErrorResponse(
 				ProtocolError::ProtocolMsgDeserialization,
 			))
 			.expect("ProtocolMsg can always be serialized. qed.");

--- a/src/qos_core/src/protocol/services/genesis.rs
+++ b/src/qos_core/src/protocol/services/genesis.rs
@@ -15,8 +15,16 @@ const QOS_TEST_MESSAGE: &[u8] = b"qos-test-message";
 
 /// Configuration for sharding a Quorum Key created in the Genesis flow.
 #[derive(
-	PartialEq, Debug, Eq, Clone, borsh::BorshSerialize, borsh::BorshDeserialize,
+	PartialEq,
+	Debug,
+	Eq,
+	Clone,
+	borsh::BorshSerialize,
+	borsh::BorshDeserialize,
+	serde::Serialize,
+	serde::Deserialize,
 )]
+#[serde(rename_all = "camelCase")]
 pub struct GenesisSet {
 	/// Share Set Member's who's production key will be used to encrypt Genesis
 	/// flow outputs.
@@ -33,11 +41,13 @@ pub struct GenesisSet {
 	Serialize,
 	Deserialize,
 )]
+#[serde(rename_all = "camelCase")]
 struct MemberShard {
 	/// Member of the Setup Set.
 	member: QuorumMember,
 	/// Shard of the generated Quorum Key, encrypted to the `member`s Setup
 	/// Key.
+	#[serde(with = "qos_hex::serde")]
 	shard: Vec<u8>,
 }
 
@@ -61,6 +71,7 @@ impl fmt::Debug for MemberShard {
 	Serialize,
 	Deserialize,
 )]
+#[serde(rename_all = "camelCase")]
 pub struct RecoveredPermutation(Vec<MemberShard>);
 
 /// Genesis output per Setup Member.
@@ -109,8 +120,10 @@ impl fmt::Debug for GenesisMemberOutput {
 	Serialize,
 	Deserialize,
 )]
+#[serde(rename_all = "camelCase")]
 pub struct GenesisOutput {
 	/// Public Quorum Key, DER encoded.
+	#[serde(with = "qos_hex::serde")]
 	pub quorum_key: Vec<u8>,
 	/// Quorum Member specific outputs from the genesis ceremony.
 	pub member_outputs: Vec<GenesisMemberOutput>,
@@ -120,16 +133,24 @@ pub struct GenesisOutput {
 	/// The threshold, K, used to generate the shards.
 	pub threshold: u32,
 	/// The quorum key encrypted to the DR key. None if no DR Key was provided
+	#[serde(
+		default,
+		skip_serializing_if = "Option::is_none",
+		with = "qos_hex::serde_opt"
+	)]
 	pub dr_key_wrapped_quorum_key: Option<Vec<u8>>,
 	/// Hash of the quorum key secret
 	#[serde(with = "qos_hex::serde")]
 	pub quorum_key_hash: [u8; 64],
 	/// Test message encrypted to the quorum public key.
+	#[serde(with = "qos_hex::serde")]
 	pub test_message_ciphertext: Vec<u8>,
 	/// Signature over the test message by the quorum key.
+	#[serde(with = "qos_hex::serde")]
 	pub test_message_signature: Vec<u8>,
 	/// The message that was used to generate [`Self::test_message_signature`]
 	/// and [`Self::test_message_ciphertext`]
+	#[serde(with = "qos_hex::serde")]
 	pub test_message: Vec<u8>,
 }
 

--- a/src/qos_core/src/protocol/services/key.rs
+++ b/src/qos_core/src/protocol/services/key.rs
@@ -1,7 +1,6 @@
 //! The services involved in the key forwarding flow.
 
 use aws_nitro_enclaves_nsm_api::api::AttestationDoc;
-use borsh::{BorshDeserialize, BorshSerialize};
 use qos_nsm::{
 	nitro::{attestation_doc_from_der, cert_from_pem, AWS_ROOT_CERT_PEM},
 	types::NsmResponse,
@@ -16,7 +15,7 @@ use crate::protocol::{
 
 /// An encrypted quorum key along with a signature over the encrypted payload
 /// from the sender.
-#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct EncryptedQuorumKey {
 	/// The encrypted payload: a quorum key
 	pub encrypted_quorum_key: Vec<u8>,

--- a/src/qos_core/src/protocol/state.rs
+++ b/src/qos_core/src/protocol/state.rs
@@ -197,7 +197,7 @@ impl ProtocolState {
 				None => continue,
 				Some(result) => match result {
 					Ok(msg_resp) | Err(msg_resp) => {
-						return borsh::to_vec(&msg_resp).expect(
+						return serde_json::to_vec(&msg_resp).expect(
 							"ProtocolMsg can always be serialized. qed.",
 						)
 					}
@@ -206,7 +206,7 @@ impl ProtocolState {
 		}
 
 		let err = ProtocolError::NoMatchingRoute(self.phase);
-		borsh::to_vec(&ProtocolMsg::ProtocolErrorResponse(err))
+		serde_json::to_vec(&ProtocolMsg::ProtocolErrorResponse(err))
 			.expect("ProtocolMsg can always be serialized. qed.")
 	}
 

--- a/src/qos_hex/src/lib.rs
+++ b/src/qos_hex/src/lib.rs
@@ -288,6 +288,46 @@ pub mod serde {
 	}
 }
 
+/// Serde helpers for optional hex-encoded bytes.
+///
+/// Use with `#[serde(with = "qos_hex::serde_opt")]` for `Option<Vec<u8>>`.
+#[cfg(feature = "serde")]
+pub mod serde_opt {
+	use serde::{Deserialize, Deserializer, Serializer};
+
+	use super::{decode, encode};
+
+	pub fn serialize<S>(
+		value: &Option<Vec<u8>>,
+		serializer: S,
+	) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		match value {
+			Some(bytes) => serializer.serialize_some(&encode(bytes)),
+			None => serializer.serialize_none(),
+		}
+	}
+
+	pub fn deserialize<'de, D>(
+		deserializer: D,
+	) -> Result<Option<Vec<u8>>, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		let opt: Option<String> = Option::deserialize(deserializer)?;
+		match opt {
+			Some(s) => {
+				let bytes = decode(&s)
+					.map_err(|e| serde::de::Error::custom(format!("{e:?}")))?;
+				Ok(Some(bytes))
+			}
+			None => Ok(None),
+		}
+	}
+}
+
 #[cfg(test)]
 mod test {
 	use super::*;

--- a/src/qos_json/Cargo.toml
+++ b/src/qos_json/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "qos_json"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+qos_hex = { workspace = true, features = ["serde"] }
+sha2 = { workspace = true }

--- a/src/qos_json/SPEC.md
+++ b/src/qos_json/SPEC.md
@@ -1,0 +1,141 @@
+# QOS Canonical JSON Specification
+
+## Overview
+
+This document defines the canonical JSON format used for serializing QOS types for signing and wire protocol communication. The format ensures deterministic serialization across languages.
+
+## Rules
+
+| Aspect | Rule | Note |
+|--------|------|------|
+| **Key order** | Alphabetically sorted (lexicographic) | deterministic |ordering of keys
+| **Key naming** | camelCase |
+| **Whitespace** | None (compact) |
+| **Enums** | Externally tagged, camelCase |
+| **Numbers** | Base-10 strings (e.g., `"3"` not `3`) | max int safety for javascript |
+| **Binary data** | Lowercase hex-encoded strings |
+| **Optional/None** | Omit field entirely | ensures older versions without field serialize the same way |
+| **Unicode** | UTF-8, minimal escaping |
+| **Depth limit** | Maximum 8 levels of nesting | minimize computational complexity |
+
+## Test Vectors
+
+### Simple Object with Numbers
+
+**Input (conceptual):**
+```
+threshold: 3
+version: 1
+name: "test"
+```
+
+**Canonical JSON:**
+```json
+{"name":"test","threshold":"3","version":"1"}
+```
+
+**SHA-256 Hash:**
+```
+898eaf2263b3ca34a9fb0b59615a16e5819b43c53fabc44396f92128f72ccc7e
+```
+
+### Nested Object
+
+**Input (conceptual):**
+```
+manifest: {
+  namespace: "prod"
+  version: 2
+}
+threshold: 3
+```
+
+**Canonical JSON:**
+```json
+{"manifest":{"namespace":"prod","version":"2"},"threshold":"3"}
+```
+
+### Binary Data (Hex Encoding)
+
+**Input (conceptual):**
+```
+data: [0xde, 0xad, 0xbe, 0xef]
+```
+
+**Canonical JSON:**
+```json
+{"data":"deadbeef"}
+```
+
+### Externally Tagged Enum (Unit Variant)
+
+**Rust:**
+```rust
+enum RestartPolicy { Never, Always }
+let policy = RestartPolicy::Never;
+```
+
+**Canonical JSON:**
+```json
+"never"
+```
+
+### Externally Tagged Enum (Tuple Variant)
+
+**Rust:**
+```rust
+enum BridgeConfig {
+    Server(u16, String),
+}
+let config = BridgeConfig::Server(3000, "0.0.0.0".to_string());
+```
+
+**Canonical JSON:**
+```json
+{"server":["3000","0.0.0.0"]}
+```
+
+### Externally Tagged Enum (Struct Variant)
+
+**Rust:**
+```rust
+enum Message {
+    Request { id: u32, data: Vec<u8> }
+}
+let msg = Message::Request { id: 42, data: vec![0xab, 0xcd] };
+```
+
+**Canonical JSON:**
+```json
+{"request":{"data":"abcd","id":"42"}}
+```
+
+### Optional Field (None)
+
+**Rust:**
+```rust
+struct Config {
+    name: String,
+    debug: Option<bool>,
+}
+let config = Config { name: "test".to_string(), debug: None };
+```
+
+**Canonical JSON:**
+```json
+{"name":"test"}
+```
+
+Note: The `debug` field is omitted entirely when `None`.
+
+### Optional Field (Some)
+
+**Rust:**
+```rust
+let config = Config { name: "test".to_string(), debug: Some(true) };
+```
+
+**Canonical JSON:**
+```json
+{"debug":true,"name":"test"}
+```

--- a/src/qos_json/src/lib.rs
+++ b/src/qos_json/src/lib.rs
@@ -1,0 +1,450 @@
+//! Canonical JSON serialization for QOS types.
+//!
+//! # Key features
+//!
+//! - Alphabetically sorted object keys (at runtime, via [`sort_keys`])
+//! - Numbers serialized as base-10 strings (via [`string_number`] module)
+//! - Optional fields omitted when None
+//! - Compact output (no whitespace)
+//!
+//! # Instrumenting types for canonical JSON
+//!
+//! ```rust,ignore
+//! use serde::{Serialize, Deserialize};
+//!
+//! #[derive(Serialize, Deserialize)]
+//! #[serde(rename_all = "camelCase")]  // Use camelCase for JSON keys
+//! struct MyType {
+//!     // Binary data as lowercase hex
+//!     #[serde(with = "qos_hex::serde")]
+//!     data: Vec<u8>,
+//!
+//!     // Numbers as base-10 strings for cross-language consistency
+//!     #[serde(with = "qos_json::string_number")]
+//!     threshold: u32,
+//!
+//!     // Optional fields omitted when None
+//!     #[serde(default, skip_serializing_if = "Option::is_none")]
+//!     optional_field: Option<String>,
+//! }
+//! ```
+//!
+//! Then serialize using [`to_vec`] or [`to_string`] which sort keys alphabetically.
+
+use serde::Serialize;
+use serde_json::Value;
+
+/// Maximum recursion depth to prevent stack overflow attacks.
+pub const MAX_DEPTH: usize = 8;
+
+/// Error type for canonical JSON operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Error {
+	/// Serialization error from serde_json.
+	Serialization(String),
+	/// Maximum recursion depth exceeded.
+	MaxDepthExceeded,
+}
+
+impl std::fmt::Display for Error {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Error::Serialization(msg) => {
+				write!(f, "serialization error: {msg}")
+			}
+			Error::MaxDepthExceeded => write!(f, "max depth exceeded"),
+		}
+	}
+}
+
+impl std::error::Error for Error {}
+
+impl From<serde_json::Error> for Error {
+	fn from(e: serde_json::Error) -> Self {
+		Error::Serialization(e.to_string())
+	}
+}
+
+/// Serialize to canonical JSON bytes with alphabetically sorted keys.
+pub fn to_vec<T: Serialize>(value: &T) -> Result<Vec<u8>, Error> {
+	let v = serde_json::to_value(value)?;
+	let sorted = sort_keys(&v, 0)?;
+	Ok(serde_json::to_vec(&sorted)?)
+}
+
+/// Serialize to canonical JSON string with alphabetically sorted keys.
+pub fn to_string<T: Serialize>(value: &T) -> Result<String, Error> {
+	let v = serde_json::to_value(value)?;
+	let sorted = sort_keys(&v, 0)?;
+	Ok(serde_json::to_string(&sorted)?)
+}
+
+/// Sort object keys alphabetically, recursively.
+fn sort_keys(value: &Value, depth: usize) -> Result<Value, Error> {
+	if depth > MAX_DEPTH {
+		return Err(Error::MaxDepthExceeded);
+	}
+
+	match value {
+		Value::Object(map) => {
+			let mut sorted: serde_json::Map<String, Value> =
+				serde_json::Map::new();
+			let mut keys: Vec<&String> = map.keys().collect();
+			keys.sort();
+			for key in keys {
+				let sorted_value = sort_keys(&map[key], depth + 1)?;
+				sorted.insert(key.clone(), sorted_value);
+			}
+			Ok(Value::Object(sorted))
+		}
+		Value::Array(arr) => {
+			// Note we don't actually sort the array, but we still want to recursively
+			// sort any nested maps.
+			let sorted: Result<Vec<Value>, _> =
+				arr.iter().map(|v| sort_keys(v, depth + 1)).collect();
+			Ok(Value::Array(sorted?))
+		}
+		_ => Ok(value.clone()),
+	}
+}
+
+/// Serde serialization helpers for numbers as strings.
+///
+/// Use this module with `#[serde(with = "qos_json::string_number")]` to
+/// serialize numeric types as base-10 strings.
+pub mod string_number {
+	use serde::{Deserialize, Deserializer, Serializer};
+	use std::fmt::Display;
+	use std::str::FromStr;
+
+	/// Serialize a number as a base-10 string.
+	pub fn serialize<S, T>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+		T: Display,
+	{
+		serializer.serialize_str(&value.to_string())
+	}
+
+	/// Deserialize a base-10 string as a number.
+	pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+	where
+		D: Deserializer<'de>,
+		T: FromStr,
+		T::Err: std::fmt::Display,
+	{
+		let s = String::deserialize(deserializer)?;
+		s.parse().map_err(serde::de::Error::custom)
+	}
+}
+
+/// Serde serialization helpers for optional numbers as strings.
+///
+/// Use this module with `#[serde(with = "qos_json::string_number_opt")]` to
+/// serialize optional numeric types as base-10 strings.
+pub mod string_number_opt {
+	use serde::{Deserialize, Deserializer, Serializer};
+	use std::fmt::Display;
+	use std::str::FromStr;
+
+	/// Serialize an optional number as a base-10 string.
+	pub fn serialize<S, T>(
+		value: &Option<T>,
+		serializer: S,
+	) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+		T: Display,
+	{
+		match value {
+			Some(v) => serializer.serialize_some(&v.to_string()),
+			None => serializer.serialize_none(),
+		}
+	}
+
+	/// Deserialize a base-10 string as an optional number.
+	pub fn deserialize<'de, D, T>(
+		deserializer: D,
+	) -> Result<Option<T>, D::Error>
+	where
+		D: Deserializer<'de>,
+		T: FromStr,
+		T::Err: std::fmt::Display,
+	{
+		let opt: Option<String> = Option::deserialize(deserializer)?;
+		match opt {
+			Some(s) => {
+				let v = s.parse().map_err(serde::de::Error::custom)?;
+				Ok(Some(v))
+			}
+			None => Ok(None),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use serde::{Deserialize, Serialize};
+
+	#[test]
+	fn sort_keys_simple() {
+		#[derive(Serialize)]
+		struct Example {
+			zebra: u32,
+			alpha: String,
+			beta: bool,
+		}
+
+		let example =
+			Example { zebra: 1, alpha: "test".to_string(), beta: true };
+		let json = to_string(&example).unwrap();
+		assert_eq!(json, r#"{"alpha":"test","beta":true,"zebra":1}"#);
+	}
+
+	#[test]
+	fn sort_keys_nested() {
+		#[derive(Serialize)]
+		struct Inner {
+			z: u32,
+			a: u32,
+		}
+
+		#[derive(Serialize)]
+		struct Outer {
+			inner: Inner,
+			name: String,
+		}
+
+		let example =
+			Outer { inner: Inner { z: 2, a: 1 }, name: "test".into() };
+		let json = to_string(&example).unwrap();
+		assert_eq!(json, r#"{"inner":{"a":1,"z":2},"name":"test"}"#);
+	}
+
+	#[test]
+	fn string_number_serialize_deserialize() {
+		#[derive(Serialize, Deserialize, PartialEq, Debug)]
+		struct Example {
+			#[serde(with = "string_number")]
+			count: u32,
+		}
+
+		let example = Example { count: 42 };
+		let json = serde_json::to_string(&example).unwrap();
+		assert_eq!(json, r#"{"count":"42"}"#);
+
+		let decoded: Example = serde_json::from_str(&json).unwrap();
+		assert_eq!(decoded, example);
+	}
+
+	#[test]
+	fn string_number_opt_serialize_deserialize() {
+		#[derive(Serialize, Deserialize, PartialEq, Debug)]
+		struct Example {
+			#[serde(
+				default,
+				skip_serializing_if = "Option::is_none",
+				with = "string_number_opt"
+			)]
+			count: Option<u32>,
+		}
+
+		// Some value
+		let example = Example { count: Some(42) };
+		let json = serde_json::to_string(&example).unwrap();
+		assert_eq!(json, r#"{"count":"42"}"#);
+
+		let decoded: Example = serde_json::from_str(&json).unwrap();
+		assert_eq!(decoded, example);
+
+		// None value
+		let example = Example { count: None };
+		let json = serde_json::to_string(&example).unwrap();
+		assert_eq!(json, r#"{}"#);
+	}
+
+	#[test]
+	fn max_depth_exceeded() {
+		// Create a deeply nested structure
+		let mut value = serde_json::json!({"a": 1});
+		for _ in 0..100 {
+			value = serde_json::json!({"nested": value});
+		}
+
+		let result = sort_keys(&value, 0);
+		assert!(matches!(result, Err(Error::MaxDepthExceeded)));
+	}
+
+	#[test]
+	fn canonical_json_determinism() {
+		// Ensure the same data always produces the same output
+		#[derive(Serialize)]
+		struct Example {
+			c: u32,
+			a: u32,
+			b: u32,
+		}
+
+		let example = Example { c: 3, a: 1, b: 2 };
+		let json1 = to_vec(&example).unwrap();
+		let json2 = to_vec(&example).unwrap();
+		assert_eq!(json1, json2);
+		assert_eq!(json1, br#"{"a":1,"b":2,"c":3}"#);
+	}
+
+	#[test]
+	fn array_of_objects_sorts_keys() {
+		use std::collections::HashMap;
+
+		let mut map1 = HashMap::new();
+		map1.insert("zebra".to_string(), "z".to_string());
+		map1.insert("alpha".to_string(), "a".to_string());
+
+		let mut map2 = HashMap::new();
+		map2.insert("gamma".to_string(), "g".to_string());
+		map2.insert("beta".to_string(), "b".to_string());
+
+		let items: Vec<HashMap<String, String>> = vec![map1, map2];
+		let json = to_string(&items).unwrap();
+
+		// Each object in the array should have sorted keys
+		assert_eq!(
+			json,
+			r#"[{"alpha":"a","zebra":"z"},{"beta":"b","gamma":"g"}]"#
+		);
+	}
+
+	// SPEC.md test vector: Simple Object
+	#[test]
+	fn spec_vector_simple_object() {
+		#[derive(Serialize)]
+		struct Example {
+			threshold: &'static str,
+			version: &'static str,
+			name: &'static str,
+		}
+
+		let example = Example { threshold: "3", version: "1", name: "test" };
+		let json = to_string(&example).unwrap();
+		// Keys should be sorted alphabetically
+		assert_eq!(json, r#"{"name":"test","threshold":"3","version":"1"}"#);
+	}
+
+	// SPEC.md test vector: Nested Object
+	#[test]
+	fn spec_vector_nested_object() {
+		#[derive(Serialize)]
+		struct Manifest {
+			namespace: &'static str,
+			version: &'static str,
+		}
+
+		#[derive(Serialize)]
+		struct Example {
+			manifest: Manifest,
+			threshold: &'static str,
+		}
+
+		let example = Example {
+			manifest: Manifest { namespace: "prod", version: "2" },
+			threshold: "3",
+		};
+		let json = to_string(&example).unwrap();
+		assert_eq!(
+			json,
+			r#"{"manifest":{"namespace":"prod","version":"2"},"threshold":"3"}"#
+		);
+	}
+
+	// SPEC.md test vector: Binary Data (Hex Encoding)
+	#[test]
+	fn spec_vector_binary_data_hex() {
+		#[derive(Serialize)]
+		struct Example {
+			#[serde(with = "qos_hex::serde")]
+			data: Vec<u8>,
+		}
+
+		let example = Example { data: vec![0xde, 0xad, 0xbe, 0xef] };
+		let json = to_string(&example).unwrap();
+		assert_eq!(json, r#"{"data":"deadbeef"}"#);
+	}
+
+	// SPEC.md test vector: Externally Tagged Enum (Unit Variant)
+	#[test]
+	fn spec_vector_enum_unit_variant() {
+		#[derive(Serialize)]
+		#[serde(rename_all = "camelCase")]
+		enum RestartPolicy {
+			Never,
+		}
+
+		let policy = RestartPolicy::Never;
+		let json = serde_json::to_string(&policy).unwrap();
+		assert_eq!(json, r#""never""#);
+	}
+
+	// SPEC.md test vector: Externally Tagged Enum (Tuple Variant)
+	#[test]
+	fn spec_vector_enum_tuple_variant() {
+		#[derive(Serialize)]
+		#[serde(rename_all = "camelCase")]
+		enum BridgeConfig {
+			Server(String, String),
+		}
+
+		let config =
+			BridgeConfig::Server("3000".to_string(), "0.0.0.0".to_string());
+		let json = to_string(&config).unwrap();
+		assert_eq!(json, r#"{"server":["3000","0.0.0.0"]}"#);
+	}
+
+	// SPEC.md test vector: Externally Tagged Enum (Struct Variant)
+	#[test]
+	fn spec_vector_enum_struct_variant() {
+		#[derive(Serialize)]
+		#[serde(rename_all = "camelCase")]
+		enum Message {
+			Request { data: String, id: String },
+		}
+
+		let msg =
+			Message::Request { id: "42".to_string(), data: "abcd".to_string() };
+		let json = to_string(&msg).unwrap();
+		// Fields should be sorted alphabetically within the struct variant
+		assert_eq!(json, r#"{"request":{"data":"abcd","id":"42"}}"#);
+	}
+
+	// SPEC.md test vector: Optional Field (None)
+	#[test]
+	fn spec_vector_optional_field_none() {
+		#[derive(Serialize)]
+		struct Config {
+			name: String,
+			#[serde(skip_serializing_if = "Option::is_none")]
+			debug: Option<bool>,
+		}
+
+		let config = Config { name: "test".to_string(), debug: None };
+		let json = to_string(&config).unwrap();
+		// debug field should be omitted entirely
+		assert_eq!(json, r#"{"name":"test"}"#);
+	}
+
+	// SPEC.md test vector: Optional Field (Some)
+	#[test]
+	fn spec_vector_optional_field_some() {
+		#[derive(Serialize)]
+		struct Config {
+			name: String,
+			#[serde(skip_serializing_if = "Option::is_none")]
+			debug: Option<bool>,
+		}
+
+		let config = Config { name: "test".to_string(), debug: Some(true) };
+		let json = to_string(&config).unwrap();
+		// Fields sorted alphabetically: debug comes before name
+		assert_eq!(json, r#"{"debug":true,"name":"test"}"#);
+	}
+}

--- a/src/qos_nsm/Cargo.toml
+++ b/src/qos_nsm/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 workspace = true
 
 [dependencies]
-qos_hex = { workspace = true }
-borsh = { workspace = true }
+qos_hex = { workspace = true, features = ["serde"] }
+serde = { workspace = true }
 aws-nitro-enclaves-nsm-api = { workspace = true, features = ["nix"] }
 aws-nitro-enclaves-cose = { workspace = true }
 sha2 = { workspace = true }

--- a/src/qos_nsm/src/mock.rs
+++ b/src/qos_nsm/src/mock.rs
@@ -43,32 +43,32 @@ impl NsmProvider for MockNsm {
 	fn nsm_process_request(&self, request: NsmRequest) -> NsmResponse {
 		match request {
 			NsmRequest::Attestation {
-				user_data: _,
 				nonce: _,
 				public_key: _,
+				user_data: _,
 			} => NsmResponse::Attestation {
 				document: MOCK_NSM_ATTESTATION_DOCUMENT.to_vec(),
 			},
-			NsmRequest::DescribeNSM => NsmResponse::DescribeNSM {
+			NsmRequest::DescribeNsm => NsmResponse::DescribeNsm {
+				digest: NsmDigest::Sha256,
+				locked_pcrs: BTreeSet::from([90, 91, 92]),
+				max_pcrs: 1024,
+				module_id: "mock_module_id".to_string(),
 				version_major: 1,
 				version_minor: 2,
 				version_patch: 14,
-				module_id: "mock_module_id".to_string(),
-				max_pcrs: 1024,
-				locked_pcrs: BTreeSet::from([90, 91, 92]),
-				digest: NsmDigest::SHA256,
 			},
-			NsmRequest::ExtendPCR { index: _, data: _ } => {
-				NsmResponse::ExtendPCR { data: vec![3, 4, 7, 4] }
+			NsmRequest::DescribePcr { index: _ } => {
+				NsmResponse::DescribePcr { data: vec![3, 4, 7, 4], lock: false }
+			}
+			NsmRequest::ExtendPcr { data: _, index: _ } => {
+				NsmResponse::ExtendPcr { data: vec![3, 4, 7, 4] }
 			}
 			NsmRequest::GetRandom => {
 				NsmResponse::GetRandom { random: vec![4, 2, 0, 69] }
 			}
-			NsmRequest::LockPCR { index: _ } => NsmResponse::LockPCR,
-			NsmRequest::LockPCRs { range: _ } => NsmResponse::LockPCRs,
-			NsmRequest::DescribePCR { index: _ } => {
-				NsmResponse::DescribePCR { lock: false, data: vec![3, 4, 7, 4] }
-			}
+			NsmRequest::LockPcr { index: _ } => NsmResponse::LockPcr,
+			NsmRequest::LockPcrs { range: _ } => NsmResponse::LockPcrs,
 		}
 	}
 

--- a/src/qos_p256/Cargo.toml
+++ b/src/qos_p256/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 qos_hex = { workspace = true }
 
 borsh = { workspace = true }
+serde = { workspace = true }
 
 sha2 = { workspace = true }
 # as of 0.13.0, the p256 crate "ecdsa" feature enables "sha384", some "ecdsa-core", and others

--- a/src/qos_p256/src/lib.rs
+++ b/src/qos_p256/src/lib.rs
@@ -31,8 +31,16 @@ pub mod sign;
 
 /// Errors for qos P256.
 #[derive(
-	Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize,
+	Debug,
+	Clone,
+	PartialEq,
+	Eq,
+	borsh::BorshSerialize,
+	borsh::BorshDeserialize,
+	serde::Serialize,
+	serde::Deserialize,
 )]
+#[serde(rename_all = "camelCase")]
 pub enum P256Error {
 	/// Hex encoding error.
 	QosHex(String),


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

- Add SPEC.md for canonical JSON scheme
- Add qos_json crate for canonical JSON serialization 
- Replace borsh with JSON for QosHash
- Migrate ProtocolMsg to be JSON encoded over the wire
- Add serde derives and hex encoding to types
- Rename some enum varients from SCREAMING_CASE to PascalCase to guarantee encoding consistency with serde camelCase derive