### PR TITLE
fix: test port logic not working on macos

### DIFF
--- a/src/qos_test_primitives/src/lib.rs
+++ b/src/qos_test_primitives/src/lib.rs
@@ -1,19 +1,17 @@
 //! Primitive types for test setup.
 
 use std::{
-	net::TcpListener,
-	ops::{Deref, Range},
+	net::{Ipv4Addr, SocketAddrV4, TcpListener, TcpStream},
+	ops::Deref,
 	thread,
 	time::Duration,
 };
 
-use rand::prelude::*;
-
 const MAX_PORT_BIND_WAIT_TIME: Duration = Duration::from_secs(5);
 const PORT_BIND_WAIT_TIME_INCREMENT: Duration = Duration::from_millis(500);
 const POST_BIND_SLEEP: Duration = Duration::from_millis(500);
-const SERVER_PORT_RANGE: Range<u16> = 10000..60000;
-const MAX_PORT_SEARCH_ATTEMPTS: u16 = 50;
+const FIND_FREE_PORT_RETRY_DELAY: Duration = Duration::from_millis(50);
+const MAX_FIND_FREE_PORT_ATTEMPTS: usize = 50;
 const EXIT_DELAY: Duration = Duration::from_millis(50);
 
 /// Wrapper type for [`std::process::Child`] that kills the process on drop.
@@ -97,12 +95,22 @@ impl Deref for PathWrapper<'_> {
 /// Get a bind-able TCP port on the local system.
 #[must_use]
 pub fn find_free_port() -> Option<u16> {
-	let mut rng = rand::rng();
-	for _ in 0..MAX_PORT_SEARCH_ATTEMPTS {
-		let port = rng.random_range(SERVER_PORT_RANGE);
-		if port_is_available(port) {
-			return Some(port);
+	let mut last_err = None;
+
+	for _ in 0..MAX_FIND_FREE_PORT_ATTEMPTS {
+		match TcpListener::bind(("127.0.0.1", 0)) {
+			Ok(listener) => {
+				return listener.local_addr().ok().map(|addr| addr.port())
+			}
+			Err(err) => {
+				last_err = Some(err);
+				thread::sleep(FIND_FREE_PORT_RETRY_DELAY);
+			}
 		}
+	}
+
+	if let Some(err) = last_err {
+		eprintln!("failed to find free port: {err}");
 	}
 
 	None
@@ -119,7 +127,7 @@ pub fn wait_until_port_is_bound(port: u16) {
 
 	while wait_time < MAX_PORT_BIND_WAIT_TIME {
 		thread::sleep(wait_time);
-		if port_is_available(port) {
+		if !can_connect_to_port(port) {
 			wait_time += PORT_BIND_WAIT_TIME_INCREMENT;
 		} else {
 			thread::sleep(POST_BIND_SLEEP);
@@ -133,7 +141,8 @@ pub fn wait_until_port_is_bound(port: u16) {
 	)
 }
 
-/// Return whether or not the port can be bind-ed too.
-fn port_is_available(port: u16) -> bool {
-	TcpListener::bind(("127.0.0.1", port)).is_ok()
+/// Return whether or not a server is accepting connections on the given port.
+fn can_connect_to_port(port: u16) -> bool {
+	let addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, port);
+	TcpStream::connect_timeout(&addr.into(), Duration::from_millis(100)).is_ok()
 }


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

This change is limited to tests.
Fix `cd src && make test` on macos, not sure if this was working for linux, but it was not on macos.
TLDR: I changed the test behavior to bind to a available port instead of random and try tcp connecting instead of binding port to test for readiness. 

## How I Tested These Changes
Ran `cd src && make test`

## Pre merge check list

- [x] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
