### PR TITLE
Fix fuzzing lints

### DIFF
--- a/src/qos_crypto/fuzz/fuzz_targets/2_shamir_input_reconstruct_two_shares.rs
+++ b/src/qos_crypto/fuzz/fuzz_targets/2_shamir_input_reconstruct_two_shares.rs
@@ -29,7 +29,7 @@ fuzz_target!(|fuzzerdata: FuzzShareReconstruct| {
 
 	// Reconstruct with the shares, we expect this to error out often
 	let reconstructed_res = shares_reconstruct(&shares);
-	if !reconstructed_res.is_err() {
+	if reconstructed_res.is_ok() {
 		let _reconstructed = reconstructed_res.unwrap();
 
 		// debug print is useful for manual evaluation

--- a/src/qos_crypto/fuzz/fuzz_targets/3_shamir_input_reconstruct_three_shares.rs
+++ b/src/qos_crypto/fuzz/fuzz_targets/3_shamir_input_reconstruct_three_shares.rs
@@ -40,7 +40,7 @@ fuzz_target!(|fuzzerdata: FuzzShareReconstruct| {
 
 	// Reconstruct with the shares, we expect this to error out often
 	let reconstructed_res = shares_reconstruct(&shares);
-	if !reconstructed_res.is_err() {
+	if reconstructed_res.is_ok() {
 		// let _reconstructed = reconstructed_res.unwrap();
 
 		// debug print is useful for manual evaluation

--- a/src/qos_net/fuzz/fuzz_targets/1_new_from_ip.rs
+++ b/src/qos_net/fuzz/fuzz_targets/1_new_from_ip.rs
@@ -2,7 +2,7 @@
 
 use libfuzzer_sys::fuzz_target;
 
-use qos_net::proxy_connection::ProxyConnection;
+// use qos_net::proxy_connection::ProxyConnection;
 
 #[derive(Clone, Debug, arbitrary::Arbitrary)]
 pub struct FuzzIPPort {
@@ -10,6 +10,10 @@ pub struct FuzzIPPort {
 	pub port: u16,
 }
 
-fuzz_target!(|data: FuzzIPPort| {
-	let _ = ProxyConnection::new_from_ip(data.ip.clone(), data.port);
+fuzz_target!(|_data: FuzzIPPort| {
+	// Commented out of now as this is an async function that is just returning
+	// a future right away without getting polled. The code inside the function
+	// (at the time of writing) is strictly std/core or tokio code that might not
+	// be worth fuzzing.
+	// let _ = ProxyConnection::new_from_ip(data.ip.clone(), data.port);
 });

--- a/src/qos_p256/fuzz/fuzz_targets/2_public_sign_key_round_trip.rs
+++ b/src/qos_p256/fuzz/fuzz_targets/2_public_sign_key_round_trip.rs
@@ -40,8 +40,7 @@ fuzz_target!(|input: FuzzKeyDataStruct| {
 	let mut wrong_signature = signature.clone();
 	let wrong_signature_last_element_index = wrong_signature.len() - 1;
 	// flip a bit in the signature
-	wrong_signature[wrong_signature_last_element_index] =
-		wrong_signature[wrong_signature_last_element_index] ^ 1;
+	wrong_signature[wrong_signature_last_element_index] ^= 1;
 	// expect the verification to fail since the signature is bad
 	assert!(public_reimported.verify(&input.data, &wrong_signature).is_err());
 });

--- a/src/qos_p256/fuzz/fuzz_targets/6_basic_encrypt_decrypt_aesgcm.rs
+++ b/src/qos_p256/fuzz/fuzz_targets/6_basic_encrypt_decrypt_aesgcm.rs
@@ -38,8 +38,7 @@ fuzz_target!(|input: FuzzKeyDataStruct| {
 	let mut corrupted_encrypted_envelope = encrypted_envelope.clone();
 	let last_element_index_envelope = corrupted_encrypted_envelope.len() - 1;
 	// flip one bit in the end of the message as a simple example of data corruption
-	corrupted_encrypted_envelope[last_element_index_envelope] =
-		corrupted_encrypted_envelope[last_element_index_envelope] ^ 1;
+	corrupted_encrypted_envelope[last_element_index_envelope] ^= 1;
 	// expect detection of the corruption
 	assert!(random_key.decrypt(&corrupted_encrypted_envelope).is_err());
 });


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

Problem: we're ignoring some lint warnings
Solution: fix it 

## How I Tested These Changes

No logical changes made (aside from commenting out the one fuzz test. See the comment for details.

## Pre merge check list

- [x] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
