### PR TITLE
Expose eph key and attestation doc in qos-host /enclave-info

### DIFF
--- a/src/integration/tests/qos_host.rs
+++ b/src/integration/tests/qos_host.rs
@@ -62,6 +62,6 @@ async fn connects_and_gets_info() {
 	assert!(r.is_ok()); // expect 200 here
 	assert_eq!(
 		r.unwrap().into_string().unwrap(),
-		"{\"phase\":\"WaitingForBootInstruction\",\"manifestEnvelope\":null}"
+		"{\"phase\":\"WaitingForBootInstruction\",\"manifestEnvelope\":null,\"ephemeralKey\":null}"
 	);
 }

--- a/src/qos_host/src/host.rs
+++ b/src/qos_host/src/host.rs
@@ -32,6 +32,7 @@ use qos_core::{
 		ProtocolPhase,
 	},
 };
+use qos_nsm::types::NsmResponse;
 
 use crate::{
 	EnclaveInfo, EnclaveVitalStats, Error, ENCLAVE_HEALTH, ENCLAVE_INFO,
@@ -192,7 +193,8 @@ impl HostServer {
 			get_manifest_envelope(&state.enclave_client).await.map_err(
 				|e| Error(format!("unable to get manifest envelope: {e:?}")),
 			)?;
-
+		let ephemeral_key =
+			get_eph_key_from_attestation_doc(&state.enclave_client).await;
 		let vitals_log = if let Some(m) = manifest_envelope.as_ref() {
 			serde_json::to_string(&EnclaveVitalStats {
 				phase,
@@ -201,14 +203,20 @@ impl HostServer {
 				pivot_hash: m.manifest.pivot.hash,
 				pcr0: m.manifest.enclave.pcr0.clone(),
 				pivot_args: m.manifest.pivot.args.clone(),
+				ephemeral_key: ephemeral_key.clone(),
 			})
 			.expect("always valid json. qed.")
 		} else {
-			serde_json::to_string(&phase).expect("always valid json. qed.")
+			let info = serde_json::json!({
+				"phase": phase,
+				"ephemeralKey": ephemeral_key.clone(),
+			});
+			serde_json::to_string(&info).expect("always valid json. qed.")
 		};
+
 		println!("{vitals_log}");
 
-		let info = EnclaveInfo { phase, manifest_envelope };
+		let info = EnclaveInfo { phase, manifest_envelope, ephemeral_key };
 
 		Ok(Json(info))
 	}
@@ -244,6 +252,30 @@ impl HostServer {
 			}
 		}
 	}
+}
+
+async fn get_eph_key_from_attestation_doc(
+	enclave_client: &SocketClient,
+) -> Option<String> {
+	let req = borsh::to_vec(&ProtocolMsg::LiveAttestationDocRequest).ok()?;
+	let resp_bytes = enclave_client.call(&req).await.ok()?;
+	let resp = ProtocolMsg::try_from_slice(&resp_bytes).ok()?;
+
+	let nsm_response = match resp {
+		ProtocolMsg::LiveAttestationDocResponse { nsm_response, .. } => {
+			nsm_response
+		}
+		_ => return None,
+	};
+
+	let document = match nsm_response {
+		NsmResponse::Attestation { document } => document,
+		_ => return None,
+	};
+
+	let attestation_doc =
+		qos_nsm::nitro::unsafe_attestation_doc_from_der(&document).ok()?;
+	attestation_doc.public_key.as_ref().map(|pk| qos_hex::encode(pk))
 }
 
 // try to get the manifest denvelope from the enclave, used for restart handling of qos_host

--- a/src/qos_host/src/lib.rs
+++ b/src/qos_host/src/lib.rs
@@ -60,6 +60,8 @@ pub struct EnclaveInfo {
 	pub phase: ProtocolPhase,
 	/// Manifest envelope in the enclave.
 	pub manifest_envelope: Option<ManifestEnvelope>,
+	/// Ephemeral public key from the live attestation doc.
+	pub ephemeral_key: Option<String>,
 }
 
 /// Vitals we just use for logging right now to avoid logging the entire
@@ -75,6 +77,8 @@ pub struct EnclaveVitalStats {
 	#[serde(with = "qos_hex::serde")]
 	pcr0: Vec<u8>,
 	pivot_args: Vec<String>,
+	/// Ephemeral public key from the live attestation doc.
+	pub ephemeral_key: Option<String>,
 }
 
 /// Body of a 4xx or 5xx response


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

To better understand an enclaves unique identity, it is helpful to log the enclave's ephemeral key in the enclave-info endpoint.

## How I Tested These Changes

Unit tests

## Pre merge check list

- [ ] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
