### PR TITLE
chore: enable clippy::pedantic and fix all lints

### DIFF
--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -53,8 +53,7 @@ missing_docs = "warn"
 unsafe_code = "deny"
 
 [workspace.lints.clippy]
-missing_errors_doc = "allow"
-module_name_repetitions = "allow"
+pedantic = "deny"
 
 [workspace.lints.rustdoc]
 missing_docs = "warn"

--- a/src/integration/tests/host_bridge.rs
+++ b/src/integration/tests/host_bridge.rs
@@ -22,7 +22,7 @@ async fn vsock_to_tcp_bridge_works() {
 		.unwrap()
 		.into();
 
-	HostBridge::new(pool, host_addr).vsock_to_tcp().await;
+	HostBridge::new(pool, host_addr).vsock_to_tcp();
 	wait_for_usock(APP_USOCK).await;
 
 	let mut stream = Stream::new(&SocketAddress::new_unix(APP_USOCK));

--- a/src/integration/tests/reaper.rs
+++ b/src/integration/tests/reaper.rs
@@ -259,7 +259,7 @@ async fn reaper_handles_bridge() {
 		SocketAddrV4::new(Ipv4Addr::LOCALHOST, host_port).into();
 	let app_pool =
 		StreamPool::single(SocketAddress::new_unix(&app_usock)).unwrap();
-	HostBridge::new(app_pool, host_addr).tcp_to_vsock().await;
+	HostBridge::new(app_pool, host_addr).tcp_to_vsock();
 
 	// Make sure we have written everything necessary to pivot, except the
 	// quorum key

--- a/src/qos_bridge/src/cli.rs
+++ b/src/qos_bridge/src/cli.rs
@@ -75,6 +75,7 @@ impl HostOpts {
 	}
 
 	/// Create a new `StreamPool` using the list of `SocketAddress` for the qos host.
+	#[cfg_attr(not(feature = "vm"), allow(clippy::unnecessary_wraps))]
 	pub(crate) fn enclave_socket(&self) -> Result<SocketAddress, IOError> {
 		match (self.parsed.single(CID), self.parsed.single(USOCK)) {
 			#[cfg(feature = "vm")]

--- a/src/qos_bridge/src/host.rs
+++ b/src/qos_bridge/src/host.rs
@@ -44,8 +44,7 @@ impl BridgeServer {
 						.manifest_envelope
 					{
 						break self
-							.run_bridges(&me.manifest.pivot.bridge_config)
-							.await;
+							.run_bridges(&me.manifest.pivot.bridge_config);
 					}
 				}
 				Err(err) => eprintln!("unable to query enclave: {err}"),
@@ -61,7 +60,7 @@ impl BridgeServer {
 		self.host_port_override.unwrap_or(port)
 	}
 
-	async fn run_bridges(&self, configs: &Vec<BridgeConfig>) {
+	fn run_bridges(&self, configs: &Vec<BridgeConfig>) {
 		for config in configs {
 			let (host_port, host_ip_str) = match config {
 				BridgeConfig::Client { port: _, host: _ } => {
@@ -99,7 +98,7 @@ impl BridgeServer {
 			};
 			let host_addr = SocketAddr::new(host_ip.into(), host_port);
 
-			HostBridge::new(app_pool, host_addr).tcp_to_vsock().await;
+			HostBridge::new(app_pool, host_addr).tcp_to_vsock();
 		}
 	}
 }

--- a/src/qos_client/src/cli/mod.rs
+++ b/src/qos_client/src/cli/mod.rs
@@ -1718,7 +1718,7 @@ mod handlers {
 			opts.restart_policy(),
 			opts.pivot_args(),
 			opts.bridge_config(),
-			opts.unsafe_eph_path_override(),
+			opts.unsafe_eph_path_override().as_deref(),
 		);
 	}
 

--- a/src/qos_client/src/cli/services.rs
+++ b/src/qos_client/src/cli/services.rs
@@ -1689,7 +1689,7 @@ pub(crate) fn dangerous_dev_boot<P: AsRef<Path>>(
 	restart: RestartPolicy,
 	args: Vec<String>,
 	host_config: Vec<BridgeConfig>,
-	unsafe_eph_path_override: Option<String>,
+	unsafe_eph_path_override: Option<&str>,
 ) {
 	// Generate a quorum key
 	let quorum_pair = P256Pair::generate().expect("Failed P256 key gen");
@@ -1779,9 +1779,7 @@ pub(crate) fn dangerous_dev_boot<P: AsRef<Path>>(
 	};
 
 	// Pull out the ephemeral key or use the override
-	let eph_pub: P256Public = if let Some(ref eph_path) =
-		unsafe_eph_path_override
-	{
+	let eph_pub: P256Public = if let Some(eph_path) = unsafe_eph_path_override {
 		P256Pair::from_hex_file(eph_path)
 			.unwrap_or_else(|e| panic!("dangerous_dev_boot: Could not read ephemeral key from {eph_path:?}: {e:?}"))
 			.public_key()

--- a/src/qos_client/src/cli/services.rs
+++ b/src/qos_client/src/cli/services.rs
@@ -197,7 +197,7 @@ impl PairOrYubi {
 	///
 	/// # Errors
 	///
-	/// Returns [`Error`] if the YubiKey cannot be opened, the PIN cannot
+	/// Returns [`Error`] if the `YubiKey` cannot be opened, the PIN cannot
 	/// be read, or the secret file is invalid.
 	#[allow(clippy::missing_panics_doc)]
 	pub fn from_inputs(
@@ -382,7 +382,7 @@ pub(crate) fn pin_from_path<P: AsRef<Path>>(path: P) -> Vec<u8> {
 ///
 /// # Errors
 ///
-/// Returns [`Error`] if the YubiKey cannot be opened, the PIN cannot be
+/// Returns [`Error`] if the `YubiKey` cannot be opened, the PIN cannot be
 /// read, or provisioning fails.
 #[cfg(feature = "smartcard")]
 pub fn advanced_provision_yubikey<P: AsRef<Path>>(

--- a/src/qos_client/src/cli/services.rs
+++ b/src/qos_client/src/cli/services.rs
@@ -580,7 +580,7 @@ pub(crate) fn verify_genesis<P: AsRef<Path>>(
 	let genesis_output_path = namespace_dir.as_ref().join(GENESIS_OUTPUT_FILE);
 	let genesis_output = GenesisOutput::try_from_slice(
 		&fs::read(&genesis_output_path).unwrap_or_else(|e| {
-			panic!("verify_genesis: Could not read genesis output from {genesis_output_path:?}: {e}")
+			panic!("verify_genesis: Could not read genesis output from {}: {e}", genesis_output_path.display())
 		}),
 	)
 	.expect(
@@ -588,11 +588,18 @@ pub(crate) fn verify_genesis<P: AsRef<Path>>(
 	);
 
 	let master_seed_path = master_seed_path.as_ref();
-	let master_seed_hex = fs::read_to_string(master_seed_path).unwrap_or_else(|e| {
-		panic!("verify_genesis: Could not read master seed from {master_seed_path:?}: {e}")
-	});
+	let master_seed_hex =
+		fs::read_to_string(master_seed_path).unwrap_or_else(|e| {
+			panic!(
+				"verify_genesis: Could not read master seed from {}: {e}",
+				master_seed_path.display()
+			)
+		});
 	let pair = P256Pair::from_hex_file(master_seed_path).unwrap_or_else(|e| {
-		panic!("verify_genesis: Could not parse master seed from {master_seed_path:?}: {e:?}")
+		panic!(
+			"verify_genesis: Could not parse master seed from {}: {e:?}",
+			master_seed_path.display()
+		)
 	});
 
 	// sanity check our logic to read in master seed
@@ -664,7 +671,10 @@ pub(crate) fn after_genesis<P: AsRef<Path>>(
 
 	// Read in the attestation doc from the genesis directory
 	let cose_sign1 = fs::read(&attestation_doc_path).unwrap_or_else(|e| {
-		panic!("after_genesis: Could not read attestation doc from {attestation_doc_path:?}: {e}")
+		panic!(
+			"after_genesis: Could not read attestation doc from {}: {e}",
+			attestation_doc_path.display()
+		)
 	});
 	let attestation_doc = extract_attestation_doc(
 		&cose_sign1,
@@ -675,7 +685,10 @@ pub(crate) fn after_genesis<P: AsRef<Path>>(
 	// Read in the genesis output from the genesis directory
 	let genesis_output = GenesisOutput::try_from_slice(
 		&fs::read(&genesis_set_path).unwrap_or_else(|e| {
-			panic!("after_genesis: Could not read genesis output from {genesis_set_path:?}: {e}")
+			panic!(
+				"after_genesis: Could not read genesis output from {}: {e}",
+				genesis_set_path.display()
+			)
 		}),
 	)
 	.expect("after_genesis: Could not deserialize the genesis output");
@@ -1699,7 +1712,10 @@ pub(crate) fn dangerous_dev_boot<P: AsRef<Path>>(
 	// Read in the pivot
 	let pivot_path = pivot_path.as_ref();
 	let pivot = fs::read(pivot_path).unwrap_or_else(|e| {
-		panic!("dangerous_dev_boot: Could not read pivot binary from {pivot_path:?}: {e}")
+		panic!(
+			"dangerous_dev_boot: Could not read pivot binary from {}: {e}",
+			pivot_path.display()
+		)
 	});
 
 	let mock_pcr = vec![0; 48];
@@ -1937,7 +1953,10 @@ fn get_share_set<P: AsRef<Path>>(dir: P) -> ShareSet {
 			}
 
 			let public = P256Public::from_hex_file(path).unwrap_or_else(|e| {
-				panic!("get_share_set: Could not read public key from {path:?}: {e:?}")
+				panic!(
+					"get_share_set: Could not read public key from {}: {e:?}",
+					path.display()
+				)
 			});
 			Some(QuorumMember {
 				alias: mem::take(&mut file_name[0]),
@@ -1962,7 +1981,7 @@ fn get_manifest_set<P: AsRef<Path>>(dir: P) -> ManifestSet {
 			}
 
 			let public = P256Public::from_hex_file(path).unwrap_or_else(|e| {
-				panic!("get_manifest_set: Could not read public key from {path:?}: {e:?}")
+				panic!("get_manifest_set: Could not read public key from {}: {e:?}", path.display())
 			});
 			Some(QuorumMember {
 				alias: mem::take(&mut file_name[0]),
@@ -1987,7 +2006,10 @@ fn get_patch_set<P: AsRef<Path>>(dir: P) -> PatchSet {
 			}
 
 			let public = P256Public::from_hex_file(path).unwrap_or_else(|e| {
-				panic!("get_patch_set: Could not read public key from {path:?}: {e:?}")
+				panic!(
+					"get_patch_set: Could not read public key from {}: {e:?}",
+					path.display()
+				)
 			});
 			Some(MemberPubKey { pub_key: public.to_bytes() })
 		})
@@ -2010,7 +2032,10 @@ fn get_genesis_set<P: AsRef<Path>>(dir: P) -> GenesisSet {
 
 			let public = P256Public::from_hex_file(path)
 				.map_err(|e| {
-					panic!("Could not read hex from share_key.pub: {path:?}: {e:?}")
+					panic!(
+						"Could not read hex from share_key.pub: {}: {e:?}",
+						path.display()
+					)
 				})
 				.unwrap();
 
@@ -2042,10 +2067,10 @@ fn find_approvals<P: AsRef<Path>>(
 
 			let approval: Approval =
 				serde_json::from_slice(&fs::read(path).unwrap_or_else(|e| {
-					panic!("find_approvals: Could not read approval from {path:?}: {e}")
+					panic!("find_approvals: Could not read approval from {}: {e}", path.display())
 				}))
 				.unwrap_or_else(|e| {
-					panic!("find_approvals: Could not deserialize approval from {path:?}: {e}")
+					panic!("find_approvals: Could not deserialize approval from {}: {e}", path.display())
 				});
 
 			assert!(

--- a/src/qos_client/src/cli/services.rs
+++ b/src/qos_client/src/cli/services.rs
@@ -193,7 +193,12 @@ pub enum PairOrYubi {
 }
 
 impl PairOrYubi {
-	/// Create a P256 key pair or yubikey from the given inputs
+	/// Create a P256 key pair or yubikey from the given inputs.
+	///
+	/// # Errors
+	///
+	/// Returns [`Error`] if the YubiKey cannot be opened, the PIN cannot
+	/// be read, or the secret file is invalid.
 	#[allow(clippy::missing_panics_doc)]
 	pub fn from_inputs(
 		yubikey_flag: bool,
@@ -235,7 +240,11 @@ impl PairOrYubi {
 		Ok(result)
 	}
 
-	/// Sign the payload
+	/// Sign the payload.
+	///
+	/// # Errors
+	///
+	/// Returns [`Error`] if signing fails.
 	pub fn sign(&mut self, data: &[u8]) -> Result<Vec<u8>, Error> {
 		match self {
 			#[cfg(feature = "smartcard")]
@@ -247,7 +256,11 @@ impl PairOrYubi {
 		}
 	}
 
-	/// Decrypt the payload
+	/// Decrypt the payload.
+	///
+	/// # Errors
+	///
+	/// Returns [`Error`] if decryption fails.
 	pub fn decrypt(&mut self, payload: &[u8]) -> Result<Vec<u8>, Error> {
 		match self {
 			#[cfg(feature = "smartcard")]
@@ -268,7 +281,11 @@ impl PairOrYubi {
 		}
 	}
 
-	/// Get the public key in bytes
+	/// Get the public key in bytes.
+	///
+	/// # Errors
+	///
+	/// Returns [`Error`] if the public key cannot be read.
 	pub fn public_key_bytes(&mut self) -> Result<Vec<u8>, Error> {
 		match self {
 			#[cfg(feature = "smartcard")]
@@ -361,7 +378,12 @@ pub(crate) fn pin_from_path<P: AsRef<Path>>(path: P) -> Vec<u8> {
 		.to_vec()
 }
 
-/// Provision a yubikey from a pre-generated master seed
+/// Provision a yubikey from a pre-generated master seed.
+///
+/// # Errors
+///
+/// Returns [`Error`] if the YubiKey cannot be opened, the PIN cannot be
+/// read, or provisioning fails.
 #[cfg(feature = "smartcard")]
 pub fn advanced_provision_yubikey<P: AsRef<Path>>(
 	master_seed_path: P,

--- a/src/qos_client/src/lib.rs
+++ b/src/qos_client/src/lib.rs
@@ -15,6 +15,11 @@ pub mod request {
 
 	/// Post a [`qos_core::protocol::msg::ProtocolMsg`] to the given host `url`.
 	///
+	/// # Errors
+	///
+	/// Returns an error string if the HTTP request fails, the response
+	/// cannot be read, or deserialization fails.
+	///
 	/// # Panics
 	/// Panics if the `msg` cannot be Borsh serialized.
 	/// Should never happen in practice because all protocol messages are
@@ -54,6 +59,10 @@ pub mod request {
 	}
 
 	/// Get the resource at the given host `url`.
+	///
+	/// # Errors
+	///
+	/// Returns an error string if the response body cannot be read.
 	///
 	/// # Panics
 	///

--- a/src/qos_client/src/yubikey.rs
+++ b/src/qos_client/src/yubikey.rs
@@ -91,6 +91,11 @@ impl From<der::Error> for YubiKeyError {
 ///
 /// Returns the public key as an uncompressed encoded point.
 ///
+/// # Errors
+///
+/// Returns [`YubiKeyError`] if PIN verification, key generation, or
+/// certificate creation fails, or if the slot is already occupied.
+///
 /// # Panics
 /// Panics if the `OsRng` is unable to provide data, which shouldn't happen in normal operation.
 pub fn generate_signed_certificate(
@@ -140,6 +145,11 @@ pub fn generate_signed_certificate(
 
 /// Import the given `key_data` onto the `yubikey` and create a signed
 /// certificate for the key.
+///
+/// # Errors
+///
+/// Returns [`YubiKeyError`] if PIN verification, key import, or
+/// certificate creation fails, or if the slot is already occupied.
 ///
 /// # Panics
 /// Panics if the `OsRng` is unable to provide data, which shouldn't happen in normal operation.
@@ -197,10 +207,15 @@ pub fn import_key_and_generate_signed_certificate(
 	Ok(())
 }
 
-/// Sign data with the yubikey and return the signature as a raw bytes.
+/// Sign data with the yubikey and return the signature as raw bytes.
+///
+/// # Errors
+///
+/// Returns [`YubiKeyError`] if the signing key cannot be found, PIN
+/// verification fails, or signature verification fails.
 ///
 /// # Panics
-/// Panics if `piv::sign_data` doesn't return a valid DER signature
+/// Panics if `piv::sign_data` doesn't return a valid DER signature.
 pub fn sign_data(
 	yubikey: &mut YubiKey,
 	data: &[u8],
@@ -242,6 +257,10 @@ pub fn sign_data(
 ///
 /// `sender_public_key` is an uncompressed encoded point of the public key used
 /// by the sender to create the shared secret.
+///
+/// # Errors
+///
+/// Returns [`YubiKeyError`] if PIN verification or key agreement fails.
 pub fn key_agreement(
 	yubikey: &mut YubiKey,
 	sender_public_key: &[u8],
@@ -253,6 +272,11 @@ pub fn key_agreement(
 }
 
 /// Open the single connected yubikey.
+///
+/// # Errors
+///
+/// Returns [`YubiKeyError`] if no YubiKey is connected or it cannot be
+/// opened.
 pub fn open_single() -> Result<YubiKey, YubiKeyError> {
 	YubiKey::open().map_err(YubiKeyError::Connection)
 }
@@ -260,6 +284,11 @@ pub fn open_single() -> Result<YubiKey, YubiKeyError> {
 /// Get the public key from the yubikey that corresponds to
 /// `P256Public::to_bytes`. This is the key agree public key concatenated with
 /// the signature public key. Encodes as `encrypt_public||sign_public`.
+///
+/// # Errors
+///
+/// Returns [`YubiKeyError`] if the signing or key agreement certificate
+/// cannot be read.
 pub fn pair_public_key(yubikey: &mut YubiKey) -> Result<Vec<u8>, YubiKeyError> {
 	let signing_slot_cert = Certificate::read(yubikey, SIGNING_SLOT)
 		.map_err(|_| YubiKeyError::CannotFindSigningKey)?;
@@ -277,6 +306,11 @@ pub fn pair_public_key(yubikey: &mut YubiKey) -> Result<Vec<u8>, YubiKeyError> {
 }
 
 /// Get the public key on the key agree slot.
+///
+/// # Errors
+///
+/// Returns [`YubiKeyError`] if the key agreement certificate cannot be
+/// read.
 pub fn key_agree_public_key(
 	yubikey: &mut YubiKey,
 ) -> Result<Vec<u8>, YubiKeyError> {
@@ -293,6 +327,11 @@ pub fn key_agree_public_key(
 /// given `serialized_envelope`.
 ///
 /// Returns `(shared_secret, public_key_bytes)`.
+///
+/// # Errors
+///
+/// Returns [`YubiKeyError`] if the envelope cannot be deserialized or
+/// key agreement fails.
 pub fn shared_secret(
 	yubikey: &mut YubiKey,
 	serialized_envelope: &[u8],
@@ -309,6 +348,11 @@ pub fn shared_secret(
 }
 
 /// Change the PIV authorization PIN on the yubikey.
+///
+/// # Errors
+///
+/// Returns [`YubiKeyError`] if the YubiKey cannot be opened or the PIN
+/// change fails.
 pub fn yubikey_change_pin(
 	current_pin: &[u8],
 	new_pin: &[u8],
@@ -323,6 +367,10 @@ pub fn yubikey_change_pin(
 /// Reset the PIV app on the attached yubikey.
 ///
 /// **WARNING:** This will delete all private keys on the PIV app.
+///
+/// # Errors
+///
+/// Returns [`YubiKeyError`] if the YubiKey cannot be opened.
 pub fn yubikey_piv_reset() -> Result<(), YubiKeyError> {
 	let mut yubikey = open_single()?;
 	// Pins need to be blocked before device can be reset

--- a/src/qos_client/src/yubikey.rs
+++ b/src/qos_client/src/yubikey.rs
@@ -275,7 +275,7 @@ pub fn key_agreement(
 ///
 /// # Errors
 ///
-/// Returns [`YubiKeyError`] if no YubiKey is connected or it cannot be
+/// Returns [`YubiKeyError`] if no `YubiKey` is connected or it cannot be
 /// opened.
 pub fn open_single() -> Result<YubiKey, YubiKeyError> {
 	YubiKey::open().map_err(YubiKeyError::Connection)
@@ -351,7 +351,7 @@ pub fn shared_secret(
 ///
 /// # Errors
 ///
-/// Returns [`YubiKeyError`] if the YubiKey cannot be opened or the PIN
+/// Returns [`YubiKeyError`] if the `YubiKey` cannot be opened or the PIN
 /// change fails.
 pub fn yubikey_change_pin(
 	current_pin: &[u8],
@@ -370,7 +370,7 @@ pub fn yubikey_change_pin(
 ///
 /// # Errors
 ///
-/// Returns [`YubiKeyError`] if the YubiKey cannot be opened.
+/// Returns [`YubiKeyError`] if the `YubiKey` cannot be opened.
 pub fn yubikey_piv_reset() -> Result<(), YubiKeyError> {
 	let mut yubikey = open_single()?;
 	// Pins need to be blocked before device can be reset

--- a/src/qos_client/tests/yubikey.rs
+++ b/src/qos_client/tests/yubikey.rs
@@ -39,7 +39,7 @@ const DATA: &[u8] = b"test data";
 /// and pressing the Yubikey for confirmation while the tests are ongoing,
 /// otherwise they'll fail with timeout related errors.
 #[test]
-#[ignore]
+#[ignore = "See doc comment for use with YubiKey"]
 fn yubikey_tests() {
 	let mut yubikey = YubiKey::open()
 		.expect("A supported PIV smartcard should be present and accessible");

--- a/src/qos_core/src/cli.rs
+++ b/src/qos_core/src/cli.rs
@@ -48,6 +48,7 @@ impl EnclaveOpts {
 	}
 
 	/// Create a new `StreamSocket` for the qos host.
+	#[cfg_attr(not(feature = "vm"), allow(clippy::unnecessary_wraps))]
 	fn enclave_socket(&self) -> Result<SocketAddress, IOError> {
 		match (
 			self.parsed.single(CID),

--- a/src/qos_core/src/client.rs
+++ b/src/qos_core/src/client.rs
@@ -42,6 +42,10 @@ impl SocketClient {
 	}
 
 	/// Create a new client from a single `SocketAddress`. This creates an implicit single socket `StreamPool`.
+	///
+	/// # Errors
+	///
+	/// Returns [`IOError`] if the stream pool cannot be created.
 	pub fn single(
 		addr: SocketAddress,
 		timeout: Duration,
@@ -53,11 +57,16 @@ impl SocketClient {
 
 	/// Returns true if all callable streams are currently exhausted
 	pub async fn busy(&self) -> bool {
-		self.pool.read().await.busy().await
+		self.pool.read().await.busy()
 	}
 
 	/// Send raw bytes and wait for a response until the clients configured
 	/// timeout.
+	///
+	/// # Errors
+	///
+	/// Returns [`ClientError`] if the request times out, the connection
+	/// fails, or serialization errors occur.
 	pub async fn call(&self, request: &[u8]) -> Result<Vec<u8>, ClientError> {
 		let pool = self.pool.read().await;
 
@@ -81,7 +90,11 @@ impl SocketClient {
 		self.timeout = timeout;
 	}
 
-	/// Expands the underlying `AsyncPool` to given `pool_size`
+	/// Expands the underlying `AsyncPool` to given `pool_size`.
+	///
+	/// # Errors
+	///
+	/// Returns [`ClientError`] if the pool expansion fails.
 	pub async fn expand_to(
 		&mut self,
 		pool_size: u8,
@@ -91,7 +104,11 @@ impl SocketClient {
 		Ok(())
 	}
 
-	/// Attempt a one-off connection, used for tests
+	/// Attempt a one-off connection, used for tests.
+	///
+	/// # Errors
+	///
+	/// Returns [`IOError`] if the connection fails.
 	pub async fn try_connect(&self) -> Result<(), IOError> {
 		let pool = self.pool.read().await;
 		let mut stream = pool.get().await;

--- a/src/qos_core/src/handles.rs
+++ b/src/qos_core/src/handles.rs
@@ -256,6 +256,11 @@ impl Handles {
 	}
 
 	/// Put the Pivot binary, ensuring it is an executable.
+	///
+	/// # Errors
+	///
+	/// Returns [`ProtocolError`] if the pivot already exists, the
+	/// directory cannot be created, or the file cannot be written.
 	pub fn put_pivot(&self, pivot: &[u8]) -> Result<(), ProtocolError> {
 		if Path::new(&self.pivot).exists() {
 			Err(ProtocolError::CannotModifyPostPivotStatic)?;

--- a/src/qos_core/src/io/host_bridge.rs
+++ b/src/qos_core/src/io/host_bridge.rs
@@ -36,7 +36,7 @@ impl HostBridge {
 	/// Create a TCP to VSOCK bridge using the provided `StreamPool` and `SocketAddr` from constructor.
 	/// This consumes the `HostBridge` instance and starts background tasks that only return on unrecoverable errors.
 	/// NOTE: this spawns a standalone tasks and *DOES NOT WAIT* for completion.
-	pub async fn tcp_to_vsock(self) {
+	pub fn tcp_to_vsock(self) {
 		println!("starting tcp to vsock host bridge @ {}", self.host_addr);
 		tokio::spawn(async move {
 			let streams = self.stream_pool.to_streams();
@@ -54,10 +54,17 @@ impl HostBridge {
 		});
 	}
 
-	/// Create a VSOCK to TCP bridge using the provided `StreamPool` and `SocketAddr` from constructor.
-	/// This consumes the `HostBridge` instance and starts background tasks that only return on unrecoverable errors.
-	/// NOTE: this spawns a standalone tasks and *DOES NOT WAIT* for completion.
-	pub async fn vsock_to_tcp(self) {
+	/// Create a VSOCK to TCP bridge using the provided `StreamPool` and
+	/// `SocketAddr` from constructor. This consumes the `HostBridge`
+	/// instance and starts background tasks that only return on
+	/// unrecoverable errors.
+	/// NOTE: this spawns a standalone tasks and *DOES NOT WAIT* for
+	/// completion.
+	///
+	/// # Panics
+	///
+	/// Panics if the stream pool fails to bind its listeners.
+	pub fn vsock_to_tcp(self) {
 		println!("starting vsock to tcp host bridge @ {}", self.host_addr);
 		tokio::spawn(async move {
 			let listeners = self

--- a/src/qos_core/src/io/mod.rs
+++ b/src/qos_core/src/io/mod.rs
@@ -171,9 +171,14 @@ impl SocketAddress {
 		}
 	}
 
-	/// Returns anew `SocketAddress` depending on socket type:
-	/// If VSOCK, the same CID is used with the provided port
-	/// If USOCK, the "<port>.appsock" suffix is added
+	/// Returns a new `SocketAddress` depending on socket type:
+	/// If VSOCK, the same CID is used with the provided port.
+	/// If USOCK, the "<port>.appsock" suffix is added.
+	///
+	/// # Errors
+	///
+	/// Returns [`IOError::ConnectAddressInvalid`] if the Unix socket path
+	/// cannot be resolved.
 	#[allow(unused)]
 	pub fn with_port(&self, port: u16) -> Result<SocketAddress, IOError> {
 		match self {

--- a/src/qos_core/src/io/pool.rs
+++ b/src/qos_core/src/io/pool.rs
@@ -62,7 +62,13 @@ impl std::ops::DerefMut for PoolGuard<'_> {
 }
 
 impl StreamPool {
-	/// Create a new `StreamPool` with given starting `SocketAddress`, timeout and number of addresses to populate.
+	/// Create a new `StreamPool` with given starting `SocketAddress`, timeout
+	/// and number of addresses to populate.
+	///
+	/// # Errors
+	///
+	/// Returns [`IOError::PoolError`] if `count` is zero, or [`IOError`] if
+	/// computing the next address fails.
 	pub fn new(
 		start_address: SocketAddress,
 		mut count: u8,
@@ -89,6 +95,10 @@ impl StreamPool {
 	}
 
 	/// Create a single address pool.
+	///
+	/// # Errors
+	///
+	/// Returns [`IOError`] if pool creation fails.
 	pub fn single(address: SocketAddress) -> Result<Self, IOError> {
 		Self::new(address, 1)
 	}
@@ -125,8 +135,9 @@ impl StreamPool {
 		self.len() == 0
 	}
 
-	/// Returns true if all callable streams are currently exhausted
-	pub async fn busy(&self) -> bool {
+	/// Returns true if all callable streams are currently exhausted.
+	#[must_use]
+	pub fn busy(&self) -> bool {
 		for h in &self.handles {
 			if h.try_lock().is_ok() {
 				return false;
@@ -158,7 +169,12 @@ impl StreamPool {
 		PoolGuard::new(guard)
 	}
 
-	/// Create a new pool by listening for new connection on all the addresses
+	/// Create a new pool by listening for new connections on all the
+	/// addresses.
+	///
+	/// # Errors
+	///
+	/// Returns [`IOError`] if binding a listener fails.
 	pub fn listen(&self) -> Result<Vec<Listener>, IOError> {
 		let mut listeners = Vec::new();
 
@@ -171,7 +187,12 @@ impl StreamPool {
 		Ok(listeners)
 	}
 
-	/// Expands the pool with new addresses using `SocketAddress::next_address`
+	/// Expands the pool with new addresses using
+	/// `SocketAddress::next_address`.
+	///
+	/// # Errors
+	///
+	/// Returns [`IOError`] if computing the next address fails.
 	pub fn expand_to(&mut self, size: u8) -> Result<(), IOError> {
 		println!("StreamPool: expanding async pool to {size}");
 		let size = size as usize;
@@ -190,7 +211,13 @@ impl StreamPool {
 		Ok(())
 	}
 
-	/// Listen to new connections on added sockets on top of existing listeners, returning the list of new `Listener`
+	/// Listen to new connections on added sockets on top of existing
+	/// listeners, returning the list of new `Listener`s.
+	///
+	/// # Errors
+	///
+	/// Returns [`IOError`] if computing the next address or binding a
+	/// listener fails.
 	pub fn listen_to(&mut self, size: u8) -> Result<Vec<Listener>, IOError> {
 		println!("StreamPool: listening async pool to {size}");
 		let size = size as usize;

--- a/src/qos_core/src/io/stream.rs
+++ b/src/qos_core/src/io/stream.rs
@@ -64,8 +64,13 @@ impl Stream {
 		Self { address: Some(address.clone()), inner: None }
 	}
 
-	/// Connect `Stream` to `SocketAddress`
+	/// Connect `Stream` to `SocketAddress`.
 	/// Sets `inner` to the new stream.
+	///
+	/// # Errors
+	///
+	/// Returns [`IOError`] if the address is invalid or the connection
+	/// fails.
 	pub async fn connect(&mut self) -> Result<(), IOError> {
 		let addr = self.address()?;
 
@@ -86,7 +91,13 @@ impl Stream {
 		Ok(())
 	}
 
-	/// Reconnects this `Stream` by calling `connect` again on the underlaying socket
+	/// Reconnects this `Stream` by calling `connect` again on the underlying
+	/// socket.
+	///
+	/// # Errors
+	///
+	/// Returns [`IOError`] if the address is invalid or the connection
+	/// fails.
 	pub async fn reconnect(&mut self) -> Result<(), IOError> {
 		let addr = self.address()?.clone();
 
@@ -102,7 +113,12 @@ impl Stream {
 		Ok(())
 	}
 
-	/// Sends a buffer over the underlying socket using async
+	/// Sends a buffer over the underlying socket using async.
+	///
+	/// # Errors
+	///
+	/// Returns [`IOError`] if the stream is disconnected or the write
+	/// fails.
 	pub async fn send(&mut self, buf: &[u8]) -> Result<(), IOError> {
 		match &mut self.inner_mut()? {
 			InnerStream::Unix(ref mut s) => send(s, buf).await,
@@ -111,7 +127,11 @@ impl Stream {
 		}
 	}
 
-	/// Receive from the underlying socket using async
+	/// Receive from the underlying socket using async.
+	///
+	/// # Errors
+	///
+	/// Returns [`IOError`] if the stream is disconnected or the read fails.
 	pub async fn recv(&mut self) -> Result<Vec<u8>, IOError> {
 		match &mut self.inner_mut()? {
 			InnerStream::Unix(ref mut s) => recv(s).await,
@@ -120,7 +140,12 @@ impl Stream {
 		}
 	}
 
-	/// Perform a "call" by sending the `req_buf` bytes and waiting for reply on the same socket.
+	/// Perform a "call" by sending the `req_buf` bytes and waiting for a
+	/// reply on the same socket.
+	///
+	/// # Errors
+	///
+	/// Returns [`IOError`] if connecting, sending, or receiving fails.
 	pub async fn call(&mut self, req_buf: &[u8]) -> Result<Vec<u8>, IOError> {
 		// first time? connect
 		if self.inner.is_none() {
@@ -133,7 +158,11 @@ impl Stream {
 		self.recv().await
 	}
 
-	/// Get the address of the socket or error out in case it's invalid
+	/// Get the address of the socket or error out in case it's invalid.
+	///
+	/// # Errors
+	///
+	/// Returns [`IOError::ConnectAddressInvalid`] if no address is set.
 	pub fn address(&self) -> Result<&SocketAddress, IOError> {
 		self.address.as_ref().ok_or(IOError::ConnectAddressInvalid)
 	}
@@ -159,6 +188,10 @@ async fn send<S: AsyncWriteExt + Unpin>(
 	stream: &mut S,
 	buf: &[u8],
 ) -> Result<(), IOError> {
+	// NOTE: due to this kernel bug: https://github.com/cloud-hypervisor/cloud-hypervisor/issues/7672
+	// we need to write in chunks of < 32kiB each
+	const MAX_WRITE_SIZE: usize = 31234;
+
 	let length = buf.len();
 
 	if length > MAX_PAYLOAD_SIZE {
@@ -172,9 +205,6 @@ async fn send<S: AsyncWriteExt + Unpin>(
 	stream.write_all(&len_buf).await?;
 
 	// Send the actual contents of the buffer
-	// NOTE: due to this kernel bug: https://github.com/cloud-hypervisor/cloud-hypervisor/issues/7672
-	// we need to write in chunks of < 32kiB each
-	const MAX_WRITE_SIZE: usize = 31234;
 	let mut total = 0;
 
 	while total < length {
@@ -312,6 +342,10 @@ impl Listener {
 	}
 
 	/// Accept a new connection.
+	///
+	/// # Errors
+	///
+	/// Returns [`IOError`] if accepting the connection fails.
 	pub async fn accept(&self) -> Result<Stream, IOError> {
 		let stream = match &self.inner {
 			InnerListener::Unix(l) => {

--- a/src/qos_core/src/parser.rs
+++ b/src/qos_core/src/parser.rs
@@ -60,6 +60,11 @@ pub struct OptionsParser<T: GetParserForOptions> {
 
 impl<T: GetParserForOptions> OptionsParser<T> {
 	/// Parse inputs for `C`.
+	///
+	/// # Errors
+	///
+	/// Returns [`ParserError`] if a required token is missing or an input
+	/// is invalid.
 	pub fn parse(inputs: &mut Vec<String>) -> Result<Parser, ParserError> {
 		// Check if the first element is binary name before removing it
 		if !inputs.is_empty() && !inputs[0].starts_with(INPUT_PREFIX) {
@@ -93,6 +98,11 @@ pub struct CommandParser<C: From<String> + GetParserForCommand> {
 
 impl<C: From<String> + GetParserForCommand> CommandParser<C> {
 	/// Parse inputs for the command `C`.
+	///
+	/// # Errors
+	///
+	/// Returns [`ParserError`] if the command is missing or unrecognized,
+	/// or if a required token is missing or an input is invalid.
 	pub fn parse(inputs: &mut Vec<String>) -> Result<(C, Parser), ParserError> {
 		let command = Self::extract_command(inputs)?;
 		let mut parser = command.parser();
@@ -190,6 +200,11 @@ impl Parser {
 
 	/// Parse the command line arguments. Instead of using this directly it is
 	/// preferred to use [`OptionsParser`] or [`CommandParser`].
+	///
+	/// # Errors
+	///
+	/// Returns [`ParserError`] if a required token is missing or an input
+	/// is invalid.
 	///
 	/// # Note
 	///

--- a/src/qos_core/src/protocol/error.rs
+++ b/src/qos_core/src/protocol/error.rs
@@ -225,6 +225,7 @@ impl From<qos_nsm::nitro::AttestError> for ProtocolError {
 }
 
 impl std::fmt::Display for ProtocolError {
+	#[allow(clippy::too_many_lines)]
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {
 			Self::InvalidShare => write!(f, "invalid quorum key share"),

--- a/src/qos_core/src/protocol/services/boot.rs
+++ b/src/qos_core/src/protocol/services/boot.rs
@@ -239,11 +239,13 @@ impl From<PivotConfigV0> for PivotConfig {
 
 impl fmt::Debug for PivotConfig {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		let Self { hash, restart, bridge_config: _, debug_mode: _, args, env } =
+			self;
 		f.debug_struct("PivotConfig")
-			.field("hash", &qos_hex::encode(&self.hash))
-			.field("restart", &self.restart)
-			.field("args", &self.args.join(" "))
-			.field("env", &self.env)
+			.field("hash", &qos_hex::encode(hash))
+			.field("restart", restart)
+			.field("args", &args.join(" "))
+			.field("env", env)
 			.finish()
 	}
 }
@@ -487,6 +489,11 @@ impl Manifest {
 	/// fields that `ManifestV0` ignores. In-tree callers avoid that by going
 	/// through `read_manifest`, which tries the current `Manifest` JSON parse
 	/// before falling back here.
+	///
+	/// # Errors
+	///
+	/// Returns [`borsh::io::Error`] if deserialization fails for both the
+	/// current and legacy formats.
 	pub fn try_from_slice_compat(buf: &[u8]) -> Result<Self, borsh::io::Error> {
 		use borsh::BorshDeserialize;
 
@@ -589,6 +596,15 @@ pub struct ManifestEnvelopeV0 {
 impl ManifestEnvelope {
 	/// Check if the encapsulated manifest has K valid approvals from the
 	/// manifest approval set.
+	///
+	/// # Errors
+	///
+	/// Returns [`ProtocolError::InvalidManifestApproval`] if a signature is
+	/// invalid, [`ProtocolError::NotManifestSetMember`] if an approver is
+	/// not in the manifest set, [`ProtocolError::DuplicateApproval`] if a
+	/// member has more than one approval, or
+	/// [`ProtocolError::NotEnoughApprovals`] if fewer than the threshold
+	/// number of members approved.
 	pub fn check_approvals(&self) -> Result<(), ProtocolError> {
 		let mut uniq_members = HashSet::new();
 		for approval in &self.manifest_set_approvals {
@@ -626,7 +642,13 @@ impl ManifestEnvelope {
 
 		Ok(())
 	}
-	/// Read a `ManifestEnvelope` from a `u8` buffer, in a backwards compatible way
+	/// Read a `ManifestEnvelope` from a `u8` buffer, in a backwards
+	/// compatible way.
+	///
+	/// # Errors
+	///
+	/// Returns [`borsh::io::Error`] if deserialization fails for both the
+	/// current and legacy formats.
 	pub fn try_from_slice_compat(buf: &[u8]) -> Result<Self, borsh::io::Error> {
 		use borsh::BorshDeserialize;
 

--- a/src/qos_core/src/protocol/services/boot/env.rs
+++ b/src/qos_core/src/protocol/services/boot/env.rs
@@ -31,6 +31,11 @@ pub struct PivotEnvVarName(String);
 
 impl PivotEnvVarName {
 	/// Parse and validate an environment variable name.
+	///
+	/// # Errors
+	///
+	/// Returns [`ProtocolError::InvalidPivotEnv`] if the name is empty,
+	/// too long, or contains invalid characters.
 	pub fn new(name: String) -> Result<Self, ProtocolError> {
 		if name.len() > MAX_PIVOT_ENV_NAME_LEN {
 			return Err(ProtocolError::InvalidPivotEnv(format!(
@@ -119,6 +124,11 @@ pub struct PivotEnvPlainValue(String);
 
 impl PivotEnvPlainValue {
 	/// Parse and validate a plain environment variable value.
+	///
+	/// # Errors
+	///
+	/// Returns [`ProtocolError::InvalidPivotEnv`] if the value contains
+	/// NUL bytes or exceeds the maximum length.
 	pub fn new(value: String) -> Result<Self, ProtocolError> {
 		if value.contains('\0') {
 			return Err(ProtocolError::InvalidPivotEnv(
@@ -210,6 +220,11 @@ pub enum PivotEnvValue {
 
 impl PivotEnvValue {
 	/// Parse and validate a plain environment variable value.
+	///
+	/// # Errors
+	///
+	/// Returns [`ProtocolError::InvalidPivotEnv`] if the value is
+	/// invalid.
 	pub fn plain(value: String) -> Result<Self, ProtocolError> {
 		Ok(Self::Plain { value: PivotEnvPlainValue::try_from(value)? })
 	}
@@ -279,6 +294,11 @@ impl PivotEnv {
 	}
 
 	/// Insert an environment variable.
+	///
+	/// # Errors
+	///
+	/// Returns [`ProtocolError::InvalidPivotEnv`] if inserting the
+	/// variable would exceed the collection limits.
 	pub fn insert(
 		&mut self,
 		name: PivotEnvVarName,

--- a/src/qos_core/src/protocol/state.rs
+++ b/src/qos_core/src/protocol/state.rs
@@ -194,7 +194,7 @@ impl ProtocolState {
 	pub fn handle_msg(&mut self, msg_req: &ProtocolMsg) -> Vec<u8> {
 		for route in &self.routes() {
 			match route.try_msg(msg_req, self) {
-				None => continue,
+				None => (),
 				Some(result) => match result {
 					Ok(msg_resp) | Err(msg_resp) => {
 						return borsh::to_vec(&msg_resp).expect(

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -69,7 +69,7 @@ async fn run_server(
 // runs the VSOCK -> TCP bridge so that apps can use any TCP based protocol without worrying about VSOCK
 // communication. This is started if `PivotConfig::bridge_config` has any members defined.
 // uses the enclave core socket and given pivot host port to constuct the VSOCK to TCP bridge.
-async fn run_vsock_to_tcp_bridge(
+fn run_vsock_to_tcp_bridge(
 	core_socket: &SocketAddress,
 	bridges: &Vec<BridgeConfig>,
 ) -> Result<(), IOError> {
@@ -88,7 +88,7 @@ async fn run_vsock_to_tcp_bridge(
 				let app_pool = StreamPool::single(app_socket)?;
 				let bridge = HostBridge::new(app_pool, host_addr);
 
-				bridge.vsock_to_tcp().await;
+				bridge.vsock_to_tcp();
 			}
 			BridgeConfig::Client { port: _, host: _ } => {
 				panic!("client bridge unimplemented")
@@ -99,7 +99,7 @@ async fn run_vsock_to_tcp_bridge(
 	Ok(())
 }
 
-async fn reprint_pivot_output(child: &mut Child) {
+fn reprint_pivot_output(child: &mut Child) {
 	let stdout = child.stdout.take().expect("failed to get pivot stdout");
 	let stderr = child.stderr.take().expect("failed to get pivot stderr");
 
@@ -196,7 +196,6 @@ impl Reaper {
 
 		// if the app indicates the need for the VSOCK -> TCP bridge, run it as another task
 		run_vsock_to_tcp_bridge(&core_socket, &host_config)
-			.await
 			.expect("failed to run VSOCK -> TCP socket bridge");
 
 		let mut pivot = Command::new(handles.pivot_path());
@@ -215,7 +214,7 @@ impl Reaper {
 			// print pivot stderr and stdout if in debug mode
 			// *NOTE*: this requires `DEBUG` and `LOGS` env vars set when booting the enclave itself. If not, nothing will be visible
 			if manifest.pivot.debug_mode {
-				reprint_pivot_output(&mut child).await;
+				reprint_pivot_output(&mut child);
 			}
 
 			let status =

--- a/src/qos_core/src/server.rs
+++ b/src/qos_core/src/server.rs
@@ -64,6 +64,10 @@ impl SocketServer {
 	/// `terminate` should be called on the server when execution is to be finished (e.g. ctrl+c handling)
 	/// The `max_connections` attribute limits how many accepted connections and running tasks can be handled concurrently
 	/// per each pool address.
+	///
+	/// # Errors
+	///
+	/// Returns [`SocketServerError`] if the pool fails to bind listeners.
 	pub fn listen_all<P>(
 		pool: StreamPool,
 		processor: P,
@@ -85,6 +89,10 @@ impl SocketServer {
 	}
 
 	/// Expand the server with listeners up to pool size. This adds new tasks as needed.
+	///
+	/// # Errors
+	///
+	/// Returns [`IOError`] if new listeners cannot be bound.
 	pub fn listen_to<P>(
 		&mut self,
 		pool_size: u8,
@@ -144,26 +152,39 @@ pub struct PermittedStream {
 impl PermittedStream {
 	/// Accept a connection from the listener, acquiring a permit from the
 	/// semaphore.
+	///
+	/// # Errors
+	///
+	/// Returns [`IOError`] if the permit cannot be acquired or the
+	/// connection cannot be accepted.
 	pub async fn accept(
 		listener: &Listener,
 		connections: Arc<Semaphore>,
 	) -> Result<Self, IOError> {
-		let _permit = connections
+		let permit = connections
 			.acquire_owned()
 			.await
 			.map_err(|_| IOError::UnknownError)?; // this really shouldn't happen since we never close the semaphore
 
 		let stream = listener.accept().await?;
 
-		Ok(PermittedStream { _permit, stream })
+		Ok(PermittedStream { _permit: permit, stream })
 	}
 
-	/// Perform a `Stream::send`
+	/// Perform a `Stream::send`.
+	///
+	/// # Errors
+	///
+	/// Returns [`IOError`] if the send fails.
 	pub async fn send(&mut self, value: &[u8]) -> Result<(), IOError> {
 		self.stream.send(value).await
 	}
 
-	/// Perform a `Stream::recv`
+	/// Perform a `Stream::recv`.
+	///
+	/// # Errors
+	///
+	/// Returns [`IOError`] if the receive fails.
 	pub async fn recv(&mut self) -> Result<Vec<u8>, IOError> {
 		self.stream.recv().await
 	}
@@ -210,13 +231,11 @@ where
 							}
 						}
 					}
-					Err(err) => match err {
-						IOError::RecvConnectionClosed => break, // expected as we reconnect after each request currently
-						_ => {
-							eprintln!("SocketServer: error receiving request {err:?}, re-accepting");
-							break;
-						}
-					},
+					Err(IOError::RecvConnectionClosed) => break,
+					Err(err) => {
+						eprintln!("SocketServer: error receiving request {err:?}, re-accepting");
+						break;
+					}
 				}
 			}
 		});

--- a/src/qos_crypto/src/shamir.rs
+++ b/src/qos_crypto/src/shamir.rs
@@ -9,6 +9,10 @@ use crate::QosCryptoError;
 /// Known limitations:
 /// threshold >= 2
 /// `share_count` <= 255
+///
+/// # Errors
+///
+/// Returns [`QosCryptoError::Vsss`] if the secret splitting fails.
 pub fn shares_generate(
 	secret: &[u8],
 	share_count: usize,
@@ -19,6 +23,10 @@ pub fn shares_generate(
 }
 
 /// Reconstruct our secret from the given `shares`.
+///
+/// # Errors
+///
+/// Returns [`QosCryptoError::Vsss`] if share reconstruction fails.
 pub fn shares_reconstruct<B: AsRef<[Vec<u8>]>>(
 	shares: B,
 ) -> Result<Vec<u8>, QosCryptoError> {

--- a/src/qos_hex/src/lib.rs
+++ b/src/qos_hex/src/lib.rs
@@ -226,7 +226,7 @@ from_hex_array_impl! {
 	32 33 34 64 65 66
 	128 256
 	384
-	512 768 1024 2048 4096 8192 16384 32768
+	512 768 1024 2048 4096 8192 16384
 }
 
 /// Serde support for hex encoding/decoding.

--- a/src/qos_hex/src/lib.rs
+++ b/src/qos_hex/src/lib.rs
@@ -89,6 +89,11 @@ fn verify_ascii(byte: u8) -> Result<(), HexError> {
 /// - if the input is an odd length
 /// - if a character is invalid hex
 /// - if the input is too long.
+///
+/// # Panics
+///
+/// Panics if validated ASCII bytes are not valid UTF-8, which should not
+/// happen.
 pub fn decode(raw_s: &str) -> Result<Vec<u8>, HexError> {
 	let sanitized_s = match raw_s.len() {
 		0 => return Ok(Vec::new()),
@@ -128,6 +133,16 @@ pub fn decode(raw_s: &str) -> Result<Vec<u8>, HexError> {
 
 /// Decode `raw_s` into a mutable buffer slice. Length of `buf` must exactly
 /// match the length of the bytes represented by `raw_s`.
+///
+/// # Errors
+///
+/// Returns [`HexError`] if the input is an odd length, contains non-hex
+/// characters, or does not match the buffer length.
+///
+/// # Panics
+///
+/// Panics if validated ASCII bytes are not valid UTF-8, which should not
+/// happen.
 pub fn decode_to_buf(raw_s: &str, buf: &mut [u8]) -> Result<(), HexError> {
 	let sanitized_s_bytes = match raw_s.len() {
 		0 => {
@@ -168,7 +183,12 @@ pub fn decode_to_buf(raw_s: &str, buf: &mut [u8]) -> Result<(), HexError> {
 	Ok(())
 }
 
-/// Decode bytes from a hex byte slice
+/// Decode bytes from a hex byte slice.
+///
+/// # Errors
+///
+/// Returns [`HexError::InvalidUtf8`] if the input is not valid UTF-8, or
+/// any [`HexError`] variant from [`decode`].
 pub fn decode_from_vec(vec: Vec<u8>) -> Result<Vec<u8>, HexError> {
 	let hex_string = String::from_utf8(vec).map_err(HexError::from)?;
 	let hex_string = hex_string.trim();
@@ -176,6 +196,11 @@ pub fn decode_from_vec(vec: Vec<u8>) -> Result<Vec<u8>, HexError> {
 }
 
 /// Encode a byte slice to hex string. Always encodes with lowercase characters.
+///
+/// # Panics
+///
+/// Panics if a byte value does not index into the hex lookup table, which
+/// should not happen since the table covers all 256 byte values.
 #[must_use]
 pub fn encode(bytes: &[u8]) -> String {
 	bytes
@@ -200,6 +225,10 @@ pub fn encode_to_vec(bytes: &[u8]) -> Vec<u8> {
 /// Implemented for some `u8` arrays and `Vec<u8>`.
 pub trait FromHex: Sized {
 	/// Creates an instance of `Self` from a hex string.
+	///
+	/// # Errors
+	///
+	/// Returns [`HexError`] if the hex string is invalid.
 	fn from_hex(raw_s: &str) -> Result<Self, HexError>;
 }
 
@@ -241,6 +270,10 @@ pub mod serde {
 	use super::{encode, FromHex};
 
 	/// Serialize bytes as a hex string.
+	///
+	/// # Errors
+	///
+	/// Returns the serializer's error type if serialization fails.
 	pub fn serialize<T, S>(bytes: T, serializer: S) -> Result<S::Ok, S::Error>
 	where
 		T: AsRef<[u8]>,
@@ -251,6 +284,11 @@ pub mod serde {
 	}
 
 	/// Deserialize a hex string into bytes.
+	///
+	/// # Errors
+	///
+	/// Returns the deserializer's error type if the input is not a valid hex
+	/// string.
 	pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
 	where
 		D: Deserializer<'de>,
@@ -438,7 +476,7 @@ mod test {
 	}
 
 	#[test]
-	#[ignore]
+	#[ignore = "long running test"]
 	fn decode_respects_max_len() {
 		// Accepts a string of exactly the correct length
 		let valid =

--- a/src/qos_hex/src/lib.rs
+++ b/src/qos_hex/src/lib.rs
@@ -73,8 +73,8 @@ impl From<FromUtf8Error> for HexError {
 	}
 }
 
-fn verify_ascii(byte: &u8) -> Result<(), HexError> {
-	if byte >= &128 {
+fn verify_ascii(byte: u8) -> Result<(), HexError> {
+	if byte >= 128 {
 		return Err(HexError::NonAsciiChar);
 	}
 	Ok(())
@@ -112,8 +112,8 @@ pub fn decode(raw_s: &str) -> Result<Vec<u8>, HexError> {
 				.step_by(2)
 				.map(|i| {
 					// check that both bytes represent ascii chars
-					verify_ascii(&sanitized_s_bytes[i])?;
-					verify_ascii(&sanitized_s_bytes[i + 1])?;
+					verify_ascii(sanitized_s_bytes[i])?;
+					verify_ascii(sanitized_s_bytes[i + 1])?;
 
 					let s = std::str::from_utf8(&sanitized_s_bytes[i..i + 2])
 						.expect("We ensure that input slice represents ASCII above. qed.");
@@ -156,8 +156,8 @@ pub fn decode_to_buf(raw_s: &str, buf: &mut [u8]) -> Result<(), HexError> {
 	for (i, b) in buf.iter_mut().enumerate() {
 		let str_idx = i * 2;
 
-		verify_ascii(&sanitized_s_bytes[str_idx])?;
-		verify_ascii(&sanitized_s_bytes[str_idx + 1])?;
+		verify_ascii(sanitized_s_bytes[str_idx])?;
+		verify_ascii(sanitized_s_bytes[str_idx + 1])?;
 
 		let s = std::str::from_utf8(&sanitized_s_bytes[str_idx..str_idx + 2])
 			.expect("We ensure that input slice represents ASCII above. qed.");

--- a/src/qos_host/src/cli.rs
+++ b/src/qos_host/src/cli.rs
@@ -121,6 +121,7 @@ impl HostOpts {
 	}
 
 	/// Create a new `StreamPool` using the list of `SocketAddress` for the qos host.
+	#[cfg_attr(not(feature = "vm"), allow(clippy::unnecessary_wraps))]
 	pub(crate) fn enclave_socket(
 		&self,
 	) -> Result<SocketAddress, qos_core::io::IOError> {

--- a/src/qos_host/src/host.rs
+++ b/src/qos_host/src/host.rs
@@ -257,20 +257,18 @@ impl HostServer {
 async fn get_eph_key_from_attestation_doc(
 	enclave_client: &SocketClient,
 ) -> Option<String> {
+	use ProtocolMsg::LiveAttestationDocResponse;
+
 	let req = borsh::to_vec(&ProtocolMsg::LiveAttestationDocRequest).ok()?;
 	let resp_bytes = enclave_client.call(&req).await.ok()?;
 	let resp = ProtocolMsg::try_from_slice(&resp_bytes).ok()?;
 
-	let nsm_response = match resp {
-		ProtocolMsg::LiveAttestationDocResponse { nsm_response, .. } => {
-			nsm_response
-		}
-		_ => return None,
+	let LiveAttestationDocResponse { nsm_response, .. } = resp else {
+		return None;
 	};
 
-	let document = match nsm_response {
-		NsmResponse::Attestation { document } => document,
-		_ => return None,
+	let NsmResponse::Attestation { document } = nsm_response else {
+		return None;
 	};
 
 	let attestation_doc =

--- a/src/qos_net/src/cli.rs
+++ b/src/qos_net/src/cli.rs
@@ -83,7 +83,13 @@ impl ProxyOpts {
 pub struct CLI;
 
 impl CLI {
-	/// Execute the enclave proxy CLI with the environment args in an async way.
+	/// Execute the enclave proxy CLI with the environment args in an async
+	/// way.
+	///
+	/// # Panics
+	///
+	/// Panics if the socket pool cannot be created, max connections cannot
+	/// be parsed, or the server fails to start.
 	pub async fn execute() {
 		use qos_core::server::SocketServer;
 

--- a/src/qos_net/src/proxy_connection.rs
+++ b/src/qos_net/src/proxy_connection.rs
@@ -27,7 +27,11 @@ pub struct ProxyConnection {
 
 impl ProxyConnection {
 	/// Create a new `ProxyConnection` from a name. This results in a DNS
-	/// request + TCP connection
+	/// request + TCP connection.
+	///
+	/// # Errors
+	///
+	/// Returns [`QosNetError`] if DNS resolution or TCP connection fails.
 	pub async fn new_from_name(
 		hostname: String,
 		port: u16,
@@ -42,7 +46,12 @@ impl ProxyConnection {
 	}
 
 	/// Create a new `ProxyConnection` from an IP address. This results in a
-	/// new TCP connection
+	/// new TCP connection.
+	///
+	/// # Errors
+	///
+	/// Returns [`QosNetError`] if the IP cannot be parsed or the TCP
+	/// connection fails.
 	pub async fn new_from_ip(
 		ip: String,
 		port: u16,
@@ -57,6 +66,10 @@ impl ProxyConnection {
 
 impl ProxyConnection {
 	/// Read data from the TCP stream into the buffer.
+	///
+	/// # Errors
+	///
+	/// Returns [`std::io::Error`] if the read fails.
 	pub async fn read(
 		&mut self,
 		buf: &mut [u8],
@@ -65,17 +78,30 @@ impl ProxyConnection {
 	}
 
 	/// Write data to the TCP stream.
+	///
+	/// # Errors
+	///
+	/// Returns [`std::io::Error`] if the write fails.
 	pub async fn write(&mut self, buf: &[u8]) -> Result<usize, std::io::Error> {
 		self.tcp_stream.write(buf).await
 	}
 
 	/// Flush any buffered data to the TCP stream.
+	///
+	/// # Errors
+	///
+	/// Returns [`std::io::Error`] if the flush fails.
 	pub async fn flush(&mut self) -> std::io::Result<()> {
 		self.tcp_stream.flush().await
 	}
 }
 
 /// Resolve a hostname into an IP address using the specified DNS resolvers.
+///
+/// # Errors
+///
+/// Returns [`QosNetError`] if the resolver addresses cannot be parsed or
+/// DNS resolution fails.
 pub async fn resolve_hostname(
 	hostname: String,
 	resolver_addrs: Vec<String>,

--- a/src/qos_net/src/proxy_msg.rs
+++ b/src/qos_net/src/proxy_msg.rs
@@ -20,7 +20,7 @@ pub enum ProxyMsg {
 		hostname: String,
 		/// e.g. 443
 		port: u16,
-		/// An array of DNS resolvers e.g. ["8.8.8.8", "8.8.4.4"]
+		/// An array of DNS resolvers e.g. `["8.8.8.8", "8.8.4.4"]`
 		dns_resolvers: Vec<String>,
 		/// Port number to perform DNS resolution, e.g. 53
 		dns_port: u16,

--- a/src/qos_net/src/proxy_stream.rs
+++ b/src/qos_net/src/proxy_stream.rs
@@ -37,6 +37,10 @@ impl<'pool> ProxyStream<'pool> {
 	///
 	/// Returns [`QosNetError`] if the connection request fails or the
 	/// proxy returns an error.
+	///
+	/// # Panics
+	///
+	/// Panics if the request cannot be serialized.
 	pub async fn connect_by_name(
 		mut stream: PoolGuard<'pool>,
 		hostname: String,
@@ -78,6 +82,10 @@ impl<'pool> ProxyStream<'pool> {
 	///
 	/// Returns [`QosNetError`] if the connection request fails or the
 	/// proxy returns an error.
+	///
+	/// # Panics
+	///
+	/// Panics if the request cannot be serialized.
 	pub async fn connect_by_ip(
 		mut stream: PoolGuard<'pool>,
 		ip: String,

--- a/src/qos_net/src/proxy_stream.rs
+++ b/src/qos_net/src/proxy_stream.rs
@@ -235,14 +235,15 @@ mod test {
 		);
 
 		// Decode the chunked content
-		let mut decoded = String::new();
+		let mut decoded_string = String::new();
 		let mut decoder = Decoder::new(&response_bytes[header_byte_size..]);
-		let res = decoder.read_to_string(&mut decoded);
+		let res = decoder.read_to_string(&mut decoded_string);
 		assert!(res.is_ok());
 
 		// Parse the JSON response body and make sure there is a proper "keys"
 		// array in it
-		let json_content: Value = serde_json::from_str(&decoded).unwrap();
+		let json_content: Value =
+			serde_json::from_str(&decoded_string).unwrap();
 		assert!(json_content["keys"].is_array());
 	}
 }

--- a/src/qos_net/src/proxy_stream.rs
+++ b/src/qos_net/src/proxy_stream.rs
@@ -33,6 +33,10 @@ impl<'pool> ProxyStream<'pool> {
 	/// * `dns_resolvers` - array of resolvers to use to resolve `hostname`
 	/// * `dns_port` - DNS port to use while resolving DNS (typically: 53 or
 	///   853)
+	/// # Errors
+	///
+	/// Returns [`QosNetError`] if the connection request fails or the
+	/// proxy returns an error.
 	pub async fn connect_by_name(
 		mut stream: PoolGuard<'pool>,
 		hostname: String,
@@ -70,6 +74,10 @@ impl<'pool> ProxyStream<'pool> {
 	/// * `ip` - the IP the remote `qos_net` proxy should connect to
 	/// * `port` - the port the remote `qos_net` proxy should connect to
 	///   (typically: 80 or 443 for http/https)
+	/// # Errors
+	///
+	/// Returns [`QosNetError`] if the connection request fails or the
+	/// proxy returns an error.
 	pub async fn connect_by_ip(
 		mut stream: PoolGuard<'pool>,
 		ip: String,
@@ -91,8 +99,12 @@ impl<'pool> ProxyStream<'pool> {
 		}
 	}
 
-	/// Refresh this connection after a request has been completed. This MUST be called
-	/// after each successful rustls session.
+	/// Refresh this connection after a request has been completed. This MUST
+	/// be called after each successful rustls session.
+	///
+	/// # Errors
+	///
+	/// Returns [`QosNetError`] if reconnecting the stream fails.
 	pub async fn refresh(&mut self) -> Result<(), QosNetError> {
 		self.stream.reconnect().await?;
 

--- a/src/qos_nsm/src/nitro/mod.rs
+++ b/src/qos_nsm/src/nitro/mod.rs
@@ -15,6 +15,7 @@ use serde_bytes::ByteBuf;
 
 mod error;
 mod syntactic_validation;
+use syntactic_validation::validate_attestation_doc;
 
 pub use error::AttestError;
 
@@ -214,14 +215,7 @@ pub fn attestation_doc_from_der(
 	let cose_sign1 = CoseSign1::from_bytes(cose_sign1_der)
 		.map_err(|_| AttestError::InvalidCOSESign1Structure)?;
 
-	syntactic_validation::module_id(&attestation_doc.module_id)?;
-	syntactic_validation::digest(attestation_doc.digest)?;
-	syntactic_validation::pcrs(&attestation_doc.pcrs)?;
-	syntactic_validation::cabundle(&attestation_doc.cabundle)?;
-	syntactic_validation::timestamp(attestation_doc.timestamp)?;
-	syntactic_validation::public_key(&attestation_doc.public_key)?;
-	syntactic_validation::user_data(&attestation_doc.user_data)?;
-	syntactic_validation::nonce(&attestation_doc.nonce)?;
+	validate_attestation_doc(&attestation_doc)?;
 
 	verify_certificate_chain(
 		&attestation_doc.cabundle,

--- a/src/qos_nsm/src/nitro/mod.rs
+++ b/src/qos_nsm/src/nitro/mod.rs
@@ -43,6 +43,10 @@ pub const AWS_ROOT_CERT_PEM: &[u8] =
 
 /// Extract a DER encoded certificate from bytes representing a PEM encoded
 /// certificate.
+///
+/// # Errors
+///
+/// Returns [`AttestError::PemDecodingError`] if the PEM cannot be decoded.
 pub fn cert_from_pem(pem: &[u8]) -> Result<Vec<u8>, AttestError> {
 	let (_, doc) =
 		x509_cert::der::Document::from_pem(&String::from_utf8_lossy(pem))
@@ -63,7 +67,10 @@ pub fn cert_from_pem(pem: &[u8]) -> Result<Vec<u8>, AttestError> {
 /// * `pcr1` - expected value of PCR index 1.
 /// * `pcr2` - expected value of PCR index 3.
 ///
-/// Returns an `AttestError` if any part of the verification fails.
+/// # Errors
+///
+/// Returns [`AttestError`] if any field is missing or does not match the
+/// expected value.
 pub fn verify_attestation_doc_against_user_input(
 	attestation_doc: &AttestationDoc,
 	user_data: &[u8],
@@ -158,6 +165,11 @@ pub fn verify_attestation_doc_against_user_input(
 ///
 /// * `cose_sign1_der` - the DER encoded COSE Sign1 structure containing the
 ///   attestation document payload.
+///
+/// # Errors
+///
+/// Returns [`AttestError`] if the COSE Sign1 structure or attestation
+/// document cannot be decoded.
 pub fn unsafe_attestation_doc_from_der(
 	cose_sign1_der: &[u8],
 ) -> Result<AttestationDoc, AttestError> {
@@ -188,6 +200,11 @@ pub fn unsafe_attestation_doc_from_der(
 /// * `validation_time` - a moment in time that the certificates should be
 ///   valid. This is measured in seconds since the unix epoch. Most likely this
 ///   will be the current time.
+///
+/// # Errors
+///
+/// Returns [`AttestError`] if the COSE Sign1 structure cannot be decoded,
+/// the certificate chain is invalid, or signature verification fails.
 pub fn attestation_doc_from_der(
 	cose_sign1_der: &[u8],
 	root_cert: &[u8],

--- a/src/qos_nsm/src/nitro/syntactic_validation.rs
+++ b/src/qos_nsm/src/nitro/syntactic_validation.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use aws_nitro_enclaves_nsm_api::api::Digest;
+use aws_nitro_enclaves_nsm_api::api::{AttestationDoc, Digest};
 
 use super::{AttestError, ByteBuf};
 
@@ -18,8 +18,35 @@ const MAX_PUB_KEY_LEN: usize = 1024;
 const MIN_CERT_LEN: usize = 1;
 const MAX_CERT_LEN: usize = 1024;
 
+pub(super) fn validate_attestation_doc(
+	attestation_doc: &AttestationDoc,
+) -> Result<(), AttestError> {
+	let AttestationDoc {
+		certificate: _, // validated in a separate step
+		module_id,
+		digest,
+		pcrs,
+		cabundle,
+		timestamp,
+		public_key,
+		user_data,
+		nonce,
+	} = attestation_doc;
+
+	validate_module_id(module_id)?;
+	validate_digest(*digest)?;
+	validate_pcrs(pcrs)?;
+	validate_cabundle(cabundle)?;
+	validate_timestamp(*timestamp)?;
+	validate_public_key(public_key.as_ref())?;
+	validate_bytes_512(user_data.as_ref())?;
+	validate_bytes_512(nonce.as_ref())?;
+
+	Ok(())
+}
+
 /// Mandatory field
-pub(super) fn module_id(id: &str) -> Result<(), AttestError> {
+fn validate_module_id(id: &str) -> Result<(), AttestError> {
 	if id.is_empty() {
 		Err(AttestError::InvalidModuleId)
 	} else {
@@ -27,7 +54,7 @@ pub(super) fn module_id(id: &str) -> Result<(), AttestError> {
 	}
 }
 /// Mandatory field
-pub(super) fn pcrs(pcrs: &BTreeMap<usize, ByteBuf>) -> Result<(), AttestError> {
+fn validate_pcrs(pcrs: &BTreeMap<usize, ByteBuf>) -> Result<(), AttestError> {
 	let is_valid_pcr_count =
 		pcrs.len() >= MIN_PCR_COUNT && pcrs.len() <= MAX_PRC_COUNT;
 
@@ -44,7 +71,7 @@ pub(super) fn pcrs(pcrs: &BTreeMap<usize, ByteBuf>) -> Result<(), AttestError> {
 	}
 }
 /// Mandatory field
-pub(super) fn cabundle(cabundle: &[ByteBuf]) -> Result<(), AttestError> {
+fn validate_cabundle(cabundle: &[ByteBuf]) -> Result<(), AttestError> {
 	let is_valid_len = cabundle.len() >= MIN_CERT_CHAIN_LEN;
 	let is_valid_entries = cabundle
 		.iter()
@@ -57,7 +84,7 @@ pub(super) fn cabundle(cabundle: &[ByteBuf]) -> Result<(), AttestError> {
 	}
 }
 /// Mandatory field
-pub(super) fn digest(d: Digest) -> Result<(), AttestError> {
+fn validate_digest(d: Digest) -> Result<(), AttestError> {
 	if d == Digest::SHA384 {
 		Ok(())
 	} else {
@@ -65,7 +92,7 @@ pub(super) fn digest(d: Digest) -> Result<(), AttestError> {
 	}
 }
 /// Mandatory field
-pub(super) fn timestamp(t: u64) -> Result<(), AttestError> {
+fn validate_timestamp(t: u64) -> Result<(), AttestError> {
 	if t == 0 {
 		Err(AttestError::InvalidTimeStamp)
 	} else {
@@ -73,7 +100,7 @@ pub(super) fn timestamp(t: u64) -> Result<(), AttestError> {
 	}
 }
 /// Optional field
-pub(super) fn public_key(pub_key: &Option<ByteBuf>) -> Result<(), AttestError> {
+fn validate_public_key(pub_key: Option<&ByteBuf>) -> Result<(), AttestError> {
 	if let Some(key) = pub_key {
 		(key.len() >= MIN_PUB_KEY_LEN && key.len() <= MAX_PUB_KEY_LEN)
 			.then_some(())
@@ -82,16 +109,8 @@ pub(super) fn public_key(pub_key: &Option<ByteBuf>) -> Result<(), AttestError> {
 
 	Ok(())
 }
-/// Optional field
-pub(super) fn user_data(data: &Option<ByteBuf>) -> Result<(), AttestError> {
-	bytes_512(data)
-}
-/// Optional field
-pub(super) fn nonce(n: &Option<ByteBuf>) -> Result<(), AttestError> {
-	bytes_512(n)
-}
 
-fn bytes_512(val: &Option<ByteBuf>) -> Result<(), AttestError> {
+fn validate_bytes_512(val: Option<&ByteBuf>) -> Result<(), AttestError> {
 	if let Some(val) = val {
 		if val.len() > 512 {
 			return Err(AttestError::InvalidBytes);
@@ -102,97 +121,209 @@ fn bytes_512(val: &Option<ByteBuf>) -> Result<(), AttestError> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
+	use std::array;
+
 	use super::*;
 
 	#[test]
-	fn user_data_works() {
-		assert!(user_data(&None).is_ok());
-		assert!(user_data(&Some(ByteBuf::new())).is_ok());
-		assert!(user_data(&Some(ByteBuf::from(
-			(0..513).map(|_| 42u8).collect::<Vec<_>>()
-		)))
+	fn valid_attestation_do_passes_validation() {
+		let attestation_doc = valid_attestation_doc();
+		assert!(validate_attestation_doc(&attestation_doc).is_ok())
+	}
+
+	#[test]
+	fn bytes_512_works() {
+		assert!(validate_bytes_512(None).is_ok());
+		assert!(validate_bytes_512(Some(ByteBuf::new()).as_ref()).is_ok());
+		assert!(validate_bytes_512(
+			Some(ByteBuf::from((0..513).map(|_| 42u8).collect::<Vec<_>>()))
+				.as_ref()
+		)
 		.is_err());
 	}
 
 	#[test]
-	fn nonce_works() {
-		assert!(nonce(&None).is_ok());
-		assert!(nonce(&Some(ByteBuf::new())).is_ok());
-		assert!(nonce(&Some(ByteBuf::from(
-			(0..513).map(|_| 42u8).collect::<Vec<_>>()
-		)))
-		.is_err());
+	fn no_pubkey_is_valid() {
+		let attestation_doc =
+			AttestationDoc { public_key: None, ..valid_attestation_doc() };
+		assert!(validate_attestation_doc(&attestation_doc).is_ok());
 	}
 
 	#[test]
-	fn public_key_works() {
-		assert!(public_key(&None).is_ok());
-		assert!(public_key(&Some(ByteBuf::new())).is_err());
-		assert!(public_key(&Some(ByteBuf::from(vec![1u8]))).is_ok());
-		assert!(public_key(&Some(ByteBuf::from(
-			(0..1025).map(|_| 42u8).collect::<Vec<_>>()
-		)))
-		.is_err());
+	fn empty_pubkey_is_invalid() {
+		let attestation_doc = AttestationDoc {
+			public_key: ByteBuf::new().into(),
+			..valid_attestation_doc()
+		};
+
+		assert!(matches!(
+			validate_attestation_doc(&attestation_doc),
+			Err(AttestError::InvalidPubKey)
+		));
 	}
 
 	#[test]
-	fn timestamp_works() {
-		assert!(timestamp(0).is_err());
-		assert!(timestamp(1).is_ok());
+	fn long_pubkey_is_invalid() {
+		let attestation_doc = AttestationDoc {
+			public_key: ByteBuf::from(vec![42; 1025]).into(),
+			..valid_attestation_doc()
+		};
+
+		assert!(matches!(
+			validate_attestation_doc(&attestation_doc),
+			Err(AttestError::InvalidPubKey)
+		));
 	}
 
 	#[test]
-	fn digest_works() {
-		assert!(digest(Digest::SHA256).is_err());
-		assert!(digest(Digest::SHA384).is_ok());
+	fn invalid_timestamp() {
+		let attestation_doc =
+			AttestationDoc { timestamp: 0, ..valid_attestation_doc() };
+
+		assert!(matches!(
+			validate_attestation_doc(&attestation_doc),
+			Err(AttestError::InvalidTimeStamp)
+		));
 	}
 
 	#[test]
-	fn cabundle_works() {
-		let valid_cert = ByteBuf::from(vec![42]);
-		assert!(cabundle(&[valid_cert]).is_ok());
+	fn invalid_digest() {
+		let attestation_doc = AttestationDoc {
+			digest: Digest::SHA256,
+			..valid_attestation_doc()
+		};
 
-		assert!(cabundle(&[]).is_err());
-
-		let short_cert = ByteBuf::new();
-		assert!(cabundle(&[short_cert]).is_err());
-
-		let long_cert = ByteBuf::from((0..1025).map(|_| 3).collect::<Vec<_>>());
-		assert!(cabundle(&[long_cert]).is_err());
+		assert!(matches!(
+			validate_attestation_doc(&attestation_doc),
+			Err(AttestError::InvalidDigest)
+		));
 	}
 
 	#[test]
-	fn pcrs_works() {
-		let pcr32 = ByteBuf::from((0..32).map(|_| 3).collect::<Vec<_>>());
-		let pcr48 = ByteBuf::from((0..48).map(|_| 3).collect::<Vec<_>>());
-		let pcr64 = ByteBuf::from((0..64).map(|_| 3).collect::<Vec<_>>());
-		let pcr_invalid = ByteBuf::from((0..31).map(|_| 3).collect::<Vec<_>>());
+	fn empty_ca_bundle() {
+		let attestation_doc =
+			AttestationDoc { cabundle: Vec::new(), ..valid_attestation_doc() };
 
-		let inner: [(usize, ByteBuf); 33] = (0..33)
-			.map(|i| (i, pcr32.clone()))
-			.collect::<Vec<_>>()
-			.try_into()
-			.unwrap();
+		assert!(matches!(
+			validate_attestation_doc(&attestation_doc),
+			Err(AttestError::InvalidCABundle)
+		));
+	}
+
+	#[test]
+	fn short_cert_in_bundle() {
+		let short_cert = vec![ByteBuf::new()];
+		let attestation_doc =
+			AttestationDoc { cabundle: short_cert, ..valid_attestation_doc() };
+
+		assert!(matches!(
+			validate_attestation_doc(&attestation_doc),
+			Err(AttestError::InvalidCABundle)
+		));
+	}
+
+	#[test]
+	fn long_cert_in_bundle() {
+		let long_ca_in_bundle = vec![ByteBuf::from(vec![3; 1025])];
+		let attestation_doc = AttestationDoc {
+			cabundle: long_ca_in_bundle,
+			..valid_attestation_doc()
+		};
+
+		assert!(matches!(
+			validate_attestation_doc(&attestation_doc),
+			Err(AttestError::InvalidCABundle)
+		));
+	}
+
+	#[test]
+	fn too_many_pcrs() {
+		let inner = array::from_fn::<_, 33, _>(|i| (i, pcr::<32>()));
+
 		let too_many_pcrs = BTreeMap::from(inner);
-		assert!(pcrs(&too_many_pcrs).is_err());
 
-		let too_few_pcrs = BTreeMap::new();
-		assert!(pcrs(&too_few_pcrs).is_err());
+		let attestation_doc =
+			AttestationDoc { pcrs: too_many_pcrs, ..valid_attestation_doc() };
 
-		// Invalid PCR index
-		assert!(pcrs(&BTreeMap::from([(33, pcr32.clone())])).is_err());
-
-		// Valid
-		assert!(pcrs(&BTreeMap::from([(0, pcr48), (32, pcr32), (5, pcr64)]))
-			.is_ok());
-
-		assert!(pcrs(&BTreeMap::from([(5, pcr_invalid)])).is_err());
+		assert!(matches!(
+			validate_attestation_doc(&attestation_doc),
+			Err(AttestError::InvalidPcr)
+		));
 	}
 
 	#[test]
-	fn module_id_works() {
-		assert!(module_id("").is_err());
-		assert!(module_id("1").is_ok());
+	fn not_enough_pcrs() {
+		let attestation_doc =
+			AttestationDoc { pcrs: BTreeMap::new(), ..valid_attestation_doc() };
+
+		assert!(matches!(
+			validate_attestation_doc(&attestation_doc),
+			Err(AttestError::InvalidPcr)
+		));
+	}
+
+	#[test]
+	fn invalid_index() {
+		let attestation_doc = AttestationDoc {
+			pcrs: BTreeMap::from([(33, pcr::<32>())]),
+			..valid_attestation_doc()
+		};
+
+		assert!(matches!(
+			validate_attestation_doc(&attestation_doc),
+			Err(AttestError::InvalidPcr)
+		));
+	}
+
+	#[test]
+	fn invalid_pcr() {
+		let invalid_pcr = pcr::<31>();
+		let pcrs = BTreeMap::from([(5, invalid_pcr)]);
+		let attestion_doc = AttestationDoc { pcrs, ..valid_attestation_doc() };
+
+		assert!(matches!(
+			validate_attestation_doc(&attestion_doc),
+			Err(AttestError::InvalidPcr)
+		));
+	}
+
+	#[test]
+	fn validate_module_id_works() {
+		let attestation_doc = AttestationDoc {
+			module_id: String::new(),
+			..valid_attestation_doc()
+		};
+
+		assert!(matches!(
+			validate_attestation_doc(&attestation_doc),
+			Err(AttestError::InvalidModuleId)
+		));
+	}
+
+	fn valid_attestation_doc() -> AttestationDoc {
+		AttestationDoc {
+			module_id: "1".into(),
+			digest: Digest::SHA384,
+			timestamp: 1,
+			pcrs: valid_pcrs(),
+			certificate: ByteBuf::new(), // not tested here
+			cabundle: vec![ByteBuf::from(vec![42])],
+			public_key: Some(ByteBuf::from(vec![1u8])),
+			user_data: valid_bytes_512().into(),
+			nonce: valid_bytes_512().into(),
+		}
+	}
+
+	fn valid_pcrs() -> BTreeMap<usize, ByteBuf> {
+		BTreeMap::from([(0, pcr::<48>()), (32, pcr::<32>()), (5, pcr::<64>())])
+	}
+
+	fn pcr<const N: usize>() -> ByteBuf {
+		ByteBuf::from(vec![3; N])
+	}
+
+	fn valid_bytes_512() -> ByteBuf {
+		ByteBuf::from(vec![42; 512])
 	}
 }

--- a/src/qos_nsm/src/nitro/syntactic_validation.rs
+++ b/src/qos_nsm/src/nitro/syntactic_validation.rs
@@ -129,7 +129,7 @@ mod tests {
 	#[test]
 	fn valid_attestation_do_passes_validation() {
 		let attestation_doc = valid_attestation_doc();
-		assert!(validate_attestation_doc(&attestation_doc).is_ok())
+		assert!(validate_attestation_doc(&attestation_doc).is_ok());
 	}
 
 	#[test]

--- a/src/qos_nsm/src/nsm.rs
+++ b/src/qos_nsm/src/nsm.rs
@@ -19,8 +19,13 @@ pub trait NsmProvider: Send + Sync {
 		request: types::NsmRequest,
 	) -> types::NsmResponse;
 
-	/// requests an attestation document and returns its timestamp in
-	/// milliseconds
+	/// Requests an attestation document and returns its timestamp in
+	/// milliseconds.
+	///
+	/// # Errors
+	///
+	/// Returns [`nitro::AttestError`] if the attestation request fails or
+	/// the timestamp cannot be extracted.
 	fn timestamp_ms(&self) -> Result<u64, nitro::AttestError>;
 }
 

--- a/src/qos_p256/src/encrypt.rs
+++ b/src/qos_p256/src/encrypt.rs
@@ -49,6 +49,11 @@ impl P256EncryptPair {
 	}
 
 	/// Decrypt a message encoded to this pair's public key.
+	///
+	/// # Errors
+	///
+	/// Returns [`P256Error`] if the envelope cannot be deserialized or
+	/// decryption fails.
 	pub fn decrypt(
 		&self,
 		serialized_envelope: &[u8],
@@ -98,6 +103,11 @@ impl P256EncryptPair {
 	}
 
 	/// Deserialize key from raw scalar byte slice.
+	///
+	/// # Errors
+	///
+	/// Returns [`P256Error::FailedToReadSecret`] if the bytes are not a
+	/// valid P256 scalar.
 	pub fn from_bytes(bytes: &[u8]) -> Result<Self, P256Error> {
 		Ok(Self {
 			private: SecretKey::from_slice(bytes)
@@ -120,6 +130,10 @@ pub struct P256EncryptPublic {
 
 impl P256EncryptPublic {
 	/// Encrypt a message to this public key.
+	///
+	/// # Errors
+	///
+	/// Returns [`P256Error`] if encryption or envelope serialization fails.
 	pub fn encrypt(&self, message: &[u8]) -> Result<Vec<u8>, P256Error> {
 		let ephemeral_sender_private = SecretKey::random(&mut OsRng);
 		let ephemeral_sender_public: [u8; PUB_KEY_LEN_UNCOMPRESSED as usize] =
@@ -175,6 +189,11 @@ impl P256EncryptPublic {
 	/// This is designed to be used in scenarios where the private key is stored
 	/// in enclave that computes a shared secret. That shared secret is then
 	// used as input to this function.
+	///
+	/// # Errors
+	///
+	/// Returns [`P256Error`] if the envelope cannot be deserialized or
+	/// decryption fails.
 	pub fn decrypt_from_shared_secret(
 		&self,
 		serialized_envelope: &[u8],
@@ -219,6 +238,11 @@ impl P256EncryptPublic {
 	}
 
 	/// Deserialize from a SEC1 encoded point, not compressed.
+	///
+	/// # Errors
+	///
+	/// Returns [`P256Error`] if the bytes are the wrong length or not a
+	/// valid SEC1 encoded point.
 	pub fn from_bytes(bytes: &[u8]) -> Result<Self, P256Error> {
 		if bytes.len() > PUB_KEY_LEN_UNCOMPRESSED as usize {
 			return Err(P256Error::EncodedPublicKeyTooLong);
@@ -358,6 +382,11 @@ impl AesGcm256Secret {
 	}
 
 	/// Create [`Self`] from bytes.
+	///
+	/// # Errors
+	///
+	/// Returns [`P256Error::FailedToCreateAes256GcmCipher`] if the key is
+	/// invalid.
 	pub fn from_bytes(bytes: [u8; AES256_KEY_LEN]) -> Result<Self, P256Error> {
 		Ok(Self { secret: bytes })
 	}
@@ -365,6 +394,10 @@ impl AesGcm256Secret {
 	/// Encrypt the given `msg`.
 	///
 	/// Returns a serialized [`SymmetricEnvelope`].
+	///
+	/// # Errors
+	///
+	/// Returns [`P256Error`] if encryption or envelope serialization fails.
 	///
 	/// # Panics
 	/// Panics if `self.secret` is an invalid AES256 secret. This should never
@@ -391,6 +424,11 @@ impl AesGcm256Secret {
 	/// Decrypt the given serialized [`SymmetricEnvelope`].
 	///
 	/// Returns the plaintext.
+	///
+	/// # Errors
+	///
+	/// Returns [`P256Error`] if the envelope cannot be deserialized or
+	/// decryption fails.
 	///
 	/// # Panics
 	/// Panics if the secret is invalid. This should never happen in practice.

--- a/src/qos_p256/src/lib.rs
+++ b/src/qos_p256/src/lib.rs
@@ -92,6 +92,10 @@ impl From<qos_hex::HexError> for P256Error {
 }
 
 /// Helper function to derive a secret from a master seed.
+///
+/// # Errors
+///
+/// Returns [`P256Error::HkdfExpansionFailed`] if HKDF expansion fails.
 pub fn derive_secret(
 	seed: &[u8; MASTER_SEED_LEN],
 	derive_path: &[u8],
@@ -126,6 +130,10 @@ pub struct P256Pair {
 
 impl P256Pair {
 	/// Generate a new private key using the OS randomness source.
+	///
+	/// # Errors
+	///
+	/// Returns [`P256Error`] if key derivation or construction fails.
 	pub fn generate() -> Result<Self, P256Error> {
 		let master_seed = bytes_os_rng::<MASTER_SEED_LEN>();
 
@@ -146,6 +154,10 @@ impl P256Pair {
 	}
 
 	/// Encrypt the given `msg` with the symmetric encryption secret.
+	///
+	/// # Errors
+	///
+	/// Returns [`P256Error`] if encryption fails.
 	pub fn aes_gcm_256_encrypt(
 		&self,
 		msg: &[u8],
@@ -154,6 +166,10 @@ impl P256Pair {
 	}
 
 	/// Decrypt a message with the symmetric encryption secret.
+	///
+	/// # Errors
+	///
+	/// Returns [`P256Error`] if decryption or envelope deserialization fails.
 	pub fn aes_gcm_256_decrypt(
 		&self,
 		serialized_envelope: &[u8],
@@ -162,6 +178,10 @@ impl P256Pair {
 	}
 
 	/// Decrypt a message encoded to this pair's public key.
+	///
+	/// # Errors
+	///
+	/// Returns [`P256Error`] if decryption or envelope deserialization fails.
 	pub fn decrypt(
 		&self,
 		serialized_envelope: &[u8],
@@ -170,6 +190,10 @@ impl P256Pair {
 	}
 
 	/// Sign the message and return the raw signature.
+	///
+	/// # Errors
+	///
+	/// Returns [`P256Error`] if signing fails.
 	pub fn sign(&self, message: &[u8]) -> Result<Vec<u8>, P256Error> {
 		self.sign_private.sign(message)
 	}
@@ -184,6 +208,10 @@ impl P256Pair {
 	}
 
 	/// Create `Self` from a master seed.
+	///
+	/// # Errors
+	///
+	/// Returns [`P256Error`] if key derivation or construction fails.
 	pub fn from_master_seed(
 		master_seed: &[u8; MASTER_SEED_LEN],
 	) -> Result<Self, P256Error> {
@@ -217,6 +245,10 @@ impl P256Pair {
 	}
 
 	/// Write the raw master seed to file as hex encoded.
+	///
+	/// # Errors
+	///
+	/// Returns [`P256Error::IOError`] if the file cannot be written.
 	pub fn to_hex_file<P: AsRef<Path>>(
 		&self,
 		path: P,
@@ -231,6 +263,11 @@ impl P256Pair {
 	}
 
 	/// Read the raw, hex encoded master from a file.
+	///
+	/// # Errors
+	///
+	/// Returns [`P256Error`] if the file cannot be read, the hex is invalid,
+	/// or the seed length is wrong.
 	pub fn from_hex_file<P: AsRef<Path>>(path: P) -> Result<Self, P256Error> {
 		let hex_bytes = std::fs::read(&path).map_err(|e| {
 			P256Error::IOError(format!(
@@ -276,6 +313,10 @@ pub struct P256Public {
 
 impl P256Public {
 	/// Encrypt a message to this public key.
+	///
+	/// # Errors
+	///
+	/// Returns [`P256Error`] if encryption fails.
 	pub fn encrypt(&self, message: &[u8]) -> Result<Vec<u8>, P256Error> {
 		self.encrypt_public.encrypt(message)
 	}
@@ -284,6 +325,11 @@ impl P256Public {
 	/// the SHA512 digest of the message.
 	///
 	/// Returns Ok if the signature is good.
+	///
+	/// # Errors
+	///
+	/// Returns [`P256Error::FailedSignatureVerification`] if the signature
+	/// is invalid.
 	pub fn verify(
 		&self,
 		message: &[u8],
@@ -306,6 +352,11 @@ impl P256Public {
 
 	/// Deserialize each public key from a SEC1 encoded point, not compressed.
 	/// Expects encoding as `encrypt_public||sign_public`.
+	///
+	/// # Errors
+	///
+	/// Returns [`P256Error`] if the bytes are the wrong length or cannot be
+	/// deserialized as valid public keys.
 	pub fn from_bytes(bytes: &[u8]) -> Result<Self, P256Error> {
 		if bytes.len() > PUB_KEY_LEN_UNCOMPRESSED as usize * 2 {
 			return Err(P256Error::EncodedPublicKeyTooLong);
@@ -332,6 +383,10 @@ impl P256Public {
 	}
 
 	/// Write the public key to a file encoded as a hex string.
+	///
+	/// # Errors
+	///
+	/// Returns [`P256Error::IOError`] if the file cannot be written.
 	pub fn to_hex_file<P: AsRef<Path>>(
 		&self,
 		path: P,
@@ -346,6 +401,11 @@ impl P256Public {
 	}
 
 	/// Read the hex encoded public keys from a file.
+	///
+	/// # Errors
+	///
+	/// Returns [`P256Error`] if the file cannot be read, the hex is invalid,
+	/// or the bytes are not valid public keys.
 	pub fn from_hex_file<P: AsRef<Path>>(path: P) -> Result<Self, P256Error> {
 		let hex_bytes = std::fs::read(&path).map_err(|e| {
 			P256Error::IOError(format!(

--- a/src/qos_p256/src/sign.rs
+++ b/src/qos_p256/src/sign.rs
@@ -26,6 +26,10 @@ impl P256SignPair {
 
 	/// Sign the message and return the. Signs the SHA512 digest of
 	/// the message.
+	///
+	/// # Errors
+	///
+	/// Returns [`P256Error`] if signing fails.
 	pub fn sign(&self, message: &[u8]) -> Result<Vec<u8>, P256Error> {
 		let signature: Signature = self.private.sign(message);
 
@@ -39,6 +43,11 @@ impl P256SignPair {
 	}
 
 	/// Deserialize key from raw scalar byte slice.
+	///
+	/// # Errors
+	///
+	/// Returns [`P256Error::FailedToReadSecret`] if the bytes are not a
+	/// valid P256 scalar.
 	pub fn from_bytes(bytes: &[u8]) -> Result<Self, P256Error> {
 		Ok(Self {
 			private: SigningKey::from_slice(bytes)
@@ -64,6 +73,12 @@ impl P256SignPublic {
 	/// the SHA512 digest of the message.
 	///
 	/// Returns Ok if the signature is good.
+	///
+	/// # Errors
+	///
+	/// Returns [`P256Error::FailedToDeserializeSignature`] if the signature
+	/// bytes are invalid, or [`P256Error::FailedSignatureVerification`] if
+	/// verification fails.
 	pub fn verify(
 		&self,
 		message: &[u8],
@@ -85,6 +100,11 @@ impl P256SignPublic {
 	}
 
 	/// Deserialize from a SEC1 encoded point, not compressed.
+	///
+	/// # Errors
+	///
+	/// Returns [`P256Error`] if the bytes are the wrong length or not a
+	/// valid SEC1 encoded point.
 	pub fn from_bytes(bytes: &[u8]) -> Result<Self, P256Error> {
 		if bytes.len() > PUB_KEY_LEN_UNCOMPRESSED as usize {
 			return Err(P256Error::EncodedPublicKeyTooLong);


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

Enable `clippy::pedantic` lints and fix all errors across the workspace (`qos_core`, `qos_client`, `qos_net`, `qos_p256`, `qos_nsm`, `qos_crypto`).

Removed unnecessary `async` from functions that only spawn tasks or do synchronous work (`tcp_to_vsock`, `vsock_to_tcp`, `run_bridges`, `run_vsock_to_tcp_bridge`, `reprint_pivot_output`, `busy`). These were never actually awaiting anything — the `async` annotation just forced callers to `.await` a function that did no async work. Removing it makes the API honest: callers can see at a glance that these are fire-and-forget spawns or pure synchronous logic.

While fixing lints in the attestation module, consolidated field-by-field validation into a single validation function and split the tests for better coverage.

### Note

All docs were generated with AI (mostly `# Errors` and `# Panics`) 

## How I Tested These Changes

Each commit passes `cargo fmt --check`, `cargo clippy`, and `cargo test`. CI should handle the rest.

## Pre merge check list

- [x] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?