### PR TITLE
ci: cover vm feature gated tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,6 +14,15 @@ jobs:
       - name: Run tests
         run: make test
 
+  test-vm:
+    name: test-vm
+    runs-on: ubicloud-standard-2
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Run vm-gated tests
+        run: make -C src test-vm
+
   lint:
     name: lint
     runs-on: ubicloud-standard-2

--- a/src/Makefile
+++ b/src/Makefile
@@ -168,7 +168,7 @@ test:
 
 .PHONY: test-vm
 test-vm:
-	cargo test -p qos_core -p qos_host --features vm --no-default-features
+	cargo test -p qos_core -p qos_net -p qos_net -p qos_host -p qos_bridge --features vm --no-default-features
 
 .PHONY: build-linux-only
 build-linux-only: qos_system qos_aws init qos_enclave qos_bridge
@@ -191,4 +191,4 @@ qos_enclave:
 
 .PHONY: qos_bridge
 qos_bridge:
-	cargo build --manifest-path ./qos_bridge/Cargo.toml
+	cargo build --manifest-path ./qos_bridge/Cargo.toml --features vm

--- a/src/qos_core/src/cli.rs
+++ b/src/qos_core/src/cli.rs
@@ -339,7 +339,7 @@ mod test {
 		let opts = EnclaveOpts::new(&mut args);
 
 		assert_eq!(
-			opts.addr(),
+			opts.enclave_socket().unwrap(),
 			SocketAddress::new_vsock(6, 3999, crate::io::VMADDR_NO_FLAGS)
 		);
 	}

--- a/src/qos_host/src/cli.rs
+++ b/src/qos_host/src/cli.rs
@@ -307,7 +307,7 @@ mod test {
 		let opts = HostOpts::new(&mut args);
 
 		assert_eq!(
-			opts.enclave_addr(),
+			opts.enclave_socket().unwrap(),
 			qos_core::io::SocketAddress::new_vsock(6, 3999, 0)
 		);
 
@@ -330,7 +330,7 @@ mod test {
 		let opts = HostOpts::new(&mut args);
 
 		assert_eq!(
-			opts.enclave_addr(),
+			opts.enclave_socket().unwrap(),
 			qos_core::io::SocketAddress::new_vsock(6, 3999, 1)
 		);
 	}


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

We have several places in the code where tests are feature gated by the `vm` feature flag. None of those tests are covered the `make test` CI job. To make testing explicit I added a new `make -C src test-vm` command to test all the crates with the vm feature gate and explicitly enable the feature. This command does not have a docker run equivalent in the root and I think that is totally fine - trying to run everything is stagex docker is overkill and its prohibitively slow to run on mac. Note these vm tests use vsock so some won't pass on mac

I also updated `make -C src qos_bridge`, which is used with the linux only make target, enables the vm feature flag. Since in production you would use qos_bridge with the vm feature flag, this should help catch build regressions.

## How I Tested These Changes

New job

## Pre merge check list

- [ ] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
