### PR TITLE
new qos_clock crate and boot-time kvm-clock validation

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1911,6 +1911,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "qos_clock"
+version = "0.6.1"
+dependencies = [
+ "qos_system",
+]
+
+[[package]]
 name = "qos_core"
 version = "0.6.1"
 dependencies = [
@@ -2050,6 +2057,13 @@ dependencies = [
  "arbitrary",
  "libfuzzer-sys",
  "qos_p256",
+]
+
+[[package]]
+name = "qos_system"
+version = "0.1.0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "integration",
   "qos_bridge",
   "qos_client",
+  "qos_clock",
   "qos_core",
   "qos_crypto",
   "qos_host",
@@ -21,6 +22,7 @@ default-members = [
   "integration",
   "qos_bridge",
   "qos_client",
+  "qos_clock",
   "qos_core",
   "qos_crypto",
   "qos_host",
@@ -103,6 +105,7 @@ zeroize = { version = "1.8", default-features = false }
 integration = { path = "integration" }
 qos_host = { path = "qos_host", default-features = false }
 qos_client = { path = "qos_client", version = "0.6.1", default-features = false }
+qos_clock = { path = "qos_clock", version = "0.6.1", default-features = false }
 qos_core = { path = "qos_core", version = "0.6.1", default-features = false }
 qos_crypto = { path = "qos_crypto", version = "0.6.1", default-features = false }
 qos_hex = { path = "qos_hex", version = "0.6.1", default-features = false }

--- a/src/qos_aws/src/lib.rs
+++ b/src/qos_aws/src/lib.rs
@@ -1,4 +1,6 @@
-use qos_system::{check_hwrng, dmesg, poweroff};
+use qos_system::{
+	check_clocksource, check_hwrng, detect_ptp_clock_device, dmesg, poweroff,
+};
 
 /// Signal to Nitro hypervisor that booting was successful
 fn nitro_heartbeat() {
@@ -38,4 +40,23 @@ pub fn init_platform() {
 			poweroff();
 		}
 	};
+
+	match check_clocksource("kvm-clock") {
+		Ok(()) => dmesg("Validated clock source is kvm-clock".to_string()),
+		Err(e) => {
+			eprintln!("{}", e);
+			dmesg(format!("Clock source validation failed: {}", e.message));
+			poweroff();
+		}
+	};
+
+	match detect_ptp_clock_device() {
+		Some(path) => dmesg(format!(
+			"PTP hardware clock device is visible at {path}; synchronization is not configured by init"
+		)),
+		None => dmesg(
+			"No PTP hardware clock device is exposed to the enclave; synchronization is not configured by init"
+				.to_string(),
+		),
+	}
 }

--- a/src/qos_clock/Cargo.toml
+++ b/src/qos_clock/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "qos_clock"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Clock abstractions for QuorumOS"
+repository = "https://github.com/tkhq/qos"
+keywords = ["quorumos", "clock", "time"]
+categories = ["os"]
+
+[lints]
+workspace = true
+
+[dependencies]
+
+[target.'cfg(target_os = "linux")'.dependencies]
+qos_system = { path = "../qos_system" }

--- a/src/qos_clock/src/lib.rs
+++ b/src/qos_clock/src/lib.rs
@@ -1,0 +1,57 @@
+//! Wall-clock access for Unix time inside QOS.
+
+use std::{fmt, time::SystemTime};
+
+/// Error returned when reading wall-clock time fails or overflows `u64`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WallClockError {
+	/// Converting between time units failed.
+	TimeConversionFailed,
+	/// The system clock was before the Unix epoch.
+	TimeBeforeUnixEpoch,
+	/// The returned value did not fit in `u64`.
+	TimeOverflow,
+}
+
+impl fmt::Display for WallClockError {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			Self::TimeConversionFailed => {
+				write!(f, "system clock conversion failed")
+			}
+			Self::TimeBeforeUnixEpoch => {
+				write!(f, "system clock was before the Unix epoch")
+			}
+			Self::TimeOverflow => {
+				write!(f, "system clock value overflowed u64")
+			}
+		}
+	}
+}
+
+/// Source of Unix wall-clock time for expiry and freshness checks.
+pub trait WallClock: Send + Sync {
+	/// Returns Unix time in whole milliseconds.
+	fn unix_time_millis(&self) -> Result<u64, WallClockError>;
+
+	/// Returns Unix time in whole seconds.
+	fn unix_time_seconds(&self) -> Result<u64, WallClockError> {
+		self.unix_time_millis()?
+			.checked_div(1_000)
+			.ok_or(WallClockError::TimeConversionFailed)
+	}
+}
+
+/// Wall clock backed by the host operating system.
+pub struct SystemWallClock;
+
+impl WallClock for SystemWallClock {
+	fn unix_time_millis(&self) -> Result<u64, WallClockError> {
+		let duration = SystemTime::now()
+			.duration_since(SystemTime::UNIX_EPOCH)
+			.map_err(|_| WallClockError::TimeBeforeUnixEpoch)?;
+
+		u64::try_from(duration.as_millis())
+			.map_err(|_| WallClockError::TimeOverflow)
+	}
+}

--- a/src/qos_system/src/lib.rs
+++ b/src/qos_system/src/lib.rs
@@ -8,6 +8,10 @@ use std::{
 
 use libc::{c_int, c_ulong, c_void};
 
+const HWRNG_CURRENT_PATH: &str = "/sys/class/misc/hw_random/rng_current";
+const CLOCKSOURCE_CURRENT_PATH: &str =
+	"/sys/devices/system/clocksource/clocksource0/current_clocksource";
+
 #[derive(Debug)]
 pub struct SystemError {
 	pub message: String,
@@ -166,6 +170,44 @@ pub fn check_hwrng(rng_expected: &str) -> Result<(), SystemError> {
 		});
 	};
 	Ok(())
+}
+
+fn read_trimmed(path: &str) -> Result<String, SystemError> {
+	use std::fs::read_to_string;
+
+	read_to_string(path)
+		.map(|value| value.trim().to_string())
+		.map_err(|_| SystemError { message: format!("Failed to read {path}") })
+}
+
+/// Verify the expected clock source is active.
+pub fn check_clocksource(clock_expected: &str) -> Result<(), SystemError> {
+	let clock_current = read_trimmed(CLOCKSOURCE_CURRENT_PATH)?;
+	if clock_expected != clock_current {
+		return Err(SystemError {
+			message: format!(
+				"Clock source was {} instead of {}",
+				clock_current, clock_expected
+			),
+		});
+	}
+
+	Ok(())
+}
+
+/// Detect whether a PTP hardware clock device is exposed in the enclave.
+///
+/// AWS documents both `/dev/ptp<index>` and the stable `/dev/ptp_ena`
+/// symlink for supported instances:
+/// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configure-ec2-ntp.html
+pub fn detect_ptp_clock_device() -> Option<&'static str> {
+	for path in ["/dev/ptp_ena", "/dev/ptp0"] {
+		if File::open(path).is_ok() {
+			return Some(path);
+		}
+	}
+
+	None
 }
 
 #[cfg(target_env = "musl")]


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

This is meant to demonstrate how we could ensure we are using the kvm-clock. 
This article discusses why the KVM clock https://blog.trailofbits.com/2024/09/24/notes-on-aws-nitro-enclaves-attack-surface/#time

Specifically


> - Ensure that current_clocksource is set to kvm-clock in the enclave’s kernel configuration; consider even adding an application-level runtime check for the clock (in case something goes wrong during enclave bootstrapping and it ends up with a different clock source).
> - Enable the [Precision Time Protocol](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html#connect-to-the-ptp-hardware-clock) for better clock synchronization between the enclave and the hypervisor. It’s like the Network Time Protocol (NTP) but works over a hardware connection. It should be more secure (as it has a smaller attack surface) and easier to [set up](https://github.com/aws/aws-nitro-enclaves-cli/issues/500) than the NTP.
> - For security-critical functionalities (like replay protections) use [Unix time](https://en.wikipedia.org/wiki/Unix_time). Be careful with UTC and time zones, as [daylight saving time](https://en.wikipedia.org/wiki/Daylight_saving_time) and [leap seconds](https://cr.yp.to/proto/utctai.html) may “move time backwards.”


Note this does not cover configuring PTP synchronization. This must be done on the parent ec2 instance

## How I Tested These Changes

## Pre merge check list

- [ ] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
