### PR TITLE
fix: use block_in_place to avoid blocking code in tokio tasks

### DIFF
--- a/src/integration/tests/boot.rs
+++ b/src/integration/tests/boot.rs
@@ -25,7 +25,7 @@ use qos_host::EnclaveInfo;
 use qos_p256::P256Pair;
 use qos_test_primitives::{ChildWrapper, PathWrapper};
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn standard_boot_e2e() {
 	const PIVOT_HASH_PATH: &str = "/tmp/standard_boot_e2e-pivot-hash.txt";
 

--- a/src/integration/tests/client.rs
+++ b/src/integration/tests/client.rs
@@ -26,7 +26,7 @@ async fn run_echo_server(
 	Ok(server)
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn direct_connect_works() {
 	let socket_path = "/tmp/async_client_test_direct_connect_works.sock";
 	let socket = SocketAddress::new_unix(socket_path);
@@ -43,7 +43,7 @@ async fn direct_connect_works() {
 	assert!(r.is_ok());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn times_out_properly() {
 	let socket_path = "/tmp/async_client_test_times_out_properly.sock";
 	let socket = SocketAddress::new_unix(socket_path);
@@ -57,7 +57,7 @@ async fn times_out_properly() {
 	assert!(r.is_err());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn repeat_connect_works() {
 	let socket_path = "/tmp/async_client_test_repeat_connect_works.sock";
 	let socket = SocketAddress::new_unix(socket_path);

--- a/src/integration/tests/dev_boot.rs
+++ b/src/integration/tests/dev_boot.rs
@@ -3,7 +3,7 @@ use std::{fs, path::Path, process::Command};
 use integration::{LOCAL_HOST, PIVOT_OK3_PATH, PIVOT_OK3_SUCCESS_FILE};
 use qos_test_primitives::{ChildWrapper, PathWrapper};
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn dev_boot_e2e() {
 	let tmp: PathWrapper = "/tmp/dev-boot-e2e-tmp".into();
 	drop(fs::create_dir_all(&*tmp));

--- a/src/integration/tests/enclave_app_client_socket_stress.rs
+++ b/src/integration/tests/enclave_app_client_socket_stress.rs
@@ -25,7 +25,7 @@ const TEST_TMP: &str = "/tmp/enclave_app_client_socket_stress";
 const ENCLAVE_SOCK: &str = "/tmp/enclave_app_client_socket_stress/enclave.sock";
 const APP_SOCK: &str = "/tmp/enclave_app_client_socket_stress/app.sock";
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn enclave_app_client_socket_stress() {
 	let _: PathWrapper = TEST_TMP.into();
 	std::fs::create_dir_all(TEST_TMP).unwrap();

--- a/src/integration/tests/genesis.rs
+++ b/src/integration/tests/genesis.rs
@@ -17,7 +17,7 @@ use rand::{rng, seq::SliceRandom};
 const DR_KEY_PUBLIC_PATH: &str = "./mock/mock_p256_dr.pub";
 const DR_KEY_PRIVATE_PATH: &str = "./mock/mock_p256_dr.secret.keep";
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn genesis_e2e() {
 	let host_port = qos_test_primitives::find_free_port().unwrap();
 	let tmp: PathWrapper = "/tmp/genesis-e2e".into();

--- a/src/integration/tests/host_bridge.rs
+++ b/src/integration/tests/host_bridge.rs
@@ -8,7 +8,7 @@ use qos_core::io::{HostBridge, SocketAddress, Stream, StreamPool};
 use qos_test_primitives::{find_free_port, ChildWrapper};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn vsock_to_tcp_bridge_works() {
 	const APP_USOCK: &str = "/tmp/vsock_to_tcp_bridge_works.usock";
 	let port = find_free_port().unwrap();

--- a/src/integration/tests/interleaving_socket_stress.rs
+++ b/src/integration/tests/interleaving_socket_stress.rs
@@ -13,7 +13,7 @@ use qos_test_primitives::ChildWrapper;
 
 const SOCKET_STRESS_SOCK: &str = "/tmp/interleaving_socket_stress.sock";
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn interleaving_socket_stress() {
 	let pool_size = 5;
 	let _enclave_app: ChildWrapper = Command::new(PIVOT_SOCKET_STRESS_PATH)

--- a/src/integration/tests/key.rs
+++ b/src/integration/tests/key.rs
@@ -24,7 +24,7 @@ const SHARED_EPH_PATH: &str = "/tmp/key-fwd-e2e/shared_eph.secret";
 const QUORUM_KEY_PUB_PATH: &str =
 	"./mock/namespaces/quit-coding-to-vape/quorum_key.pub";
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn key_fwd_e2e() {
 	// Make sure everything in the temp dir gets dropped
 	let _: PathWrapper = TMP_DIR.into();

--- a/src/integration/tests/proofs.rs
+++ b/src/integration/tests/proofs.rs
@@ -13,7 +13,7 @@ use qos_test_primitives::ChildWrapper;
 
 const PROOF_TEST_ENCLAVE_SOCKET: &str = "/tmp/proof_test.enclave.sock";
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn fetch_and_verify_app_proof() {
 	let _enclave_app: ChildWrapper = Command::new(PIVOT_PROOF_PATH)
 		.arg(PROOF_TEST_ENCLAVE_SOCKET)

--- a/src/integration/tests/qos_bridge.rs
+++ b/src/integration/tests/qos_bridge.rs
@@ -28,7 +28,7 @@ use tokio::{
 	net::TcpStream,
 };
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn qos_bridge_works() {
 	const PIVOT_HASH_PATH: &str = "/tmp/qos_host_bridge-pivot-hash.txt";
 

--- a/src/integration/tests/qos_host.rs
+++ b/src/integration/tests/qos_host.rs
@@ -3,7 +3,7 @@ use std::{process::Command, time::Duration};
 use integration::PIVOT_OK_PATH;
 use qos_test_primitives::{ChildWrapper, PathWrapper};
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn connects_and_gets_info() {
 	// prep sock pool dir
 	std::fs::create_dir_all("/tmp/qos_host_test").unwrap();

--- a/src/integration/tests/reaper.rs
+++ b/src/integration/tests/reaper.rs
@@ -20,7 +20,7 @@ use tokio::{
 	net::TcpStream,
 };
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn reaper_works() {
 	let secret_path: PathWrapper = "/tmp/reaper_works.secret".into();
 	let usock: PathWrapper = "/tmp/reaper_works.sock".into();
@@ -71,7 +71,7 @@ async fn reaper_works() {
 	assert!(fs::remove_file(integration::PIVOT_OK_SUCCESS_FILE).is_ok());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn reaper_handles_non_zero_exits() {
 	let secret_path: PathWrapper =
 		"/tmp/reaper_handles_non_zero_exits.secret".into();
@@ -119,7 +119,7 @@ async fn reaper_handles_non_zero_exits() {
 	assert!(reaper_handle.is_finished());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn reaper_handles_panic() {
 	let secret_path: PathWrapper = "/tmp/reaper_handles_panics.secret".into();
 	let usock: PathWrapper = "/tmp/reaper_handles_panics.sock".into();
@@ -166,7 +166,7 @@ async fn reaper_handles_panic() {
 	assert!(reaper_handle.is_finished());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn reaper_handles_bridge() {
 	let pivot_port = find_free_port().unwrap();
 	let host_port = find_free_port().unwrap();

--- a/src/integration/tests/remote_tls.rs
+++ b/src/integration/tests/remote_tls.rs
@@ -17,7 +17,7 @@ const REMOTE_TLS_TEST_ENCLAVE_SOCKET: &str =
 	"/tmp/remote_tls_test.enclave.sock";
 const POOL_SIZE: &str = "1";
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn fetch_async_remote_tls_content() {
 	let _net_proxy: ChildWrapper = Command::new(QOS_NET_PATH)
 		.arg("--usock")

--- a/src/integration/tests/simple_socket_stress.rs
+++ b/src/integration/tests/simple_socket_stress.rs
@@ -12,7 +12,7 @@ use qos_test_primitives::ChildWrapper;
 
 const SOCKET_STRESS_SOCK: &str = "/tmp/simple_socket_stress.sock";
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn simple_socket_stress() {
 	let _enclave_app: ChildWrapper = Command::new(PIVOT_SOCKET_STRESS_PATH)
 		.arg(SOCKET_STRESS_SOCK)

--- a/src/qos_core/src/protocol/processor.rs
+++ b/src/qos_core/src/protocol/processor.rs
@@ -38,6 +38,7 @@ impl RequestProcessor for ProtocolProcessor {
 			.expect("ProtocolMsg can always be serialized. qed.");
 		};
 
-		self.state.write().await.handle_msg(&msg_req)
+		let mut state = self.state.write().await;
+		tokio::task::block_in_place(|| state.handle_msg(&msg_req))
 	}
 }


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

Problem we were blocking the tokio runtime, solution: don't block the tokio runtime.
I used [`block_in_place`](https://docs.rs/tokio/latest/tokio/task/fn.block_in_place.html) over `spawn_blocking` to minimize behavior changes and avoid cloning `state`. `state` is an `Arc` so cloning it and using `spawn_blocking` would be fine too.

Because I used `block_in_place` I had to make the tests use the multi threaded tokio runtime.

# Problems (codex wrote this):
## Summary

This PR moves synchronous protocol handling in `qos_core` behind a Tokio blocking boundary.

The request pipeline was running synchronous filesystem, NSM, and protocol logic directly on Tokio async worker threads. This change wraps the synchronous handler in `tokio::task::block_in_place(...)` so that blocking work no longer executes inline on the async scheduler.

## Problem

Accepted connections are handled on Tokio tasks in `qos_core/src/server.rs:199`. Each request then flows through `qos_core/src/protocol/processor.rs:25`.

Before this change, the processor awaited the async state lock and immediately ran the full synchronous state machine on the Tokio worker thread in `qos_core/src/protocol/processor.rs:41`.

That synchronous handler dispatches through `qos_core/src/protocol/state.rs:194` into request handlers such as:
- `qos_core/src/protocol/state.rs:340` `manifest_envelope`
- `qos_core/src/protocol/state.rs:355` `provision`
- `qos_core/src/protocol/state.rs:373` `boot_standard`
- `qos_core/src/protocol/state.rs:412` `live_attestation_doc`
- `qos_core/src/protocol/state.rs:453` `export_key`
- `qos_core/src/protocol/state.rs:483` `inject_key`

Those paths perform blocking work.

### Blocking filesystem access

The request path uses synchronous filesystem operations in `qos_core/src/handles.rs`, including:
- `qos_core/src/handles.rs:186` `fs::read`
- `qos_core/src/handles.rs:226` `fs::set_permissions`
- `qos_core/src/handles.rs:230` `fs::write`
- `qos_core/src/handles.rs:271` `fs::write`
- `qos_core/src/handles.rs:305` `fs::write`
- `qos_core/src/handles.rs:308` `fs::rename`

### Blocking NSM calls

The request path also performs synchronous NSM driver calls:
- `qos_core/src/protocol/services/attestation.rs:34` `attestor.nsm_process_request(request)`
- `qos_core/src/protocol/services/genesis.rs:208` `state.attestor.nsm_process_request(request)`
- `qos_core/src/protocol/services/key.rs:284` `nsm.timestamp_ms()?`

The production NSM implementation is synchronous driver I/O in `qos_nsm/src/nsm.rs:30`, where it opens the NSM device, issues the request, and closes the device inline.

## How I Tested These Changes

I ran `make test`

## Pre merge check list

- [x] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

~~TODO: going to ask zeke about how to verify this.~~ (Outcome not needed for this PR)
- [ ] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
