### PR TITLE
ci: remove docker from test and lint ci

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,10 +9,14 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Setup Docker
-        uses: ./.github/actions/docker-setup
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+      - name: Install Linux deps
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libpcsclite-dev
       - name: Run tests
-        run: make test
+        run: make -C src test
 
   test-vm:
     name: test-vm
@@ -29,10 +33,15 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Setup Docker
-        uses: ./.github/actions/docker-setup
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+          components: clippy,rustfmt
+      - name: Install Linux deps
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libpcsclite-dev
       - name: Run linting
-        run: make lint
+        run: make -C src lint
 
   build-linux-only-crates:
     name: build-linux-only-crates


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

It was taking 10 minutes to build the docker image and 2 minutes to build/run cargo test.
No more docker in the test/lint path.

## How I Tested These Changes

## Pre merge check list

- [x] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
