### PR TITLE
Prevent excessive RwLock wrapping

### DIFF
--- a/src/integration/src/bin/pivot_proof.rs
+++ b/src/integration/src/bin/pivot_proof.rs
@@ -1,5 +1,4 @@
 use core::panic;
-use std::sync::Arc;
 
 use borsh::BorshDeserialize;
 use integration::{AdditionProof, AdditionProofPayload, PivotProofMsg};
@@ -8,15 +7,15 @@ use qos_core::{
 	io::{SocketAddress, StreamPool},
 	server::{RequestProcessor, SocketServer},
 };
-use tokio::sync::RwLock;
 
+#[derive(Clone)]
 struct Processor {
-	ephemeral_key_handle: EphemeralKeyHandle,
+	ephemeral_key_handle: EphemeralKeyHandle<&'static str>,
 }
 
 impl Processor {
-	pub fn new(ephemeral_key_handle: EphemeralKeyHandle) -> Arc<RwLock<Self>> {
-		Arc::new(RwLock::new(Self { ephemeral_key_handle }))
+	pub fn new(ephemeral_key_handle: EphemeralKeyHandle<&'static str>) -> Self {
+		Self { ephemeral_key_handle }
 	}
 }
 
@@ -66,8 +65,8 @@ async fn main() {
 
 	let _server = SocketServer::listen_all(
 		app_pool,
-		&Processor::new(EphemeralKeyHandle::new(
-			"./mock/ephemeral_seed.secret.keep".to_string(),
+		Processor::new(EphemeralKeyHandle::new(
+			"./mock/ephemeral_seed.secret.keep",
 		)),
 		1,
 	)

--- a/src/integration/src/bin/pivot_remote_tls.rs
+++ b/src/integration/src/bin/pivot_remote_tls.rs
@@ -9,10 +9,7 @@ use qos_core::{
 };
 use qos_net::proxy_stream::ProxyStream;
 use rustls::RootCertStore;
-use tokio::{
-	io::{AsyncReadExt, AsyncWriteExt},
-	sync::RwLock,
-};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio_rustls::TlsConnector;
 
 #[derive(Clone)]
@@ -21,8 +18,8 @@ struct Processor {
 }
 
 impl Processor {
-	fn new(net_pool: SharedStreamPool) -> Arc<RwLock<Self>> {
-		Arc::new(RwLock::new(Processor { net_pool }))
+	fn new(net_pool: SharedStreamPool) -> Self {
+		Self { net_pool }
 	}
 }
 
@@ -113,13 +110,9 @@ async fn main() {
 	let proxy_pool = StreamPool::new(SocketAddress::new_unix(proxy_path), 1)
 		.expect("unable to create async stream pool")
 		.shared();
-
-	let _server = SocketServer::listen_all(
-		enclave_pool,
-		&Processor::new(proxy_pool),
-		128,
-	)
-	.unwrap();
+	let _server =
+		SocketServer::listen_all(enclave_pool, Processor::new(proxy_pool), 128)
+			.unwrap();
 
 	match tokio::signal::ctrl_c().await {
 		Ok(()) => eprintln!("pivot handling ctrl+c the tokio way"),

--- a/src/integration/src/bin/pivot_socket_stress.rs
+++ b/src/integration/src/bin/pivot_socket_stress.rs
@@ -1,5 +1,4 @@
 use core::panic;
-use std::sync::Arc;
 
 use borsh::BorshDeserialize;
 use integration::PivotSocketStressMsg;
@@ -7,16 +6,9 @@ use qos_core::{
 	io::{SocketAddress, StreamPool},
 	server::{RequestProcessor, SocketServer},
 };
-use tokio::sync::RwLock;
 
 #[derive(Clone)]
 struct Processor;
-
-impl Processor {
-	pub fn new() -> Arc<RwLock<Self>> {
-		Arc::new(RwLock::new(Self))
-	}
-}
 
 impl RequestProcessor for Processor {
 	async fn process(&self, request: &[u8]) -> Vec<u8> {
@@ -71,8 +63,7 @@ async fn main() {
 		StreamPool::new(SocketAddress::new_unix(socket_path), pool_size)
 			.expect("unable to create app pool");
 
-	let _server =
-		SocketServer::listen_all(app_pool, &Processor::new(), 128).unwrap();
+	let _server = SocketServer::listen_all(app_pool, Processor, 128).unwrap();
 
 	tokio::signal::ctrl_c().await.unwrap();
 }

--- a/src/integration/tests/client.rs
+++ b/src/integration/tests/client.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
 use qos_core::{
 	client::SocketClient,
@@ -6,16 +6,9 @@ use qos_core::{
 	server::SocketServerError,
 	server::{RequestProcessor, SocketServer},
 };
-use tokio::sync::RwLock;
 
 #[derive(Clone)]
 struct EchoProcessor;
-
-impl EchoProcessor {
-	pub fn new() -> Arc<RwLock<Self>> {
-		Arc::new(RwLock::new(Self))
-	}
-}
 
 impl RequestProcessor for EchoProcessor {
 	async fn process(&self, request: &[u8]) -> Vec<u8> {
@@ -28,7 +21,7 @@ async fn run_echo_server(
 ) -> Result<SocketServer, SocketServerError> {
 	let pool = StreamPool::new(SocketAddress::new_unix(socket_path), 1)
 		.expect("unable to create async pool");
-	let server = SocketServer::listen_all(pool, &EchoProcessor::new(), 128)?;
+	let server = SocketServer::listen_all(pool, EchoProcessor, 128)?;
 
 	Ok(server)
 }

--- a/src/qos_core/src/handles.rs
+++ b/src/qos_core/src/handles.rs
@@ -36,15 +36,18 @@ impl QuorumKeyHandle {
 }
 
 /// Handle for accessing the enclave ephemeral key.
-#[derive(Debug, Clone)]
-pub struct EphemeralKeyHandle {
-	ephemeral_key_path: String,
+#[derive(Debug, Clone, Copy)]
+pub struct EphemeralKeyHandle<S = String> {
+	ephemeral_key_path: S,
 }
 
-impl EphemeralKeyHandle {
+impl<P> EphemeralKeyHandle<P>
+where
+	P: AsRef<Path>,
+{
 	/// Create a new instance of [`Self`].
 	#[must_use]
-	pub fn new(ephemeral_key_path: String) -> Self {
+	pub fn new(ephemeral_key_path: P) -> Self {
 		Self { ephemeral_key_path }
 	}
 

--- a/src/qos_core/src/protocol/processor.rs
+++ b/src/qos_core/src/protocol/processor.rs
@@ -1,17 +1,15 @@
 //! Quorum protocol processor
 
-use std::sync::Arc;
-
 use borsh::BorshDeserialize;
-use tokio::sync::RwLock;
 
 use super::{
 	error::ProtocolError, msg::ProtocolMsg, SharedProtocolState,
 	MAX_ENCODED_MSG_LEN,
 };
-use crate::server::{RequestProcessor, SharedProcessor};
+use crate::server::RequestProcessor;
 
 /// Enclave state machine that executes when given a `ProtocolMsg`.
+#[derive(Clone)]
 pub struct ProtocolProcessor {
 	state: SharedProtocolState,
 }
@@ -19,8 +17,8 @@ pub struct ProtocolProcessor {
 impl ProtocolProcessor {
 	/// Create a new `Self` inside `Arc` and `Mutex`.
 	#[must_use]
-	pub fn new(state: SharedProtocolState) -> SharedProcessor<Self> {
-		Arc::new(RwLock::new(Self { state }))
+	pub fn new(state: SharedProtocolState) -> Self {
+		Self { state }
 	}
 }
 

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -55,7 +55,7 @@ async fn run_server(
 
 	// listen on the protocol server
 	let _protocol_server =
-		SocketServer::listen_all(core_pool, &protocol_processor, 1)
+		SocketServer::listen_all(core_pool, protocol_processor, 1)
 			.expect("unable to get listen task list for protocol server");
 
 	println!("Reaper::server running");

--- a/src/qos_core/src/server.rs
+++ b/src/qos_core/src/server.rs
@@ -1,10 +1,10 @@
 //! Streaming socket based server for use in an enclave. Listens for connections
 //! from [`crate::client::Client`].
 
-use std::sync::Arc;
+use std::{future::Future, ops::Deref, sync::Arc};
 
 use tokio::{
-	sync::{OwnedSemaphorePermit, RwLock, Semaphore},
+	sync::{OwnedSemaphorePermit, Semaphore},
 	task::JoinHandle,
 };
 
@@ -25,9 +25,6 @@ impl From<IOError> for SocketServerError {
 	}
 }
 
-/// Alias to simplify `Arc<RwLock<P>>` where `P` is the `RequestProcessor`
-pub type SharedProcessor<P> = Arc<RwLock<P>>;
-
 /// Something that can process requests in an async way.
 pub trait RequestProcessor: Send + Sync {
 	/// Process an incoming request and return a response in async.
@@ -39,6 +36,16 @@ pub trait RequestProcessor: Send + Sync {
 		&self,
 		request: &[u8],
 	) -> impl std::future::Future<Output = Vec<u8>> + Send;
+}
+
+impl<T, U> RequestProcessor for T
+where
+	T: Deref<Target = U> + Send + Sync,
+	U: RequestProcessor + 'static,
+{
+	fn process(&self, request: &[u8]) -> impl Future<Output = Vec<u8>> + Send {
+		self.deref().process(request)
+	}
 }
 
 /// A bare bones, socket based server.
@@ -59,11 +66,11 @@ impl SocketServer {
 	/// per each pool address.
 	pub fn listen_all<P>(
 		pool: StreamPool,
-		processor: &SharedProcessor<P>,
+		processor: P,
 		max_connections: usize,
 	) -> Result<Self, SocketServerError>
 	where
-		P: RequestProcessor + Sync + 'static,
+		P: RequestProcessor + Clone + 'static,
 	{
 		println!("`SocketServer` listening on pool size {}", pool.len());
 
@@ -77,35 +84,14 @@ impl SocketServer {
 		Ok(Self { pool, tasks, max_connections })
 	}
 
-	fn spawn_tasks_for_listeners<P>(
-		listeners: Vec<Listener>,
-		processor: &SharedProcessor<P>,
-		max_connections: usize,
-	) -> Vec<JoinHandle<Result<(), SocketServerError>>>
-	where
-		P: RequestProcessor + Sync + 'static,
-	{
-		let mut tasks = Vec::new();
-		for listener in listeners {
-			let p = processor.clone();
-			let task = tokio::spawn(async move {
-				accept_loop(listener, p, max_connections).await
-			});
-
-			tasks.push(task);
-		}
-
-		tasks
-	}
-
 	/// Expand the server with listeners up to pool size. This adds new tasks as needed.
 	pub fn listen_to<P>(
 		&mut self,
 		pool_size: u8,
-		processor: &SharedProcessor<P>,
+		processor: P,
 	) -> Result<(), IOError>
 	where
-		P: RequestProcessor + Sync + 'static,
+		P: RequestProcessor + Clone + 'static,
 	{
 		let listeners = self.pool.listen_to(pool_size)?;
 		let tasks = Self::spawn_tasks_for_listeners(
@@ -117,6 +103,27 @@ impl SocketServer {
 		self.tasks.extend(tasks);
 
 		Ok(())
+	}
+
+	fn spawn_tasks_for_listeners<P>(
+		listeners: Vec<Listener>,
+		processor: P,
+		max_connections: usize,
+	) -> Vec<JoinHandle<Result<(), SocketServerError>>>
+	where
+		P: RequestProcessor + Clone + 'static,
+	{
+		let mut tasks = Vec::new();
+		for listener in listeners {
+			let p = processor.clone();
+			let task = tokio::spawn(async move {
+				accept_loop(listener, &p, max_connections).await
+			});
+
+			tasks.push(task);
+		}
+
+		tasks
 	}
 }
 
@@ -169,11 +176,11 @@ impl PermittedStream {
 
 async fn accept_loop<P>(
 	listener: Listener,
-	processor: SharedProcessor<P>,
+	processor: &P,
 	max_connections: usize,
 ) -> Result<(), SocketServerError>
 where
-	P: RequestProcessor + 'static,
+	P: RequestProcessor + Clone + 'static,
 {
 	let connections = Arc::new(Semaphore::const_new(max_connections));
 	loop {
@@ -187,12 +194,13 @@ where
 				}
 			};
 
-		let p = processor.clone();
+		let processor = processor.clone();
+
 		tokio::spawn(async move {
 			loop {
 				match stream.recv().await {
 					Ok(payload) => {
-						let response = p.read().await.process(&payload).await;
+						let response = processor.process(&payload).await;
 
 						match stream.send(&response).await {
 							Ok(()) => {}


### PR DESCRIPTION
Remove `SharedProcessor<P>` which had a bit of a knock on effect.

## Summary & Motivation (Problem vs. Solution)

The problem is twofold. RwLocks can be expensive compared to Mutexes. The accounting on the RwLock will cause a cpu cache miss. I know that's a micro-optimization and the actual best practice is to benchmark, but short of doing that, it's generally better to use a mutex if you're just doing something like reading a field, then releasing the lock. But I've started with the more nuanced detail that probably doesn't even justify a change. The part that I think actually justifies the change the fact that the function signature(s) that required `SharedProcessor<P>` were forcing the syncing primitive. 

Further reading (watching) on RwLock vs Mutex and cache misses: 
https://www.youtube.com/watch?v=tND-wBBZ8RY

## How I Tested These Changes

I haven't... I don't know how yet

## Pre merge check list

~~TBD...~~
CI here: https://github.com/tkhq/mono/pull/6003

- [ ] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
