### PR TITLE
 feat!: add VersionRequest/VersionResponse protocol messages (SYS-43)

### DIFF
--- a/src/integration/Cargo.toml
+++ b/src/integration/Cargo.toml
@@ -25,7 +25,7 @@ qos_p256 = { workspace = true, features = ["mock"] }
 qos_test_primitives = { workspace = true }
 
 futures = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "fs"] }
 borsh = { workspace = true }
 nix = { workspace = true }
 rustls = { workspace = true }

--- a/src/integration/examples/boot_enclave.rs
+++ b/src/integration/examples/boot_enclave.rs
@@ -4,6 +4,7 @@
 use std::{
 	fs,
 	io::{BufRead, BufReader, Write},
+	path::PathBuf,
 	process::{Command, Stdio},
 };
 
@@ -29,30 +30,28 @@ async fn main() {
 	const PIVOT_HASH_PATH: &str = "/tmp/enclave-example-pivot-hash.txt";
 
 	let host_port = 3001;
-	let tmp: PathWrapper = "/tmp/enclave-example".into();
-	let _: PathWrapper = PIVOT_HASH_PATH.into();
-	fs::create_dir_all(&*tmp).unwrap();
+	let tmp = PathWrapper::from("/tmp/enclave-example");
+	let _ = PathWrapper::from(PIVOT_HASH_PATH);
+	fs::create_dir_all(&tmp).unwrap();
 
-	let usock: PathWrapper = "/tmp/enclave-example/example.sock".into();
-	let secret_path: PathWrapper = "/tmp/enclave-example/example.secret".into();
-	let pivot_path: PathWrapper = "/tmp/enclave-example/example.pivot".into();
-	let manifest_path: PathWrapper =
-		"/tmp/enclave-example/example.manifest".into();
-	let eph_path: PathWrapper =
-		"/tmp/enclave-example/ephemeral_key.secret".into();
+	let usock = tmp.join("example.sock");
+	let secret_path = tmp.join("example.secret");
+	let pivot_path = tmp.join("example.pivot");
+	let manifest_path = tmp.join("example.manifest");
+	let eph_path = tmp.join("ephemeral_key.secret");
 
-	let boot_dir: PathWrapper = "/tmp/enclave-example/boot-dir".into();
-	fs::create_dir_all(&*boot_dir).unwrap();
-	let attestation_dir: PathWrapper =
-		"/tmp/enclave-example/attestation-dir".into();
-	fs::create_dir_all(&*attestation_dir).unwrap();
-	let attestation_doc_path = format!("{}/attestation_doc", &*attestation_dir);
+	let boot_dir = PathWrapper::from("boot-dir");
+	fs::create_dir_all(&boot_dir).unwrap();
+	let attestation_dir = PathWrapper::from("attestation-dir");
+	fs::create_dir_all(&attestation_dir).unwrap();
+	let attestation_doc_path = attestation_dir.join("attestation_doc");
 
-	let all_personal_dir = "./mock/boot-e2e/all-personal-dir";
+	let all_personal_dir = PathBuf::from("./mock/boot-e2e/all-personal-dir");
 
 	let namespace = "quit-coding-to-vape";
 
-	let personal_dir = |user: &str| format!("{all_personal_dir}/{user}-dir");
+	let personal_dir =
+		|user: &str| all_personal_dir.join(format!("{user}-dir"));
 
 	let user1 = "user1";
 	let user2 = "user2";
@@ -67,7 +66,7 @@ async fn main() {
 	// -- CLIENT create manifest.
 	let pivot_args = std::env::args().nth(2).expect("No pivot args provided");
 	let pivot_env = "pivot_env_var=will be set";
-	let cli_manifest_path = format!("{}/manifest", &*boot_dir);
+	let cli_manifest_path = boot_dir.join("manifest");
 	let app_host_port = 3000;
 
 	assert!(Command::new(integration::QOS_CLIENT_PATH)
@@ -86,7 +85,7 @@ async fn main() {
 			"--pcr3-preimage-path",
 			PCR3_PRE_IMAGE_PATH,
 			"--manifest-path",
-			&cli_manifest_path,
+			cli_manifest_path.to_str().unwrap(),
 			"--pivot-args",
 			&pivot_args,
 			"--pivot-env",
@@ -141,22 +140,22 @@ async fn main() {
 
 	// -- CLIENT make sure each user can run `approve-manifest`
 	for alias in [user1, user2, user3] {
-		let approval_path = format!(
-			"{}/{}-{}-{}.approval",
-			&*boot_dir, alias, namespace, manifest.namespace.nonce,
-		);
+		let approval_path = boot_dir.join(format!(
+			"{}-{}-{}.approval",
+			alias, namespace, manifest.namespace.nonce,
+		));
 
-		let secret_path = format!("{}/{}.secret", &personal_dir(alias), alias);
+		let secret_path = personal_dir(alias).join(format!("{alias}.secret"));
 
 		let mut child = Command::new(integration::QOS_CLIENT_PATH)
 			.args([
 				"approve-manifest",
 				"--secret-path",
-				&*secret_path,
+				secret_path.to_str().unwrap(),
 				"--manifest-path",
-				&cli_manifest_path,
+				cli_manifest_path.to_str().unwrap(),
 				"--manifest-approvals-dir",
-				&*boot_dir,
+				boot_dir.to_str().unwrap(),
 				"--pcr3-preimage-path",
 				PCR3_PRE_IMAGE_PATH,
 				"--pivot-hash-path",
@@ -240,11 +239,9 @@ async fn main() {
 		// Read in the generated approval to check it was created correctly
 		let approval: Approval =
 			serde_json::from_slice(&fs::read(approval_path).unwrap()).unwrap();
-		let personal_pair = P256Pair::from_hex_file(format!(
-			"{}/{}.secret",
-			personal_dir(alias),
-			alias,
-		))
+		let personal_pair = P256Pair::from_hex_file(
+			personal_dir(alias).join(format!("{alias}.secret")),
+		)
 		.unwrap();
 
 		let signature = personal_pair.sign(&manifest.qos_hash()).unwrap();
@@ -262,16 +259,16 @@ async fn main() {
 		Command::new(integration::QOS_CORE_PATH)
 			.args([
 				"--usock",
-				&*usock,
+				usock.to_str().unwrap(),
 				"--quorum-file",
-				&*secret_path,
+				secret_path.to_str().unwrap(),
 				"--pivot-file",
-				&*pivot_path,
+				pivot_path.to_str().unwrap(),
 				"--ephemeral-file",
-				&*eph_path,
+				eph_path.to_str().unwrap(),
 				"--mock",
 				"--manifest-file",
-				&*manifest_path,
+				manifest_path.to_str().unwrap(),
 			])
 			.spawn()
 			.unwrap()
@@ -286,7 +283,7 @@ async fn main() {
 				"--host-ip",
 				LOCAL_HOST,
 				"--usock",
-				&*usock,
+				usock.to_str().unwrap(),
 			])
 			.spawn()
 			.unwrap()
@@ -300,9 +297,9 @@ async fn main() {
 		.args([
 			"generate-manifest-envelope",
 			"--manifest-approvals-dir",
-			&*boot_dir,
+			boot_dir.to_str().unwrap(),
 			"--manifest-path",
-			&cli_manifest_path,
+			cli_manifest_path.to_str().unwrap(),
 		])
 		.spawn()
 		.unwrap()
@@ -311,12 +308,12 @@ async fn main() {
 		.success());
 
 	// -- CLIENT broadcast boot standard instruction
-	let manifest_envelope_path = format!("{}/manifest_envelope", &*boot_dir,);
+	let manifest_envelope_path = boot_dir.join("manifest_envelope");
 	assert!(Command::new(integration::QOS_CLIENT_PATH)
 		.args([
 			"boot-standard",
 			"--manifest-envelope-path",
-			&manifest_envelope_path,
+			manifest_envelope_path.to_str().unwrap(),
 			"--pivot-path",
 			&pivot_file_path,
 			"--host-port",
@@ -343,7 +340,7 @@ async fn main() {
 				"--host-ip",
 				LOCAL_HOST,
 				"--attestation-doc-path",
-				&*attestation_doc_path,
+				attestation_doc_path.to_str().unwrap(),
 				"--manifest-envelope-path",
 				"/tmp/dont_care"
 			])
@@ -353,28 +350,28 @@ async fn main() {
 			.unwrap()
 			.success());
 
-		let share_path = format!("{}/{}.share", &personal_dir(user), user);
-		let secret_path = format!("{}/{}.secret", &personal_dir(user), user);
-		let eph_wrapped_share_path: PathWrapper =
-			format!("{}/{}.eph_wrapped.share", &*tmp, user).into();
-		let approval_path: PathWrapper =
-			format!("{}/{}.attestation.approval", &*tmp, user).into();
+		let share_path = personal_dir(user).join(format!("{user}.share"));
+		let secret_path = personal_dir(user).join(format!("{user}.secret"));
+		let eph_wrapped_share_path =
+			PathWrapper::from(tmp.join(format!("{user}.eph_wrapped.share")));
+		let approval_path =
+			PathWrapper::from(tmp.join(format!("{user}.attestation.approval")));
 		// Encrypt share to ephemeral key
 		let mut child = Command::new(integration::QOS_CLIENT_PATH)
 			.args([
 				"proxy-re-encrypt-share",
 				"--share-path",
-				&share_path,
+				share_path.to_str().unwrap(),
 				"--secret-path",
-				&secret_path,
+				secret_path.to_str().unwrap(),
 				"--attestation-doc-path",
-				&*attestation_doc_path,
+				attestation_doc_path.to_str().unwrap(),
 				"--eph-wrapped-share-path",
-				&eph_wrapped_share_path,
+				eph_wrapped_share_path.to_str().unwrap(),
 				"--approval-path",
-				&approval_path,
+				approval_path.to_str().unwrap(),
 				"--manifest-envelope-path",
-				&manifest_envelope_path,
+				manifest_envelope_path.to_str().unwrap(),
 				"--pcr3-preimage-path",
 				PCR3_PRE_IMAGE_PATH,
 				"--manifest-set-dir",
@@ -383,7 +380,7 @@ async fn main() {
 				user,
 				"--unsafe-skip-attestation",
 				"--unsafe-eph-path-override",
-				&*eph_path,
+				eph_path.to_str().unwrap(),
 			])
 			.stdin(Stdio::piped())
 			.stdout(Stdio::piped())
@@ -438,9 +435,9 @@ async fn main() {
 				"--host-ip",
 				LOCAL_HOST,
 				"--eph-wrapped-share-path",
-				&eph_wrapped_share_path,
+				eph_wrapped_share_path.to_str().unwrap(),
 				"--approval-path",
-				&approval_path,
+				approval_path.to_str().unwrap(),
 			])
 			.spawn()
 			.unwrap()

--- a/src/integration/src/bin/pivot_proof.rs
+++ b/src/integration/src/bin/pivot_proof.rs
@@ -57,8 +57,8 @@ impl RequestProcessor for Processor {
 
 #[tokio::main]
 async fn main() {
-	let args: Vec<String> = std::env::args().collect();
-	let socket_path: &String = &args[1];
+	let mut args = std::env::args().skip(1);
+	let socket_path = args.next().unwrap();
 
 	let app_pool = StreamPool::new(SocketAddress::new_unix(socket_path), 1)
 		.expect("unable to create app pool");

--- a/src/integration/src/bin/pivot_remote_tls.rs
+++ b/src/integration/src/bin/pivot_remote_tls.rs
@@ -99,10 +99,10 @@ async fn main() {
 	// Parse args:
 	// - first argument is the socket to bind to (normal server server)
 	// - second argument is the socket to use for remote proxying
-	let args: Vec<String> = std::env::args().collect();
+	let mut args = std::env::args().skip(1);
 
-	let socket_path: &String = &args[1];
-	let proxy_path: &String = &args[2];
+	let socket_path = args.next().unwrap();
+	let proxy_path = args.next().unwrap();
 
 	let enclave_pool = StreamPool::new(SocketAddress::new_unix(socket_path), 1)
 		.expect("unable to create async stream pool");

--- a/src/integration/src/bin/pivot_socket_stress.rs
+++ b/src/integration/src/bin/pivot_socket_stress.rs
@@ -52,12 +52,13 @@ impl RequestProcessor for Processor {
 
 #[tokio::main]
 async fn main() {
-	let args: Vec<String> = std::env::args().collect();
-	let socket_path = &args[1];
+	let mut args = std::env::args().skip(1);
+	let socket_path = args.next().unwrap();
 	// 2nd arg should be "--pool-size" for Reaper compatibility
-	let pool_size_str: &str = args.get(3).map_or("1", String::as_str);
-	let pool_size =
-		pool_size_str.parse().expect("Unable to parse pool size argument");
+	let pool_size = args
+		.nth(1)
+		.map(|s| s.parse().expect("Unable to parse pool size argument"))
+		.unwrap_or(1u8);
 
 	let app_pool =
 		StreamPool::new(SocketAddress::new_unix(socket_path), pool_size)

--- a/src/integration/src/lib.rs
+++ b/src/integration/src/lib.rs
@@ -6,8 +6,8 @@ use qos_core::{
 	io::{SocketAddress, StreamPool},
 	parser::{GetParserForOptions, OptionsParser, Parser, Token},
 };
-use std::time::Duration;
-use tokio::net::TcpStream;
+use std::{path::Path, time::Duration};
+use tokio::net::{TcpStream, ToSocketAddrs};
 
 /// Path to the file `pivot_ok` writes on success for tests.
 pub const PIVOT_OK_SUCCESS_FILE: &str = "./pivot_ok_works";
@@ -157,7 +157,8 @@ pub struct AdditionProofPayload {
 ///
 /// # Panics
 /// Panics if `fs::exists` errors.
-pub async fn wait_for_usock(path: &str) {
+pub async fn wait_for_usock<P: AsRef<Path>>(path: P) {
+	let path = path.as_ref();
 	let addr = SocketAddress::new_unix(path);
 	let pool = StreamPool::single(addr).unwrap().shared();
 	let client = SocketClient::new(pool, Duration::from_millis(50));
@@ -170,17 +171,23 @@ pub async fn wait_for_usock(path: &str) {
 
 		tokio::time::sleep(Duration::from_millis(100)).await;
 	}
+
+	eprintln!("warning: no usock found at path: {}", path.display())
 }
 
-pub async fn wait_for_tcp_sock(host_addr: &str) {
+pub async fn wait_for_tcp_sock<Addr>(host_addr: &Addr)
+where
+	Addr: ToSocketAddrs + std::fmt::Debug,
+{
 	// Some integration flows start the listener only after a few control-loop
 	// iterations, so give the socket enough time to appear before failing.
 	let mut attempts = 0;
 	loop {
-		if let Ok(_stream) = TcpStream::connect(&host_addr).await {
+		if let Ok(_stream) = TcpStream::connect(host_addr).await {
 			return;
 		}
-		assert!((attempts <= 99), "unable to connect to {host_addr}");
+
+		assert!((attempts <= 99), "unable to connect to {host_addr:?}");
 		attempts += 1;
 		tokio::time::sleep(Duration::from_millis(100)).await;
 	}

--- a/src/integration/tests/boot.rs
+++ b/src/integration/tests/boot.rs
@@ -1,7 +1,7 @@
 use std::{
 	fs,
 	io::{BufRead, BufReader, Write},
-	path::Path,
+	path::{Path, PathBuf},
 	process::{Command, Stdio},
 };
 
@@ -30,28 +30,29 @@ async fn standard_boot_e2e() {
 	const PIVOT_HASH_PATH: &str = "/tmp/standard_boot_e2e-pivot-hash.txt";
 
 	let host_port = qos_test_primitives::find_free_port().unwrap();
-	let tmp: PathWrapper = "/tmp/boot-e2e".into();
-	let _: PathWrapper = PIVOT_OK2_SUCCESS_FILE.into();
-	let _: PathWrapper = PIVOT_HASH_PATH.into();
+	let tmp = PathWrapper::from("/tmp/boot-e2e");
+	let _ = PathWrapper::from(PIVOT_OK2_SUCCESS_FILE);
+	let _ = PathWrapper::from(PIVOT_HASH_PATH);
 	fs::create_dir_all(&*tmp).unwrap();
 
-	let usock: PathWrapper = "/tmp/boot-e2e/boot_e2e.sock".into();
-	let secret_path: PathWrapper = "/tmp/boot-e2e/boot_e2e.secret".into();
-	let pivot_path: PathWrapper = "/tmp/boot-e2e/boot_e2e.pivot".into();
-	let manifest_path: PathWrapper = "/tmp/boot-e2e/boot_e2e.manifest".into();
-	let eph_path: PathWrapper = "/tmp/boot-e2e/ephemeral_key.secret".into();
+	let usock = PathWrapper::from(tmp.join("boot_e2e.sock"));
+	let secret_path = PathWrapper::from(tmp.join("boot_e2e.secret"));
+	let pivot_path = PathWrapper::from(tmp.join("boot_e2e.pivot"));
+	let manifest_path = PathWrapper::from(tmp.join("boot_e2e.manifest"));
+	let eph_path = PathWrapper::from(tmp.join("ephemeral_key.secret"));
 
-	let boot_dir: PathWrapper = "/tmp/boot-e2e/boot-dir".into();
-	fs::create_dir_all(&*boot_dir).unwrap();
-	let attestation_dir: PathWrapper = "/tmp/boot-e2e/attestation-dir".into();
-	fs::create_dir_all(&*attestation_dir).unwrap();
-	let attestation_doc_path = format!("{}/attestation_doc", &*attestation_dir);
+	let boot_dir = tmp.join("boot-dir");
+	fs::create_dir_all(&boot_dir).unwrap();
+	let attestation_dir = tmp.join("attestation-dir");
+	fs::create_dir_all(&attestation_dir).unwrap();
+	let attestation_doc_path = attestation_dir.join("attestation_doc");
 
-	let all_personal_dir = "./mock/boot-e2e/all-personal-dir";
+	let all_personal_dir = PathBuf::from("./mock/boot-e2e/all-personal-dir");
 
 	let namespace = "quit-coding-to-vape";
 
-	let personal_dir = |user: &str| format!("{all_personal_dir}/{user}-dir");
+	let personal_dir =
+		|user: &str| all_personal_dir.join(format!("{user}-dir"));
 
 	let user1 = "user1";
 	let user2 = "user2";
@@ -66,7 +67,7 @@ async fn standard_boot_e2e() {
 	// -- CLIENT create manifest.
 	let msg = "testing420";
 	let pivot_args = format!("[--msg,{msg}]");
-	let cli_manifest_path = format!("{}/manifest", &*boot_dir);
+	let cli_manifest_path = boot_dir.join("manifest");
 
 	assert!(Command::new(integration::QOS_CLIENT_PATH)
 		.args([
@@ -84,7 +85,7 @@ async fn standard_boot_e2e() {
 			"--pcr3-preimage-path",
 			PCR3_PRE_IMAGE_PATH,
 			"--manifest-path",
-			&cli_manifest_path,
+			cli_manifest_path.to_str().unwrap(),
 			"--pivot-args",
 			&pivot_args,
 			"--manifest-set-dir",
@@ -141,22 +142,22 @@ async fn standard_boot_e2e() {
 
 	// -- CLIENT make sure each user can run `approve-manifest`
 	for alias in [user1, user2, user3] {
-		let approval_path = format!(
-			"{}/{}-{}-{}.approval",
-			&*boot_dir, alias, namespace, manifest.namespace.nonce,
-		);
+		let approval_path = boot_dir.join(format!(
+			"{}-{}-{}.approval",
+			alias, namespace, manifest.namespace.nonce,
+		));
 
-		let secret_path = format!("{}/{}.secret", &personal_dir(alias), alias);
+		let secret_path = personal_dir(alias).join(format!("{alias}.secret"));
 
 		let mut child = Command::new(integration::QOS_CLIENT_PATH)
 			.args([
 				"approve-manifest",
 				"--secret-path",
-				&*secret_path,
+				secret_path.to_str().unwrap(),
 				"--manifest-path",
-				&cli_manifest_path,
+				cli_manifest_path.to_str().unwrap(),
 				"--manifest-approvals-dir",
-				&*boot_dir,
+				boot_dir.to_str().unwrap(),
 				"--pcr3-preimage-path",
 				PCR3_PRE_IMAGE_PATH,
 				"--pivot-hash-path",
@@ -232,11 +233,9 @@ async fn standard_boot_e2e() {
 		// Read in the generated approval to check it was created correctly
 		let approval: Approval =
 			serde_json::from_slice(&fs::read(approval_path).unwrap()).unwrap();
-		let personal_pair = P256Pair::from_hex_file(format!(
-			"{}/{}.secret",
-			personal_dir(alias),
-			alias,
-		))
+		let personal_pair = P256Pair::from_hex_file(
+			personal_dir(alias).join(format!("{alias}.secret")),
+		)
 		.unwrap();
 
 		let signature = personal_pair.sign(&manifest.qos_hash()).unwrap();
@@ -254,16 +253,16 @@ async fn standard_boot_e2e() {
 		Command::new(integration::QOS_CORE_PATH)
 			.args([
 				"--usock",
-				&*usock,
+				usock.to_str().unwrap(),
 				"--quorum-file",
-				&*secret_path,
+				secret_path.to_str().unwrap(),
 				"--pivot-file",
-				&*pivot_path,
+				pivot_path.to_str().unwrap(),
 				"--ephemeral-file",
-				&*eph_path,
+				eph_path.to_str().unwrap(),
 				"--mock",
 				"--manifest-file",
-				&*manifest_path,
+				manifest_path.to_str().unwrap(),
 			])
 			.spawn()
 			.unwrap()
@@ -278,7 +277,7 @@ async fn standard_boot_e2e() {
 				"--host-ip",
 				LOCAL_HOST,
 				"--usock",
-				&*usock,
+				usock.to_str().unwrap(),
 			])
 			.spawn()
 			.unwrap()
@@ -292,9 +291,9 @@ async fn standard_boot_e2e() {
 		.args([
 			"generate-manifest-envelope",
 			"--manifest-approvals-dir",
-			&*boot_dir,
+			boot_dir.to_str().unwrap(),
 			"--manifest-path",
-			&cli_manifest_path,
+			cli_manifest_path.to_str().unwrap(),
 		])
 		.spawn()
 		.unwrap()
@@ -303,12 +302,12 @@ async fn standard_boot_e2e() {
 		.success());
 
 	// -- CLIENT broadcast boot standard instruction
-	let manifest_envelope_path = format!("{}/manifest_envelope", &*boot_dir,);
+	let manifest_envelope_path = boot_dir.join("manifest_envelope");
 	assert!(Command::new(integration::QOS_CLIENT_PATH)
 		.args([
 			"boot-standard",
 			"--manifest-envelope-path",
-			&manifest_envelope_path,
+			manifest_envelope_path.to_str().unwrap(),
 			"--pivot-path",
 			PIVOT_OK2_PATH,
 			"--host-port",
@@ -338,7 +337,7 @@ async fn standard_boot_e2e() {
 				"--host-ip",
 				LOCAL_HOST,
 				"--attestation-doc-path",
-				&*attestation_doc_path,
+				attestation_doc_path.to_str().unwrap(),
 				"--manifest-envelope-path",
 				"/tmp/dont_care"
 			])
@@ -348,28 +347,28 @@ async fn standard_boot_e2e() {
 			.unwrap()
 			.success());
 
-		let share_path = format!("{}/{}.share", &personal_dir(user), user);
-		let secret_path = format!("{}/{}.secret", &personal_dir(user), user);
-		let eph_wrapped_share_path: PathWrapper =
-			format!("{}/{}.eph_wrapped.share", &*tmp, user).into();
-		let approval_path: PathWrapper =
-			format!("{}/{}.attestation.approval", &*tmp, user).into();
+		let share_path = personal_dir(user).join(format!("{user}.share"));
+		let secret_path = personal_dir(user).join(format!("{user}.secret"));
+		let eph_wrapped_share_path =
+			PathWrapper::from(tmp.join(format!("{user}.eph_wrapped.share")));
+		let approval_path =
+			PathWrapper::from(tmp.join(format!("{user}.attestation.approval")));
 		// Encrypt share to ephemeral key
 		let mut child = Command::new(integration::QOS_CLIENT_PATH)
 			.args([
 				"proxy-re-encrypt-share",
 				"--share-path",
-				&share_path,
+				share_path.to_str().unwrap(),
 				"--secret-path",
-				&secret_path,
+				secret_path.to_str().unwrap(),
 				"--attestation-doc-path",
-				&*attestation_doc_path,
+				attestation_doc_path.to_str().unwrap(),
 				"--eph-wrapped-share-path",
-				&eph_wrapped_share_path,
+				eph_wrapped_share_path.to_str().unwrap(),
 				"--approval-path",
-				&approval_path,
+				approval_path.to_str().unwrap(),
 				"--manifest-envelope-path",
-				&manifest_envelope_path,
+				manifest_envelope_path.to_str().unwrap(),
 				"--pcr3-preimage-path",
 				PCR3_PRE_IMAGE_PATH,
 				"--manifest-set-dir",
@@ -378,7 +377,7 @@ async fn standard_boot_e2e() {
 				user,
 				"--unsafe-skip-attestation",
 				"--unsafe-eph-path-override",
-				&*eph_path,
+				eph_path.to_str().unwrap(),
 			])
 			.stdin(Stdio::piped())
 			.stdout(Stdio::piped())
@@ -433,9 +432,9 @@ async fn standard_boot_e2e() {
 				"--host-ip",
 				LOCAL_HOST,
 				"--eph-wrapped-share-path",
-				&eph_wrapped_share_path,
+				eph_wrapped_share_path.to_str().unwrap(),
 				"--approval-path",
-				&approval_path,
+				approval_path.to_str().unwrap(),
 			])
 			.spawn()
 			.unwrap()

--- a/src/integration/tests/dev_boot.rs
+++ b/src/integration/tests/dev_boot.rs
@@ -5,15 +5,14 @@ use qos_test_primitives::{ChildWrapper, PathWrapper};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn dev_boot_e2e() {
-	let tmp: PathWrapper = "/tmp/dev-boot-e2e-tmp".into();
+	let tmp = PathWrapper::from("/tmp/dev-boot-e2e-tmp");
 	drop(fs::create_dir_all(&*tmp));
-	let _: PathWrapper = PIVOT_OK3_SUCCESS_FILE.into();
-	let usock: PathWrapper = "/tmp/dev-boot-e2e-tmp/sock.sock".into();
-	let secret_path: PathWrapper = "/tmp/dev-boot-e2e-tmp/quorum.secret".into();
-	let pivot_path: PathWrapper = "/tmp/dev-boot-e2e-tmp/pivot.pivot".into();
-	let manifest_path: PathWrapper =
-		"/tmp/dev-boot-e2e-tmp/manifest.manifest".into();
-	let eph_path: PathWrapper = "/tmp/dev-boot-e2e-tmp/eph.secret".into();
+	let _ = PathWrapper::from(PIVOT_OK3_SUCCESS_FILE);
+	let usock = tmp.join("sock.sock");
+	let secret_path = tmp.join("quorum.secret");
+	let pivot_path = tmp.join("pivot.pivot");
+	let manifest_path = tmp.join("manifest.manifest");
+	let eph_path = tmp.join("eph.secret");
 
 	let host_port = qos_test_primitives::find_free_port().unwrap();
 
@@ -22,16 +21,16 @@ async fn dev_boot_e2e() {
 		Command::new(integration::QOS_CORE_PATH)
 			.args([
 				"--usock",
-				&*usock,
+				usock.to_str().unwrap(),
 				"--quorum-file",
-				&*secret_path,
+				secret_path.to_str().unwrap(),
 				"--pivot-file",
-				&*pivot_path,
+				pivot_path.to_str().unwrap(),
 				"--ephemeral-file",
-				&*eph_path,
+				eph_path.to_str().unwrap(),
 				"--mock",
 				"--manifest-file",
-				&*manifest_path,
+				manifest_path.to_str().unwrap(),
 			])
 			.spawn()
 			.unwrap()
@@ -46,7 +45,7 @@ async fn dev_boot_e2e() {
 				"--host-ip",
 				LOCAL_HOST,
 				"--usock",
-				&*usock,
+				usock.to_str().unwrap(),
 			])
 			.spawn()
 			.unwrap()
@@ -69,7 +68,7 @@ async fn dev_boot_e2e() {
 			"--pivot-args",
 			"[--msg,vapers-only]",
 			"--unsafe-eph-path-override",
-			&*eph_path,
+			eph_path.to_str().unwrap(),
 		])
 		.spawn()
 		.unwrap()

--- a/src/integration/tests/enclave_app_client_socket_stress.rs
+++ b/src/integration/tests/enclave_app_client_socket_stress.rs
@@ -27,7 +27,7 @@ const APP_SOCK: &str = "/tmp/enclave_app_client_socket_stress/app.sock";
 
 #[tokio::test(flavor = "multi_thread")]
 async fn enclave_app_client_socket_stress() {
-	let _: PathWrapper = TEST_TMP.into();
+	let _ = PathWrapper::from(TEST_TMP);
 	std::fs::create_dir_all(TEST_TMP).unwrap();
 
 	let manifest = Manifest {

--- a/src/integration/tests/genesis.rs
+++ b/src/integration/tests/genesis.rs
@@ -20,28 +20,24 @@ const DR_KEY_PRIVATE_PATH: &str = "./mock/mock_p256_dr.secret.keep";
 #[tokio::test(flavor = "multi_thread")]
 async fn genesis_e2e() {
 	let host_port = qos_test_primitives::find_free_port().unwrap();
-	let tmp: PathWrapper = "/tmp/genesis-e2e".into();
-	fs::create_dir_all(&*tmp).unwrap();
-	let tmp_dir =
-		|file: &str| -> PathWrapper { format!("{}/{file}", &*tmp).into() };
+	let tmp_dir = PathWrapper::from("/tmp/genesis-e2e");
+	fs::create_dir_all(&*tmp_dir).unwrap();
 
-	let usock = tmp_dir("genesis_e2e.sock");
-	let secret_path = tmp_dir("genesis_e2e.secret");
-	let pivot_path = tmp_dir("genesis_e2e.pivot");
-	let manifest_path = tmp_dir("manifest.manifest");
+	let usock = tmp_dir.join("genesis_e2e.sock");
+	let secret_path = tmp_dir.join("genesis_e2e.secret");
+	let pivot_path = tmp_dir.join("genesis_e2e.pivot");
+	let manifest_path = tmp_dir.join("manifest.manifest");
 
-	let all_personal_dir = tmp_dir("all-personal-dir");
-	let genesis_dir = tmp_dir("genesis-dir");
+	let all_personal_dir = tmp_dir.join("all-personal-dir");
+	let genesis_dir = tmp_dir.join("genesis-dir");
 
-	let attestation_doc_path =
-		format!("{}/genesis_attestation_doc", &*genesis_dir);
-	let genesis_output_path = format!("{}/genesis_output", &*genesis_dir);
-	let dr_wrapped_quorum_key_path =
-		format!("{}/dr_wrapped_quorum_key", &*genesis_dir);
-	let dr_artifacts_path = format!("{}/genesis_dr_artifacts", &*genesis_dir);
+	let attestation_doc_path = genesis_dir.join("genesis_attestation_doc");
+	let genesis_output_path = genesis_dir.join("genesis_output");
+	let dr_wrapped_quorum_key_path = genesis_dir.join("dr_wrapped_quorum_key");
+	let dr_artifacts_path = genesis_dir.join("genesis_dr_artifacts");
 
 	let personal_dir =
-		|user: &str| format!("{}/{}-dir", &*all_personal_dir, user);
+		|user: &str| all_personal_dir.join(format!("{user}-dir"));
 	let get_key_paths =
 		|user: &str| (format!("{user}.secret"), format!("{user}.pub"));
 
@@ -66,15 +62,15 @@ async fn genesis_e2e() {
 		(&user3, &user3_private_share_key, &user3_public_share_key),
 	] {
 		fs::create_dir_all(personal_dir(user)).unwrap();
-		let master_seed_path = format!("{}/{}", personal_dir(user), private);
-		let public_path = format!("{}/{}", personal_dir(user), public);
+		let master_seed_path = personal_dir(user).join(private);
+		let public_path = personal_dir(user).join(public);
 		assert!(Command::new(integration::QOS_CLIENT_PATH)
 			.args([
 				"generate-file-key",
 				"--master-seed-path",
-				&master_seed_path,
+				master_seed_path.to_str().unwrap(),
 				"--pub-path",
-				&public_path,
+				public_path.to_str().unwrap(),
 			])
 			.spawn()
 			.unwrap()
@@ -106,14 +102,14 @@ async fn genesis_e2e() {
 		Command::new(integration::QOS_CORE_PATH)
 			.args([
 				"--usock",
-				&*usock,
+				usock.to_str().unwrap(),
 				"--quorum-file",
-				&*secret_path,
+				secret_path.to_str().unwrap(),
 				"--pivot-file",
-				&*pivot_path,
+				pivot_path.to_str().unwrap(),
 				"--mock",
 				"--manifest-file",
-				&*manifest_path,
+				manifest_path.to_str().unwrap(),
 			])
 			.spawn()
 			.unwrap()
@@ -128,7 +124,7 @@ async fn genesis_e2e() {
 				"--host-ip",
 				LOCAL_HOST,
 				"--usock",
-				&*usock,
+				usock.to_str().unwrap(),
 			])
 			.spawn()
 			.unwrap()
@@ -143,9 +139,9 @@ async fn genesis_e2e() {
 		.args([
 			"boot-genesis",
 			"--share-set-dir",
-			&*genesis_dir,
+			genesis_dir.to_str().unwrap(),
 			"--namespace-dir",
-			&*genesis_dir,
+			genesis_dir.to_str().unwrap(),
 			"--host-ip",
 			LOCAL_HOST,
 			"--host-port",
@@ -212,19 +208,19 @@ async fn genesis_e2e() {
 	// -- CLIENT make sure each user can run `after-genesis` against their
 	// member output and decrypt their share with their share key.
 	for user in [&user1, &user2, &user3] {
-		let share_path = format!("{}/{}.share", &personal_dir(user), user);
-		let secret_path = format!("{}/{}.secret", &personal_dir(user), user);
+		let share_path = personal_dir(user).join(format!("{user}.share"));
+		let secret_path = personal_dir(user).join(format!("{user}.secret"));
 		assert!(Command::new(integration::QOS_CLIENT_PATH)
 			.args([
 				"after-genesis",
 				"--secret-path",
-				&secret_path,
+				secret_path.to_str().unwrap(),
 				"--share-path",
-				&share_path,
+				share_path.to_str().unwrap(),
 				"--alias",
 				user,
 				"--namespace-dir",
-				&genesis_dir,
+				genesis_dir.to_str().unwrap(),
 				"--qos-release-dir",
 				QOS_DIST_DIR,
 				"--pcr3-preimage-path",
@@ -267,14 +263,15 @@ async fn genesis_e2e() {
 	assert_eq!(io::BufReader::new(dr_artifacts_contents).lines().count(), 4);
 
 	// Check that we can verify the dr artifacts.
-	let reconstructed_path = tmp_dir("reconstructed_quorum_master_seed_hex");
-	reconstructed.to_hex_file(&*reconstructed_path).unwrap();
+	let reconstructed_path =
+		tmp_dir.join("reconstructed_quorum_master_seed_hex");
+	reconstructed.to_hex_file(&reconstructed_path).unwrap();
 	assert!(Command::new(integration::QOS_CLIENT_PATH)
 		.arg("verify-genesis")
 		.arg("--namespace-dir")
-		.arg(&*genesis_dir)
+		.arg(genesis_dir)
 		.arg("--master-seed-path")
-		.arg(&*reconstructed_path)
+		.arg(reconstructed_path)
 		.spawn()
 		.unwrap()
 		.wait()

--- a/src/integration/tests/host_bridge.rs
+++ b/src/integration/tests/host_bridge.rs
@@ -46,5 +46,5 @@ async fn vsock_to_tcp_bridge_works() {
 	let mut buf = [0u8; 4];
 	assert_eq!(4, stream2.read(&mut buf).await.unwrap());
 
-	assert!(pivot.0.wait().unwrap().success());
+	assert!(pivot.wait().unwrap().success());
 }

--- a/src/integration/tests/key.rs
+++ b/src/integration/tests/key.rs
@@ -27,7 +27,7 @@ const QUORUM_KEY_PUB_PATH: &str =
 #[tokio::test(flavor = "multi_thread")]
 async fn key_fwd_e2e() {
 	// Make sure everything in the temp dir gets dropped
-	let _: PathWrapper = TMP_DIR.into();
+	let _ = PathWrapper::from(TMP_DIR);
 	fs::create_dir_all(BOOT_DIR).unwrap();
 	let old_host_port = qos_test_primitives::find_free_port().unwrap();
 	let new_host_port = qos_test_primitives::find_free_port().unwrap();
@@ -351,10 +351,10 @@ fn boot_old_enclave(old_host_port: u16) -> (ChildWrapper, ChildWrapper) {
 	for user in &USERS[0..2] {
 		let share_path = format!("{}/{}.share", &personal_dir(user), user);
 		let secret_path = format!("{}/{}.secret", &personal_dir(user), user);
-		let eph_wrapped_share_path: PathWrapper =
-			format!("{TMP_DIR}/{user}.eph_wrapped.share").into();
-		let approval_path: PathWrapper =
-			format!("{TMP_DIR}/{user}.attestation.approval").into();
+		let eph_wrapped_share_path =
+			PathWrapper::from(format!("{TMP_DIR}/{user}.eph_wrapped.share"));
+		let approval_path =
+			PathWrapper::from(format!("{TMP_DIR}/{user}.attestation.approval"));
 		assert!(Command::new(integration::QOS_CLIENT_PATH)
 			.args([
 				"proxy-re-encrypt-share",
@@ -365,9 +365,9 @@ fn boot_old_enclave(old_host_port: u16) -> (ChildWrapper, ChildWrapper) {
 				"--attestation-doc-path",
 				ATTESTATION_DOC_PATH,
 				"--eph-wrapped-share-path",
-				&eph_wrapped_share_path,
+				eph_wrapped_share_path.to_str().unwrap(),
 				"--approval-path",
-				&approval_path,
+				approval_path.to_str().unwrap(),
 				"--manifest-envelope-path",
 				MANIFEST_ENVELOPE_PATH,
 				"--pcr3-preimage-path",
@@ -395,9 +395,9 @@ fn boot_old_enclave(old_host_port: u16) -> (ChildWrapper, ChildWrapper) {
 				"--host-ip",
 				LOCAL_HOST,
 				"--eph-wrapped-share-path",
-				&eph_wrapped_share_path,
+				eph_wrapped_share_path.to_str().unwrap(),
 				"--approval-path",
-				&approval_path,
+				approval_path.to_str().unwrap(),
 			])
 			.spawn()
 			.unwrap()

--- a/src/integration/tests/qos_bridge.rs
+++ b/src/integration/tests/qos_bridge.rs
@@ -1,6 +1,7 @@
 use std::{
 	fs,
 	io::{BufRead, BufReader, Write},
+	path::PathBuf,
 	process::{Command, Stdio},
 };
 
@@ -35,33 +36,34 @@ async fn qos_bridge_works() {
 	let host_port = qos_test_primitives::find_free_port().unwrap();
 	let app_host_port = qos_test_primitives::find_free_port().unwrap();
 	let app_host_port_override = qos_test_primitives::find_free_port().unwrap();
-	let tmp: PathWrapper = "/tmp/qos_host_bridge".into();
-	let _: PathWrapper = PIVOT_HASH_PATH.into();
-	fs::create_dir_all(&*tmp).unwrap();
+	let tmp = PathWrapper::from("/tmp/qos_host_bridge");
+	let _ = PathWrapper::from(PIVOT_HASH_PATH);
+	fs::create_dir_all(&tmp).unwrap();
 
 	let usock_path = "/tmp/qos_host_bridge/qos_host_bridge.sock".to_owned();
-	let usock: PathWrapper = usock_path.clone().into();
-	let secret_path: PathWrapper =
-		"/tmp/qos_host_bridge/qos_host_bridge.secret".into();
-	let pivot_path: PathWrapper =
-		"/tmp/qos_host_bridge/qos_host_bridge.pivot".into();
-	let manifest_path: PathWrapper =
-		"/tmp/qos_host_bridge/qos_host_bridge.manifest".into();
-	let eph_path: PathWrapper =
-		"/tmp/qos_host_bridge/ephemeral_key.secret".into();
+	let usock = PathWrapper::from(usock_path.clone());
+	let secret_path =
+		PathWrapper::from("/tmp/qos_host_bridge/qos_host_bridge.secret");
+	let pivot_path =
+		PathWrapper::from("/tmp/qos_host_bridge/qos_host_bridge.pivot");
+	let manifest_path =
+		PathWrapper::from("/tmp/qos_host_bridge/qos_host_bridge.manifest");
+	let eph_path =
+		PathWrapper::from("/tmp/qos_host_bridge/ephemeral_key.secret");
 
-	let boot_dir: PathWrapper = "/tmp/qos_host_bridge/boot-dir".into();
-	fs::create_dir_all(&*boot_dir).unwrap();
-	let attestation_dir: PathWrapper =
-		"/tmp/qos_host_bridge/attestation-dir".into();
-	fs::create_dir_all(&*attestation_dir).unwrap();
-	let attestation_doc_path = format!("{}/attestation_doc", &*attestation_dir);
+	let boot_dir = PathWrapper::from("/tmp/qos_host_bridge/boot-dir");
+	fs::create_dir_all(&boot_dir).unwrap();
+	let attestation_dir =
+		PathWrapper::from("/tmp/qos_host_bridge/attestation-dir");
+	fs::create_dir_all(&attestation_dir).unwrap();
+	let attestation_doc_path = attestation_dir.join("attestation_doc");
 
-	let all_personal_dir = "./mock/boot-e2e/all-personal-dir";
+	let all_personal_dir = PathBuf::from("./mock/boot-e2e/all-personal-dir");
 
 	let namespace = "quit-coding-to-vape";
 
-	let personal_dir = |user: &str| format!("{all_personal_dir}/{user}-dir");
+	let personal_dir =
+		|user: &str| all_personal_dir.join(format!("{user}-dir"));
 
 	let user1 = "user1";
 	let user2 = "user2";
@@ -77,7 +79,7 @@ async fn qos_bridge_works() {
 	let pivot_app_sock_path =
 		usock_path + "." + &app_host_port.to_string() + ".appsock";
 	let pivot_args = format!("[{pivot_app_sock_path}]");
-	let cli_manifest_path = format!("{}/manifest", &*boot_dir);
+	let cli_manifest_path = boot_dir.join("manifest");
 
 	assert!(Command::new(integration::QOS_CLIENT_PATH)
 		.args([
@@ -95,7 +97,7 @@ async fn qos_bridge_works() {
 			"--pcr3-preimage-path",
 			PCR3_PRE_IMAGE_PATH,
 			"--manifest-path",
-			&cli_manifest_path,
+			cli_manifest_path.to_str().unwrap(),
 			"--pivot-args",
 			&pivot_args,
 			"--manifest-set-dir",
@@ -158,22 +160,22 @@ async fn qos_bridge_works() {
 
 	// -- CLIENT make sure each user can run `approve-manifest`
 	for alias in [user1, user2, user3] {
-		let approval_path = format!(
-			"{}/{}-{}-{}.approval",
-			&*boot_dir, alias, namespace, manifest.namespace.nonce,
-		);
+		let approval_path = boot_dir.join(format!(
+			"{}-{}-{}.approval",
+			alias, namespace, manifest.namespace.nonce,
+		));
 
-		let secret_path = format!("{}/{}.secret", &personal_dir(alias), alias);
+		let secret_path = personal_dir(alias).join(format!("{alias}.secret"));
 
 		let mut child = Command::new(integration::QOS_CLIENT_PATH)
 			.args([
 				"approve-manifest",
 				"--secret-path",
-				&*secret_path,
+				secret_path.to_str().unwrap(),
 				"--manifest-path",
-				&cli_manifest_path,
+				cli_manifest_path.to_str().unwrap(),
 				"--manifest-approvals-dir",
-				&*boot_dir,
+				boot_dir.to_str().unwrap(),
 				"--pcr3-preimage-path",
 				PCR3_PRE_IMAGE_PATH,
 				"--pivot-hash-path",
@@ -249,11 +251,9 @@ async fn qos_bridge_works() {
 		// Read in the generated approval to check it was created correctly
 		let approval: Approval =
 			serde_json::from_slice(&fs::read(approval_path).unwrap()).unwrap();
-		let personal_pair = P256Pair::from_hex_file(format!(
-			"{}/{}.secret",
-			personal_dir(alias),
-			alias,
-		))
+		let personal_pair = P256Pair::from_hex_file(
+			personal_dir(alias).join(format!("{alias}.secret",)),
+		)
 		.unwrap();
 
 		let signature = personal_pair.sign(&manifest.qos_hash()).unwrap();
@@ -271,16 +271,16 @@ async fn qos_bridge_works() {
 		Command::new(integration::QOS_CORE_PATH)
 			.args([
 				"--usock",
-				&*usock,
+				usock.to_str().unwrap(),
 				"--quorum-file",
-				&*secret_path,
+				secret_path.to_str().unwrap(),
 				"--pivot-file",
-				&*pivot_path,
+				pivot_path.to_str().unwrap(),
 				"--ephemeral-file",
-				&*eph_path,
+				eph_path.to_str().unwrap(),
 				"--mock",
 				"--manifest-file",
-				&*manifest_path,
+				manifest_path.to_str().unwrap(),
 			])
 			.spawn()
 			.unwrap()
@@ -295,7 +295,7 @@ async fn qos_bridge_works() {
 				"--host-ip",
 				LOCAL_HOST,
 				"--usock",
-				&*usock,
+				usock.to_str().unwrap(),
 			])
 			.spawn()
 			.unwrap()
@@ -312,7 +312,7 @@ async fn qos_bridge_works() {
 				"--host-port-override",
 				&app_host_port_override.to_string(),
 				"--usock",
-				&*usock,
+				usock.to_str().unwrap(),
 				"--control-url",
 				&control_url,
 			])
@@ -325,9 +325,9 @@ async fn qos_bridge_works() {
 		.args([
 			"generate-manifest-envelope",
 			"--manifest-approvals-dir",
-			&*boot_dir,
+			boot_dir.to_str().unwrap(),
 			"--manifest-path",
-			&cli_manifest_path,
+			cli_manifest_path.to_str().unwrap(),
 		])
 		.spawn()
 		.unwrap()
@@ -336,12 +336,12 @@ async fn qos_bridge_works() {
 		.success());
 
 	// -- CLIENT broadcast boot standard instruction
-	let manifest_envelope_path = format!("{}/manifest_envelope", &*boot_dir,);
+	let manifest_envelope_path = boot_dir.join("manifest_envelope");
 	assert!(Command::new(integration::QOS_CLIENT_PATH)
 		.args([
 			"boot-standard",
 			"--manifest-envelope-path",
-			&manifest_envelope_path,
+			manifest_envelope_path.to_str().unwrap(),
 			"--pivot-path",
 			PIVOT_SOCKET_STRESS_PATH,
 			"--host-port",
@@ -369,7 +369,7 @@ async fn qos_bridge_works() {
 				"--host-ip",
 				LOCAL_HOST,
 				"--attestation-doc-path",
-				&*attestation_doc_path,
+				attestation_doc_path.to_str().unwrap(),
 				"--manifest-envelope-path",
 				"/tmp/dont_care"
 			])
@@ -379,28 +379,29 @@ async fn qos_bridge_works() {
 			.unwrap()
 			.success());
 
-		let share_path = format!("{}/{}.share", &personal_dir(user), user);
-		let secret_path = format!("{}/{}.secret", &personal_dir(user), user);
-		let eph_wrapped_share_path: PathWrapper =
-			format!("{}/{}.eph_wrapped.share", &*tmp, user).into();
-		let approval_path: PathWrapper =
-			format!("{}/{}.attestation.approval", &*tmp, user).into();
+		let share_path = personal_dir(user).join(format!("{user}.share"));
+		let secret_path = personal_dir(user).join(format!("{user}.secret"));
+		let eph_wrapped_share_path =
+			PathWrapper::from(tmp.join(format!("{user}.eph_wrapped.share")));
+		let approval_path = PathWrapper::from(
+			tmp.join(format!("{user}.attestation.approval",)),
+		);
 		// Encrypt share to ephemeral key
 		let mut child = Command::new(integration::QOS_CLIENT_PATH)
 			.args([
 				"proxy-re-encrypt-share",
 				"--share-path",
-				&share_path,
+				share_path.to_str().unwrap(),
 				"--secret-path",
-				&secret_path,
+				secret_path.to_str().unwrap(),
 				"--attestation-doc-path",
-				&*attestation_doc_path,
+				attestation_doc_path.to_str().unwrap(),
 				"--eph-wrapped-share-path",
-				&eph_wrapped_share_path,
+				eph_wrapped_share_path.to_str().unwrap(),
 				"--approval-path",
-				&approval_path,
+				approval_path.to_str().unwrap(),
 				"--manifest-envelope-path",
-				&manifest_envelope_path,
+				manifest_envelope_path.to_str().unwrap(),
 				"--pcr3-preimage-path",
 				PCR3_PRE_IMAGE_PATH,
 				"--manifest-set-dir",
@@ -409,7 +410,7 @@ async fn qos_bridge_works() {
 				user,
 				"--unsafe-skip-attestation",
 				"--unsafe-eph-path-override",
-				&*eph_path,
+				eph_path.to_str().unwrap(),
 			])
 			.stdin(Stdio::piped())
 			.stdout(Stdio::piped())
@@ -464,9 +465,9 @@ async fn qos_bridge_works() {
 				"--host-ip",
 				LOCAL_HOST,
 				"--eph-wrapped-share-path",
-				&eph_wrapped_share_path,
+				eph_wrapped_share_path.to_str().unwrap(),
 				"--approval-path",
-				&approval_path,
+				approval_path.to_str().unwrap(),
 			])
 			.spawn()
 			.unwrap()
@@ -518,7 +519,7 @@ async fn qos_bridge_works() {
 	}
 
 	// test qos_bridge restart after enclave is up
-	bridge_child_process.0.kill().expect("unable to kill qos_host");
+	bridge_child_process.kill().expect("unable to kill qos_host");
 	drop(bridge_child_process);
 
 	// -- BRIDGE restart bridge
@@ -528,7 +529,7 @@ async fn qos_bridge_works() {
 				"--host-port-override",
 				&app_host_port_override.to_string(),
 				"--usock",
-				&*usock,
+				usock.to_str().unwrap(),
 				"--control-url",
 				&control_url,
 			])

--- a/src/integration/tests/qos_host.rs
+++ b/src/integration/tests/qos_host.rs
@@ -28,11 +28,11 @@ async fn connects_and_gets_info() {
 	assert!(r.is_err()); // expect 500 here
 
 	let enclave_socket = format!("{TEST_ENCLAVE_SOCKET}_0"); // manually pick the 1st one
-	let secret_path: PathWrapper = "/tmp/qos_host_test.secret".into();
-	let manifest_path: PathWrapper = "/tmp/qos_host_test.manifest".into();
+	let secret_path = PathWrapper::from("/tmp/qos_host_test.secret");
+	let manifest_path = PathWrapper::from("/tmp/qos_host_test.manifest");
 
 	// For our sanity, ensure the secret does not yet exist
-	drop(std::fs::remove_file(&*secret_path));
+	drop(std::fs::remove_file(&secret_path));
 	// Remove the socket file if it exists as well, in case of bad crashes
 	drop(std::fs::remove_file(&enclave_socket));
 
@@ -42,14 +42,14 @@ async fn connects_and_gets_info() {
 				"--usock",
 				TEST_ENCLAVE_SOCKET,
 				"--quorum-file",
-				&*secret_path,
+				secret_path.to_str().unwrap(),
 				"--pivot-file",
 				PIVOT_OK_PATH,
 				"--ephemeral-file",
 				"eph_path",
 				"--mock",
 				"--manifest-file",
-				&*manifest_path,
+				manifest_path.to_str().unwrap(),
 			])
 			.spawn()
 			.unwrap()

--- a/src/integration/tests/reaper.rs
+++ b/src/integration/tests/reaper.rs
@@ -22,9 +22,9 @@ use tokio::{
 
 #[tokio::test(flavor = "multi_thread")]
 async fn reaper_works() {
-	let secret_path: PathWrapper = "/tmp/reaper_works.secret".into();
-	let usock: PathWrapper = "/tmp/reaper_works.sock".into();
-	let manifest_path: PathWrapper = "/tmp/reaper_works.manifest".into();
+	let secret_path = PathWrapper::from("/tmp/reaper_works.secret");
+	let usock = PathWrapper::from("/tmp/reaper_works.sock");
+	let manifest_path = PathWrapper::from("/tmp/reaper_works.manifest");
 	let msg = "durp-a-durp";
 
 	// For our sanity, ensure the secret does not yet exist
@@ -32,8 +32,8 @@ async fn reaper_works() {
 
 	let handles = Handles::new(
 		"eph_path".to_string(),
-		(*secret_path).to_string(),
-		(*manifest_path).to_string(),
+		secret_path.to_str().map(ToString::to_string).unwrap(),
+		manifest_path.to_str().map(ToString::to_string).unwrap(),
 		PIVOT_OK_PATH.to_string(),
 	);
 
@@ -75,8 +75,8 @@ async fn reaper_works() {
 async fn reaper_clears_host_env() {
 	let secret_path = PathWrapper::from("/tmp/reaper_clears_host_env.secret");
 	let usock = PathWrapper::from("/tmp/reaper_clears_host_env.sock");
-	let manifest_path: PathWrapper =
-		"/tmp/reaper_clears_host_env.manifest".into();
+	let manifest_path =
+		PathWrapper::from("/tmp/reaper_clears_host_env.manifest");
 	let msg = "host-env-cleared";
 	let host_only_env_key = "QOS_TEST_REAPER_HOST_ONLY_ENV";
 
@@ -85,8 +85,8 @@ async fn reaper_clears_host_env() {
 
 	let handles = Handles::new(
 		"reaper_clears_host_env.eph".to_string(),
-		(*secret_path).to_string(),
-		(*manifest_path).to_string(),
+		secret_path.to_str().map(ToString::to_string).unwrap(),
+		manifest_path.to_str().map(ToString::to_string).unwrap(),
 		PIVOT_OK2_PATH.to_string(),
 	);
 
@@ -189,19 +189,19 @@ async fn reaper_clears_host_env() {
 
 #[tokio::test]
 async fn reaper_handles_non_zero_exits() {
-	let secret_path: PathWrapper =
-		"/tmp/reaper_handles_non_zero_exits.secret".into();
-	let usock: PathWrapper = "/tmp/reaper_handles_non_zero_exits.sock".into();
-	let manifest_path: PathWrapper =
-		"/tmp/reaper_handles_non_zero_exits.manifest".into();
+	let secret_path =
+		PathWrapper::from("/tmp/reaper_handles_non_zero_exits.secret");
+	let usock = PathWrapper::from("/tmp/reaper_handles_non_zero_exits.sock");
+	let manifest_path =
+		PathWrapper::from("/tmp/reaper_handles_non_zero_exits.manifest");
 
 	// For our sanity, ensure the secret does not yet exist
 	drop(fs::remove_file(&*secret_path));
 
 	let handles = Handles::new(
 		"eph_path".to_string(),
-		(*secret_path).to_string(),
-		(*manifest_path).to_string(),
+		secret_path.to_str().map(ToString::to_string).unwrap(),
+		manifest_path.to_str().map(ToString::to_string).unwrap(),
 		PIVOT_ABORT_PATH.to_string(),
 	);
 
@@ -237,18 +237,18 @@ async fn reaper_handles_non_zero_exits() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn reaper_handles_panic() {
-	let secret_path: PathWrapper = "/tmp/reaper_handles_panics.secret".into();
-	let usock: PathWrapper = "/tmp/reaper_handles_panics.sock".into();
-	let manifest_path: PathWrapper =
-		"/tmp/reaper_handles_panics.manifest".into();
+	let secret_path = PathWrapper::from("/tmp/reaper_handles_panics.secret");
+	let usock = PathWrapper::from("/tmp/reaper_handles_panics.sock");
+	let manifest_path =
+		PathWrapper::from("/tmp/reaper_handles_panics.manifest");
 
 	// For our sanity, ensure the secret does not yet exist
 	drop(fs::remove_file(&*secret_path));
 
 	let handles = Handles::new(
 		"eph_path".to_string(),
-		secret_path.to_string(),
-		manifest_path.to_string(),
+		secret_path.to_str().map(ToString::to_string).unwrap(),
+		manifest_path.to_str().map(ToString::to_string).unwrap(),
 		PIVOT_PANIC_PATH.to_string(),
 	);
 
@@ -286,20 +286,21 @@ async fn reaper_handles_panic() {
 async fn reaper_handles_bridge() {
 	let pivot_port = find_free_port().unwrap();
 	let host_port = find_free_port().unwrap();
-	let secret_path: PathWrapper = "/tmp/reaper_handles_bridge.secret".into();
-	let usock: PathWrapper = "/tmp/reaper_handles_bridge.sock".into();
-	let app_usock: PathWrapper =
-		format!("/tmp/reaper_handles_bridge.sock.{pivot_port}.appsock").into();
-	let manifest_path: PathWrapper =
-		"/tmp/reaper_handles_bridge.manifest".into();
+	let secret_path = PathWrapper::from("/tmp/reaper_handles_bridge.secret");
+	let usock = PathWrapper::from("/tmp/reaper_handles_bridge.sock");
+	let app_usock = PathWrapper::from(format!(
+		"/tmp/reaper_handles_bridge.sock.{pivot_port}.appsock"
+	));
+	let manifest_path =
+		PathWrapper::from("/tmp/reaper_handles_bridge.manifest");
 
 	// For our sanity, ensure the secret does not yet exist
 	drop(fs::remove_file(&*secret_path));
 
 	let handles = Handles::new(
 		"eph_path".to_string(),
-		(*secret_path).to_string(),
-		(*manifest_path).to_string(),
+		secret_path.to_str().map(ToString::to_string).unwrap(),
+		manifest_path.to_str().map(ToString::to_string).unwrap(),
 		PIVOT_TCP_PATH.to_string(),
 	);
 

--- a/src/integration/tests/version.rs
+++ b/src/integration/tests/version.rs
@@ -1,0 +1,114 @@
+use borsh::BorshDeserialize;
+use integration::{wait_for_tcp_sock, wait_for_usock, PIVOT_OK_PATH};
+use qos_core::{
+	handles::Handles, io::SocketAddress, protocol::msg::ProtocolMsg,
+	reaper::Reaper,
+};
+use qos_host::host::HostServer;
+use qos_nsm::mock::MockNsm;
+use qos_test_primitives::PathWrapper;
+use std::{
+	io::{self, Read},
+	net::{Ipv4Addr, SocketAddr},
+	time::Duration,
+};
+use tokio::{
+	fs::{create_dir_all, remove_dir_all},
+	join, select,
+};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn version_request_returns_version_and_commit() -> Result<(), io::Error> {
+	const HOST_PORT: u16 = 3324;
+	let test_dir = PathWrapper::from("/tmp/qos_version_test");
+
+	// Pre-clean in case a prior crashed run left files behind.
+	remove_dir_all(&test_dir).await.or_else(|err| match err.kind() {
+		io::ErrorKind::NotFound => Ok(()),
+		_ => Err(err),
+	})?;
+	create_dir_all(&test_dir).await?;
+
+	let socket = test_dir.join("enclave.sock");
+	let secret = test_dir.join("qos.secret");
+	let manifest = test_dir.join("qos.manifest");
+	let eph = test_dir.join("eph.key");
+
+	let qos_core_handles = Handles::new(
+		eph.to_string_lossy().into_owned(),
+		secret.to_string_lossy().into_owned(),
+		manifest.to_string_lossy().into_owned(),
+		PIVOT_OK_PATH.to_string(),
+	);
+
+	let qos_core_socket = SocketAddress::new_unix(&socket);
+	let mut qos_core_task = tokio::spawn(async move {
+		Reaper::execute(
+			&qos_core_handles,
+			Box::new(MockNsm),
+			qos_core_socket,
+			None,
+		)
+		.await;
+		panic!("qos_core task ended prematurely");
+	});
+
+	let addr = Ipv4Addr::LOCALHOST;
+
+	let qos_host_server = HostServer::new(
+		SocketAddress::new_unix(&socket),
+		Duration::from_millis(50),
+		SocketAddr::new(addr.into(), HOST_PORT),
+		None,
+	);
+	let mut qos_host_task = tokio::spawn(async move {
+		qos_host_server.serve().await;
+		panic!("qos_host task ended prematurely");
+	});
+
+	let wait_for_sockets_future = async move {
+		let addr = &(addr, HOST_PORT);
+		join!(
+			wait_for_tcp_sock(&addr),
+			wait_for_usock(socket.to_str().unwrap())
+		)
+	};
+
+	select! {
+		res = &mut qos_host_task => match res {
+			Err(join_err) => {
+				return Err(io::Error::other(format!("qos_host task did not run to completion: {join_err}")))
+			},
+			Ok(()) => unreachable!("tokio tasks should explicitly panic if it exits early"),
+		},
+		res = &mut qos_core_task => match res {
+			Err(join_err) => {
+				return Err(io::Error::other(format!("qos_core task did not run to completion: {join_err}")))
+
+			},
+			Ok(()) => unreachable!("tokio tasks should explicitly panic if it exits early"),
+		},
+		_ = wait_for_sockets_future => {},
+	}
+
+	let url = format!("http://127.0.0.1:{HOST_PORT}/qos/message");
+	let req_bytes = borsh::to_vec(&ProtocolMsg::VersionRequest).unwrap();
+	let response = ureq::post(&url).send_bytes(&req_bytes).unwrap();
+
+	let mut buf = Vec::new();
+	response.into_reader().read_to_end(&mut buf).unwrap();
+	let decoded = ProtocolMsg::try_from_slice(&buf).unwrap();
+
+	match decoded {
+		ProtocolMsg::VersionResponse { version, commit } => {
+			assert_eq!(version, env!("CARGO_PKG_VERSION"));
+			assert!(!commit.is_empty(), "commit should not be empty");
+		}
+		other => panic!("unexpected response: {other:?}"),
+	}
+
+	qos_host_task.abort();
+	qos_core_task.abort();
+
+	Ok(())
+}

--- a/src/qos_client/src/cli/mod.rs
+++ b/src/qos_client/src/cli/mod.rs
@@ -110,6 +110,8 @@ pub enum Command {
 	HostHealth,
 	/// Query the status of the enclave.
 	EnclaveStatus,
+	/// Query the QOS version and git commit of the running enclave.
+	EnclaveVersion,
 	/// Generate a Setup Key for use in the Genesis ceremony.
 	GenerateFileKey,
 	/// Run the the Boot Genesis logic to generate and shard a Quorum Key
@@ -230,6 +232,7 @@ impl From<&str> for Command {
 		match s {
 			"host-health" => Self::HostHealth,
 			"enclave-status" => Self::EnclaveStatus,
+			"enclave-version" => Self::EnclaveVersion,
 			"generate-file-key" => Self::GenerateFileKey,
 			"generate-manifest-envelope" => Self::GenerateManifestEnvelope,
 			"boot-genesis" => Self::BootGenesis,
@@ -862,7 +865,9 @@ impl Command {
 impl GetParserForCommand for Command {
 	fn parser(&self) -> Parser {
 		match self {
-			Self::HostHealth | Self::EnclaveStatus => Self::base(),
+			Self::HostHealth | Self::EnclaveStatus | Self::EnclaveVersion => {
+				Self::base()
+			}
 			Self::GenerateFileKey => Self::generate_file_key(),
 			Self::BootGenesis => Self::boot_genesis(),
 			Self::AfterGenesis => Self::after_genesis(),
@@ -1299,6 +1304,9 @@ impl ClientRunner {
 			match self.cmd {
 				Command::HostHealth => handlers::host_health(&self.opts),
 				Command::EnclaveStatus => handlers::enclave_status(&self.opts),
+				Command::EnclaveVersion => {
+					handlers::enclave_version(&self.opts);
+				}
 				Command::GenerateFileKey => {
 					handlers::generate_file_key(&self.opts);
 				}
@@ -1430,6 +1438,22 @@ mod handlers {
 		match response {
 			ProtocolMsg::StatusResponse(phase) => {
 				println!("Enclave phase: {phase:?}");
+			}
+			other => panic!("Unexpected response {other:?}"),
+		}
+	}
+
+	pub(super) fn enclave_version(opts: &ClientOpts) {
+		let path = &opts.path_message();
+
+		let response = request::post(path, &ProtocolMsg::VersionRequest)
+			.map_err(|e| println!("{e:?}"))
+			.expect("Enclave request failed");
+
+		match response {
+			ProtocolMsg::VersionResponse { version, commit } => {
+				println!("QOS version: {version}");
+				println!("Git commit:  {commit}");
 			}
 			other => panic!("Unexpected response {other:?}"),
 		}

--- a/src/qos_client/tests/golden_artifacts.rs
+++ b/src/qos_client/tests/golden_artifacts.rs
@@ -216,7 +216,7 @@ const EXPECTED_MANIFEST_V0_JSON: &str = concat!(
 );
 
 struct Fixture {
-	_tmp: PathWrapper<'static>,
+	_tmp: PathWrapper<PathBuf>,
 	manifest_set: PathBuf,
 	share_set: PathBuf,
 	patch_set: PathBuf,
@@ -245,7 +245,7 @@ impl Fixture {
 			std::process::id(),
 			nanos
 		));
-		let tmp: PathWrapper<'static> = root.display().to_string().into();
+		let root = PathWrapper::from(root);
 
 		let manifest_set = root.join("manifest-set");
 		let share_set = root.join("share-set");
@@ -297,7 +297,7 @@ impl Fixture {
 		std::fs::write(&pivot_path, PIVOT_BYTES).unwrap();
 
 		Self {
-			_tmp: tmp,
+			_tmp: root,
 			manifest_set,
 			share_set,
 			patch_set,

--- a/src/qos_client/tests/p256.rs
+++ b/src/qos_client/tests/p256.rs
@@ -14,7 +14,7 @@ const EXPECTED_SIGNATURE: &str = "36c7f22c3831a32b8c8a9e823641e7df591c6e92848e7b
 
 #[test]
 fn p256_sign_verify_roundtrip() {
-	let tmp: PathWrapper = "/tmp/p256_sign_verify_roundtrip".into();
+	let tmp = PathWrapper::from("/tmp/p256_sign_verify_roundtrip");
 	std::fs::create_dir_all(&*tmp).unwrap();
 
 	let payload_path = "/tmp/p256_sign_verify_roundtrip/payload";
@@ -58,8 +58,8 @@ fn p256_sign_verify_roundtrip() {
 
 #[test]
 fn p256_asymmetric_encrypt_decrypt_roundtrip() {
-	let tmp: PathWrapper =
-		"/tmp/p256_asymmetric_encrypt_decrypt_roundtrip".into();
+	let tmp =
+		PathWrapper::from("/tmp/p256_asymmetric_encrypt_decrypt_roundtrip");
 	std::fs::create_dir_all(&*tmp).unwrap();
 
 	let plaintext_input_path =

--- a/src/qos_client/tests/shamir.rs
+++ b/src/qos_client/tests/shamir.rs
@@ -10,7 +10,7 @@ const QOS_CLIENT_PATH: &str =
 
 #[test]
 fn shamir_commands_work() {
-	let _tmp: PathWrapper = "/tmp/shamir_commands_works".into();
+	let _tmp = PathWrapper::from("/tmp/shamir_commands_works");
 	let secret_path: &str = "/tmp/shamir_commands_works/secret";
 	let shares_dir: &str = "/tmp/shamir_commands_works/shares";
 	let reconstructed_secret_path: &str =

--- a/src/qos_client/tests/yubikey.rs
+++ b/src/qos_client/tests/yubikey.rs
@@ -198,9 +198,9 @@ fn import_key_agreement_works(yubikey: &mut YubiKey) {
 }
 
 fn provision_yubikey_works() {
-	let tmp_dir: PathWrapper = "/tmp/provision_yubikey_works".into();
-	let pub_path: PathWrapper =
-		"/tmp/provision_yubikey_works/yubikey.pub".into();
+	let tmp_dir = PathWrapper::from("/tmp/provision_yubikey_works");
+	let pub_path =
+		PathWrapper::from("/tmp/provision_yubikey_works/yubikey.pub");
 
 	// Create the temporary directory where we write the yubikey
 	std::fs::create_dir(&*tmp_dir).unwrap();
@@ -225,11 +225,12 @@ fn provision_yubikey_works() {
 }
 
 fn advanced_provision_yubikey_works() {
-	let tmp_dir: PathWrapper = "/tmp/advanced_provision_yubikey_works".into();
-	let master_seed_path: PathWrapper =
-		"/tmp/advanced_provision_yubikey_works/yubikey.master.secret".into();
-	let pub_path: PathWrapper =
-		"/tmp/advanced_provision_yubikey_works/yubikey.pub".into();
+	let tmp_dir = PathWrapper::from("/tmp/advanced_provision_yubikey_works");
+	let master_seed_path = PathWrapper::from(
+		"/tmp/advanced_provision_yubikey_works/yubikey.master.secret",
+	);
+	let pub_path =
+		PathWrapper::from("/tmp/advanced_provision_yubikey_works/yubikey.pub");
 
 	// Create the temporary directory where we write the yubikey
 	std::fs::create_dir(&*tmp_dir).unwrap();
@@ -275,10 +276,10 @@ fn advanced_provision_yubikey_works() {
 }
 
 fn provision_sign_and_verify() {
-	let tmp_dir: PathWrapper = "/tmp/provision_sign_and_verify".into();
+	let tmp_dir = PathWrapper::from("/tmp/provision_sign_and_verify");
 	create_dir_all(&*tmp_dir).unwrap();
-	let pub_path: PathWrapper =
-		"/tmp/provision_sign_and_verify/yubikey.pub".into();
+	let pub_path =
+		PathWrapper::from("/tmp/provision_sign_and_verify/yubikey.pub");
 	let signature_path = "/tmp/provision_sign_and_verify/signature";
 	let payload_path = "/tmp/provision_sign_and_verify/payload";
 

--- a/src/qos_core/build.rs
+++ b/src/qos_core/build.rs
@@ -1,0 +1,34 @@
+//! Captures the git commit at build time and exposes it to the crate via the
+//! `QOS_GIT_COMMIT` env var. Reads `QOS_GIT_COMMIT` from the environment if
+//! set (intended for hermetic builds like `StageX` where the caller injects it),
+//! otherwise falls back to `git rev-parse --short HEAD` for dev builds, and
+//! finally to `"unknown"` if neither is available.
+
+use std::process::Command;
+
+fn main() {
+	println!("cargo:rerun-if-env-changed=QOS_GIT_COMMIT");
+
+	let commit = std::env::var("QOS_GIT_COMMIT")
+		.ok()
+		.or_else(git_short_sha)
+		.unwrap_or_else(|| "unknown".to_string());
+
+	println!("cargo:rustc-env=QOS_GIT_COMMIT={commit}");
+}
+
+fn git_short_sha() -> Option<String> {
+	let out = Command::new("git")
+		.args(["rev-parse", "--short", "HEAD"])
+		.output()
+		.ok()?;
+	if !out.status.success() {
+		return None;
+	}
+	let s = String::from_utf8(out.stdout).ok()?.trim().to_string();
+	if s.is_empty() {
+		None
+	} else {
+		Some(s)
+	}
+}

--- a/src/qos_core/src/cli.rs
+++ b/src/qos_core/src/cli.rs
@@ -63,7 +63,7 @@ impl EnclaveOpts {
 					p.parse().map_err(|_| IOError::ConnectAddressInvalid)?;
 				Ok(SocketAddress::new_vsock(c, p, crate::io::VMADDR_NO_FLAGS))
 			}
-			(None, None, Some(u)) => Ok(SocketAddress::new_unix(u)),
+			(None, None, Some(u)) => Ok(SocketAddress::new_unix(u.as_str())),
 			_ => panic!("Invalid socket opts"),
 		}
 	}

--- a/src/qos_core/src/handles.rs
+++ b/src/qos_core/src/handles.rs
@@ -333,20 +333,22 @@ mod test {
 
 	#[test]
 	fn put_ephemeral_key_is_read_only_write() {
-		let pivot_file: PathWrapper =
-			"put_ephemeral_key_is_read_only_write.pivot".into();
-		let ephemeral_file: PathWrapper =
-			"put_ephemeral_key_is_read_only_write_eph.secret".into();
-		let quorum_file: PathWrapper =
-			"put_ephemeral_key_is_read_only_write_quor.secret".into();
-		let manifest_file: PathWrapper =
-			"put_ephemeral_key_is_read_only_write.manifest".into();
+		let pivot_file =
+			PathWrapper::from("put_ephemeral_key_is_read_only_write.pivot");
+		let ephemeral_file = PathWrapper::from(
+			"put_ephemeral_key_is_read_only_write_eph.secret",
+		);
+		let quorum_file = PathWrapper::from(
+			"put_ephemeral_key_is_read_only_write_quor.secret",
+		);
+		let manifest_file =
+			PathWrapper::from("put_ephemeral_key_is_read_only_write.manifest");
 
 		let handles = Handles::new(
-			(*ephemeral_file).to_string(),
-			(*quorum_file).to_string(),
-			(*manifest_file).to_string(),
-			(*pivot_file).to_string(),
+			ephemeral_file.to_str().map(ToString::to_string).unwrap(),
+			quorum_file.to_str().map(ToString::to_string).unwrap(),
+			manifest_file.to_str().map(ToString::to_string).unwrap(),
+			pivot_file.to_str().map(ToString::to_string).unwrap(),
 		);
 
 		let ephemeral_key = P256Pair::generate().unwrap();
@@ -360,20 +362,20 @@ mod test {
 
 	#[test]
 	fn put_quorum_key_is_read_only_write() {
-		let pivot_file: PathWrapper =
-			"put_quorum_key_is_read_only_write.pivot".into();
-		let ephemeral_file: PathWrapper =
-			"put_quorum_key_is_read_only_write_eph.secret".into();
-		let quorum_file: PathWrapper =
-			"put_quorum_key_is_read_only_write_quor.secret".into();
-		let manifest_file: PathWrapper =
-			"put_quorum_key_is_read_only_write.manifest".into();
+		let pivot_file =
+			PathWrapper::from("put_quorum_key_is_read_only_write.pivot");
+		let ephemeral_file =
+			PathWrapper::from("put_quorum_key_is_read_only_write_eph.secret");
+		let quorum_file =
+			PathWrapper::from("put_quorum_key_is_read_only_write_quor.secret");
+		let manifest_file =
+			PathWrapper::from("put_quorum_key_is_read_only_write.manifest");
 
 		let handles = Handles::new(
-			(*ephemeral_file).to_string(),
-			(*quorum_file).to_string(),
-			(*manifest_file).to_string(),
-			(*pivot_file).to_string(),
+			ephemeral_file.to_str().map(ToString::to_string).unwrap(),
+			quorum_file.to_str().map(ToString::to_string).unwrap(),
+			manifest_file.to_str().map(ToString::to_string).unwrap(),
+			pivot_file.to_str().map(ToString::to_string).unwrap(),
 		);
 
 		let quorum_key = P256Pair::generate().unwrap();
@@ -388,21 +390,21 @@ mod test {
 
 	#[test]
 	fn put_pivot_is_read_only_write() {
-		let pivot_file: PathWrapper =
-			"put_pivot_is_read_only_write.pivot".into();
-		let ephemeral_file: PathWrapper =
-			"put_pivot_is_read_only_write_eph.secret".into();
-		let quorum_file: PathWrapper =
-			"put_pivot_is_read_only_write_quor.secret".into();
+		let pivot_file =
+			PathWrapper::from("put_pivot_is_read_only_write.pivot");
+		let ephemeral_file =
+			PathWrapper::from("put_pivot_is_read_only_write_eph.secret");
+		let quorum_file =
+			PathWrapper::from("put_pivot_is_read_only_write_quor.secret");
 
-		let manifest_file: PathWrapper =
-			"put_pivot_is_read_only_write.manifest".into();
+		let manifest_file =
+			PathWrapper::from("put_pivot_is_read_only_write.manifest");
 
 		let handles = Handles::new(
-			(*ephemeral_file).to_string(),
-			(*quorum_file).to_string(),
-			(*manifest_file).to_string(),
-			(*pivot_file).to_string(),
+			ephemeral_file.to_str().map(ToString::to_string).unwrap(),
+			quorum_file.to_str().map(ToString::to_string).unwrap(),
+			manifest_file.to_str().map(ToString::to_string).unwrap(),
+			pivot_file.to_str().map(ToString::to_string).unwrap(),
 		);
 
 		let pivot = b"this is a pivot binary".to_vec();
@@ -416,20 +418,20 @@ mod test {
 
 	#[test]
 	fn put_manifest_is_read_only_write() {
-		let pivot_file: PathWrapper =
-			"put_manifest_is_read_only_write.pivot".into();
-		let ephemeral_file: PathWrapper =
-			"put_manifest_is_read_only_write_eph.secret".into();
-		let quorum_file: PathWrapper =
-			"put_manifest_is_read_only_write_quor.secret".into();
-		let manifest_file: PathWrapper =
-			"put_manifest_is_read_only_write.manifest".into();
+		let pivot_file =
+			PathWrapper::from("put_manifest_is_read_only_write.pivot");
+		let ephemeral_file =
+			PathWrapper::from("put_manifest_is_read_only_write_eph.secret");
+		let quorum_file =
+			PathWrapper::from("put_manifest_is_read_only_write_quor.secret");
+		let manifest_file =
+			PathWrapper::from("put_manifest_is_read_only_write.manifest");
 
 		let handles = Handles::new(
-			(*ephemeral_file).to_string(),
-			(*quorum_file).to_string(),
-			(*manifest_file).to_string(),
-			(*pivot_file).to_string(),
+			ephemeral_file.to_str().map(ToString::to_string).unwrap(),
+			quorum_file.to_str().map(ToString::to_string).unwrap(),
+			manifest_file.to_str().map(ToString::to_string).unwrap(),
+			pivot_file.to_str().map(ToString::to_string).unwrap(),
 		);
 
 		let pivot = b"this is a pivot binary".to_vec();

--- a/src/qos_core/src/io/mod.rs
+++ b/src/qos_core/src/io/mod.rs
@@ -6,6 +6,8 @@
 mod host_bridge;
 mod pool;
 mod stream;
+use std::path::Path;
+
 pub use host_bridge::*;
 pub use pool::*;
 pub use stream::*;
@@ -93,8 +95,8 @@ impl SocketAddress {
 	///
 	/// Panics if `nix::sys::socket::UnixAddr::new` panics.
 	#[must_use]
-	pub fn new_unix(path: &str) -> Self {
-		let addr = UnixAddr::new(path).unwrap();
+	pub fn new_unix<P: AsRef<Path>>(path: P) -> Self {
+		let addr = UnixAddr::new(path.as_ref()).unwrap();
 		Self::Unix(addr)
 	}
 

--- a/src/qos_core/src/protocol/msg.rs
+++ b/src/qos_core/src/protocol/msg.rs
@@ -138,6 +138,20 @@ pub enum ProtocolMsg {
 		/// if the manifest envelope does not exist.
 		manifest_envelope: Box<Option<ManifestEnvelope>>,
 	},
+
+	/// Request the QOS version and git commit of the running enclave.
+	VersionRequest,
+	/// Response for [`Self::VersionRequest`].
+	VersionResponse {
+		/// `qos_core` crate semver, captured at compile time from
+		/// `CARGO_PKG_VERSION`.
+		version: String,
+		/// Git commit captured at build time. Sourced from the
+		/// `QOS_GIT_COMMIT` env var (set by the build caller) with a
+		/// `git rev-parse --short HEAD` fallback. May be `"unknown"` if
+		/// neither was available at build time.
+		commit: String,
+	},
 }
 
 impl std::fmt::Display for ProtocolMsg {
@@ -219,6 +233,13 @@ impl std::fmt::Display for ProtocolMsg {
 			Self::ManifestEnvelopeResponse { .. } => {
 				write!(f, "ManifestEnvelopeResponse")
 			}
+			Self::VersionRequest => write!(f, "VersionRequest"),
+			Self::VersionResponse { version, commit } => {
+				write!(
+					f,
+					"VersionResponse{{ version: {version}, commit: {commit} }}"
+				)
+			}
 		}
 	}
 }
@@ -256,5 +277,28 @@ mod test {
 		let test = ProtocolMsg::try_from_slice(&vec).unwrap();
 
 		assert_eq!(test, genesis_response);
+	}
+
+	#[test]
+	fn version_response_round_trip() {
+		let msg = ProtocolMsg::VersionResponse {
+			version: "0.5.0".to_string(),
+			commit: "abc1234".to_string(),
+		};
+
+		let vec = borsh::to_vec(&msg).unwrap();
+		let decoded = ProtocolMsg::try_from_slice(&vec).unwrap();
+
+		assert_eq!(msg, decoded);
+	}
+
+	#[test]
+	fn version_request_round_trip() {
+		let msg = ProtocolMsg::VersionRequest;
+
+		let vec = borsh::to_vec(&msg).unwrap();
+		let decoded = ProtocolMsg::try_from_slice(&vec).unwrap();
+
+		assert_eq!(msg, decoded);
 	}
 }

--- a/src/qos_core/src/protocol/services/boot.rs
+++ b/src/qos_core/src/protocol/services/boot.rs
@@ -1101,18 +1101,18 @@ mod test {
 			}
 		};
 
-		let pivot_file: PathWrapper =
-			"boot_standard_rejects_manifest_envelope_with_share_set_approvals.pivot".into();
-		let ephemeral_file: PathWrapper =
-			"boot_standard_rejects_manifest_envelope_with_share_set_approvals_eph.secret".into();
-		let manifest_file: PathWrapper =
-			"boot_standard_rejects_manifest_envelope_with_share_set_approvals.manifest".into();
+		let pivot_file = PathWrapper::from(
+			"boot_standard_rejects_manifest_envelope_with_share_set_approvals.pivot");
+		let ephemeral_file = PathWrapper::from(
+			"boot_standard_rejects_manifest_envelope_with_share_set_approvals_eph.secret");
+		let manifest_file = PathWrapper::from(
+			"boot_standard_rejects_manifest_envelope_with_share_set_approvals.manifest");
 
 		let handles = Handles::new(
-			(*ephemeral_file).to_string(),
+			ephemeral_file.to_str().map(ToString::to_string).unwrap(),
 			"quorum_key".to_string(),
-			(*manifest_file).to_string(),
-			(*pivot_file).to_string(),
+			manifest_file.to_str().map(ToString::to_string).unwrap(),
+			pivot_file.to_str().map(ToString::to_string).unwrap(),
 		);
 		let mut protocol_state =
 			ProtocolState::new(Box::new(MockNsm), handles, None);
@@ -1156,19 +1156,19 @@ mod test {
 			}
 		};
 
-		let pivot_file: PathWrapper =
-			"boot_standard_rejects_approval_from_non_manifest_set_member.pivot"
-				.into();
-		let ephemeral_file: PathWrapper =
-			"boot_standard_rejects_approval_from_non_manifest_set_member.secret".into();
-		let manifest_file: PathWrapper =
-			"boot_standard_rejects_approval_from_non_manifest_set_member.manifest".into();
+		let pivot_file = PathWrapper::from(
+			"boot_standard_rejects_approval_from_non_manifest_set_member.pivot",
+		);
+		let ephemeral_file = PathWrapper::from(
+			"boot_standard_rejects_approval_from_non_manifest_set_member.secret");
+		let manifest_file = PathWrapper::from(
+			"boot_standard_rejects_approval_from_non_manifest_set_member.manifest");
 
 		let handles = Handles::new(
-			(*ephemeral_file).to_string(),
+			ephemeral_file.to_str().map(ToString::to_string).unwrap(),
 			"quorum_key".to_string(),
-			(*manifest_file).to_string(),
-			(*pivot_file).to_string(),
+			manifest_file.to_str().map(ToString::to_string).unwrap(),
+			pivot_file.to_str().map(ToString::to_string).unwrap(),
 		);
 		let mut protocol_state =
 			ProtocolState::new(Box::new(MockNsm), handles, None);

--- a/src/qos_core/src/protocol/services/key.rs
+++ b/src/qos_core/src/protocol/services/key.rs
@@ -291,7 +291,7 @@ fn verify_and_extract_attestation_doc_from_der(
 
 #[cfg(test)]
 mod test {
-	use std::{collections::BTreeMap, ops::Deref};
+	use std::collections::BTreeMap;
 
 	use aws_nitro_enclaves_nsm_api::api::{AttestationDoc, Digest};
 	use qos_crypto::sha_256;
@@ -438,18 +438,21 @@ mod test {
 		fn accepts_approved_manifest() {
 			let TestArgs { manifest_envelope, pivot, .. } = get_test_args();
 
-			let pivot_file: PathWrapper =
-				"/tmp/boot_key_forward_accepts_approved_manifest.pivot".into();
-			let ephemeral_file: PathWrapper =
-				"/tmp/boot_key_accepts_approved_manifest.eph.secret".into();
-			let manifest_file: PathWrapper =
-				"/tmp/boot_key_accepts_approved_manifest.manifest".into();
+			let pivot_file = PathWrapper::from(
+				"/tmp/boot_key_forward_accepts_approved_manifest.pivot",
+			);
+			let ephemeral_file = PathWrapper::from(
+				"/tmp/boot_key_accepts_approved_manifest.eph.secret",
+			);
+			let manifest_file = PathWrapper::from(
+				"/tmp/boot_key_accepts_approved_manifest.manifest",
+			);
 
 			let handles = Handles::new(
-				ephemeral_file.deref().to_string(),
+				ephemeral_file.to_str().map(ToString::to_string).unwrap(),
 				"qorum".to_string(),
-				manifest_file.deref().to_string(),
-				pivot_file.deref().to_string(),
+				manifest_file.to_str().map(ToString::to_string).unwrap(),
+				pivot_file.to_str().map(ToString::to_string).unwrap(),
 			);
 			let mut state =
 				ProtocolState::new(Box::new(MockNsm), handles.clone(), None);
@@ -476,20 +479,20 @@ mod test {
 		fn rejects_manifest_if_not_enough_approvals() {
 			let TestArgs { mut manifest_envelope, pivot, .. } = get_test_args();
 
-			let pivot_file: PathWrapper =
-				"/tmp/boot_key_rejects_manifest_if_not_enough_approvals.pivot"
-					.into();
-			let ephemeral_file: PathWrapper =
-				"/tmp/boot_key_rejects_manifest_if_not_enough_approvals.secret"
-					.into();
-			let manifest_file: PathWrapper =
-				"/tmp/boot_key_rejects_manifest_if_not_enough_approvals.manifest".into();
+			let pivot_file = PathWrapper::from(
+				"/tmp/boot_key_rejects_manifest_if_not_enough_approvals.pivot",
+			);
+			let ephemeral_file = PathWrapper::from(
+				"/tmp/boot_key_rejects_manifest_if_not_enough_approvals.secret",
+			);
+			let manifest_file = PathWrapper::from(
+				"/tmp/boot_key_rejects_manifest_if_not_enough_approvals.manifest");
 
 			let handles = Handles::new(
-				ephemeral_file.deref().to_string(),
+				ephemeral_file.to_str().map(ToString::to_string).unwrap(),
 				"qorum".to_string(),
-				manifest_file.deref().to_string(),
-				pivot_file.deref().to_string(),
+				manifest_file.to_str().map(ToString::to_string).unwrap(),
+				pivot_file.to_str().map(ToString::to_string).unwrap(),
 			);
 			let mut state =
 				ProtocolState::new(Box::new(MockNsm), handles.clone(), None);
@@ -513,21 +516,21 @@ mod test {
 		fn rejects_manifest_if_wrong_pivot_hash() {
 			let TestArgs { manifest_envelope, .. } = get_test_args();
 
-			let pivot_file: PathWrapper =
-				"/tmp/boot_key_rejects_manifest_if_wrong_pivot_hash.pivot"
-					.into();
-			let ephemeral_file: PathWrapper =
-				"/tmp/boot_key_rejects_manifest_if_wrong_pivot_hash.secret"
-					.into();
-			let manifest_file: PathWrapper =
-				"/tmp/boot_key_rejects_manifest_if_wrong_pivot_hash.manifest"
-					.into();
+			let pivot_file = PathWrapper::from(
+				"/tmp/boot_key_rejects_manifest_if_wrong_pivot_hash.pivot",
+			);
+			let ephemeral_file = PathWrapper::from(
+				"/tmp/boot_key_rejects_manifest_if_wrong_pivot_hash.secret",
+			);
+			let manifest_file = PathWrapper::from(
+				"/tmp/boot_key_rejects_manifest_if_wrong_pivot_hash.manifest",
+			);
 
 			let handles = Handles::new(
-				ephemeral_file.deref().to_string(),
+				ephemeral_file.to_str().map(ToString::to_string).unwrap(),
 				"qorum".to_string(),
-				manifest_file.deref().to_string(),
-				pivot_file.deref().to_string(),
+				manifest_file.to_str().map(ToString::to_string).unwrap(),
+				pivot_file.to_str().map(ToString::to_string).unwrap(),
 			);
 			let mut state =
 				ProtocolState::new(Box::new(MockNsm), handles.clone(), None);
@@ -555,19 +558,21 @@ mod test {
 		fn rejects_manifest_with_bad_approval_signature() {
 			let TestArgs { mut manifest_envelope, pivot, .. } = get_test_args();
 
-			let pivot_file: PathWrapper =
-				"/tmp/boot_key_rejects_rejects_manifest_with_bad_approval_signature.pivot".into();
-			let ephemeral_file: PathWrapper =
-				"/tmp/boot_key_rejects_rejects_manifest_with_bad_approval_signature.secret".into();
-			let manifest_file: PathWrapper =
+			let pivot_file = PathWrapper::from(
+				"/tmp/boot_key_rejects_rejects_manifest_with_bad_approval_signature.pivot"
+			);
+			let ephemeral_file = PathWrapper::from(
+				"/tmp/boot_key_rejects_rejects_manifest_with_bad_approval_signature.secret"
+			);
+			let manifest_file = PathWrapper::from(
 				"/tmp/boot_key_rejects_rejects_manifest_with_bad_approval_signature.manifest"
-					.into();
+			);
 
 			let handles = Handles::new(
-				ephemeral_file.deref().to_string(),
+				ephemeral_file.to_str().map(ToString::to_string).unwrap(),
 				"quorum".to_string(),
-				manifest_file.deref().to_string(),
-				pivot_file.deref().to_string(),
+				manifest_file.to_str().map(ToString::to_string).unwrap(),
+				pivot_file.to_str().map(ToString::to_string).unwrap(),
 			);
 			let mut state =
 				ProtocolState::new(Box::new(MockNsm), handles.clone(), None);
@@ -609,18 +614,18 @@ mod test {
 				member: non_member,
 			};
 
-			let pivot_file: PathWrapper =
-				"/tmp/boot_key_reject_manifest_with_approval_from_non_memberpivot".into();
-			let ephemeral_file: PathWrapper =
-				"/tmp/boot_key_reject_manifest_with_approval_from_non_membersecret".into();
-			let manifest_file: PathWrapper =
-				"/tmp/boot_key_reject_manifest_with_approval_from_non_membermanifest".into();
+			let pivot_file = PathWrapper::from(
+				"/tmp/boot_key_reject_manifest_with_approval_from_non_memberpivot");
+			let ephemeral_file = PathWrapper::from(
+				"/tmp/boot_key_reject_manifest_with_approval_from_non_membersecret");
+			let manifest_file = PathWrapper::from(
+				"/tmp/boot_key_reject_manifest_with_approval_from_non_membermanifest");
 
 			let handles = Handles::new(
-				ephemeral_file.deref().to_string(),
+				ephemeral_file.to_str().map(ToString::to_string).unwrap(),
 				"quorum".to_string(),
-				manifest_file.deref().to_string(),
-				pivot_file.deref().to_string(),
+				manifest_file.to_str().map(ToString::to_string).unwrap(),
+				pivot_file.to_str().map(ToString::to_string).unwrap(),
 			);
 			let mut state =
 				ProtocolState::new(Box::new(MockNsm), handles.clone(), None);
@@ -1080,15 +1085,15 @@ mod test {
 				..
 			} = get_test_args();
 
-			let ephemeral_file: PathWrapper =
-				"export_key_inner_works.eph.secret".into();
+			let ephemeral_file =
+				PathWrapper::from("export_key_inner_works.eph.secret");
 			eph_pair.to_hex_file(&*ephemeral_file).unwrap();
 
-			let manifest_file: PathWrapper =
-				"export_key_inner_works.manifest".into();
+			let manifest_file =
+				PathWrapper::from("export_key_inner_works.manifest");
 
-			let quorum_file: PathWrapper =
-				"export_key_inner_works.quorum.secret".into();
+			let quorum_file =
+				PathWrapper::from("export_key_inner_works.quorum.secret");
 			quorum_pair.to_hex_file(&*quorum_file).unwrap();
 
 			std::fs::write(
@@ -1097,9 +1102,9 @@ mod test {
 			)
 			.unwrap();
 			let handles = Handles::new(
-				ephemeral_file.deref().to_string(),
-				quorum_file.deref().to_string(),
-				manifest_file.deref().to_string(),
+				ephemeral_file.to_str().map(ToString::to_string).unwrap(),
+				quorum_file.to_str().map(ToString::to_string).unwrap(),
+				manifest_file.to_str().map(ToString::to_string).unwrap(),
 				"pivot".to_string(),
 			);
 
@@ -1140,12 +1145,12 @@ mod test {
 			let TestArgs { manifest_envelope, eph_pair, quorum_pair, .. } =
 				get_test_args();
 
-			let ephemeral_file: PathWrapper =
-				"inject_key_works.eph.secret".into();
+			let ephemeral_file =
+				PathWrapper::from("inject_key_works.eph.secret");
 			eph_pair.to_hex_file(&*ephemeral_file).unwrap();
-			let manifest_file: PathWrapper = "inject_key_works.manifest".into();
-			let quorum_file: PathWrapper =
-				"inject_key_works.quorum.secret".into();
+			let manifest_file = PathWrapper::from("inject_key_works.manifest");
+			let quorum_file =
+				PathWrapper::from("inject_key_works.quorum.secret");
 			std::fs::write(
 				&*manifest_file,
 				serde_json::to_vec(&manifest_envelope).unwrap(),
@@ -1159,9 +1164,9 @@ mod test {
 			let signature = quorum_pair.sign(&encrypted_quorum_key).unwrap();
 
 			let handles = Handles::new(
-				ephemeral_file.deref().to_string(),
-				quorum_file.deref().to_string(),
-				manifest_file.deref().to_string(),
+				ephemeral_file.to_str().map(ToString::to_string).unwrap(),
+				quorum_file.to_str().map(ToString::to_string).unwrap(),
+				manifest_file.to_str().map(ToString::to_string).unwrap(),
 				"pivot".to_string(),
 			);
 			let mut protocol_state =
@@ -1196,13 +1201,13 @@ mod test {
 			let TestArgs { manifest_envelope, eph_pair, quorum_pair, .. } =
 				get_test_args();
 
-			let ephemeral_file: PathWrapper =
-				"inject_rejects_bad_signature.eph.secret".into();
+			let ephemeral_file =
+				PathWrapper::from("inject_rejects_bad_signature.eph.secret");
 			eph_pair.to_hex_file(&*ephemeral_file).unwrap();
-			let manifest_file: PathWrapper =
-				"inject_rejects_bad_signature.manifest".into();
-			let quorum_file: PathWrapper =
-				"inject_rejects_bad_signature.quorum.secret".into();
+			let manifest_file =
+				PathWrapper::from("inject_rejects_bad_signature.manifest");
+			let quorum_file =
+				PathWrapper::from("inject_rejects_bad_signature.quorum.secret");
 			std::fs::write(
 				&*manifest_file,
 				serde_json::to_vec(&manifest_envelope).unwrap(),
@@ -1217,9 +1222,9 @@ mod test {
 			let signature = quorum_pair.sign(&encrypted_quorum_key).unwrap();
 
 			let handles = Handles::new(
-				ephemeral_file.deref().to_string(),
-				quorum_file.deref().to_string(),
-				manifest_file.deref().to_string(),
+				ephemeral_file.to_str().map(ToString::to_string).unwrap(),
+				quorum_file.to_str().map(ToString::to_string).unwrap(),
+				manifest_file.to_str().map(ToString::to_string).unwrap(),
 				"pivot".to_string(),
 			);
 			let mut protocol_state =
@@ -1247,13 +1252,16 @@ mod test {
 			let TestArgs { manifest_envelope, eph_pair, quorum_pair, .. } =
 				get_test_args();
 
-			let ephemeral_file: PathWrapper =
-				"inject_key_rejects_wrong_quorum_key.eph.secret".into();
+			let ephemeral_file = PathWrapper::from(
+				"inject_key_rejects_wrong_quorum_key.eph.secret",
+			);
 			eph_pair.to_hex_file(&*ephemeral_file).unwrap();
-			let manifest_file: PathWrapper =
-				"inject_key_rejects_wrong_quorum_key.manifest".into();
-			let quorum_file: PathWrapper =
-				"inject_key_rejects_wrong_quorum_key.quorum.secret".into();
+			let manifest_file = PathWrapper::from(
+				"inject_key_rejects_wrong_quorum_key.manifest",
+			);
+			let quorum_file = PathWrapper::from(
+				"inject_key_rejects_wrong_quorum_key.quorum.secret",
+			);
 			std::fs::write(
 				&*manifest_file,
 				serde_json::to_vec(&manifest_envelope).unwrap(),
@@ -1268,9 +1276,9 @@ mod test {
 			let signature = wrong_key.sign(&encrypted_quorum_key).unwrap();
 
 			let handles = Handles::new(
-				ephemeral_file.deref().to_string(),
-				quorum_file.deref().to_string(),
-				manifest_file.deref().to_string(),
+				ephemeral_file.to_str().map(ToString::to_string).unwrap(),
+				quorum_file.to_str().map(ToString::to_string).unwrap(),
+				manifest_file.to_str().map(ToString::to_string).unwrap(),
 				"pivot".to_string(),
 			);
 			let mut protocol_state =
@@ -1298,13 +1306,16 @@ mod test {
 			let TestArgs { manifest_envelope, eph_pair, quorum_pair, .. } =
 				get_test_args();
 
-			let ephemeral_file: PathWrapper =
-				"inject_key_rejects_invalid_quorum_key.eph.secret".into();
+			let ephemeral_file = PathWrapper::from(
+				"inject_key_rejects_invalid_quorum_key.eph.secret",
+			);
 			eph_pair.to_hex_file(&*ephemeral_file).unwrap();
-			let manifest_file: PathWrapper =
-				"inject_key_rejects_invalid_quorum_key.manifest".into();
-			let quorum_file: PathWrapper =
-				"inject_key_rejects_invalid_quorum_key.quorum.secret".into();
+			let manifest_file = PathWrapper::from(
+				"inject_key_rejects_invalid_quorum_key.manifest",
+			);
+			let quorum_file = PathWrapper::from(
+				"inject_key_rejects_invalid_quorum_key.quorum.secret",
+			);
 			std::fs::write(
 				&*manifest_file,
 				serde_json::to_vec(&manifest_envelope).unwrap(),
@@ -1319,9 +1330,9 @@ mod test {
 				quorum_pair.sign(&invalid_encrypted_quorum_key).unwrap();
 
 			let handles = Handles::new(
-				ephemeral_file.deref().to_string(),
-				quorum_file.deref().to_string(),
-				manifest_file.deref().to_string(),
+				ephemeral_file.to_str().map(ToString::to_string).unwrap(),
+				quorum_file.to_str().map(ToString::to_string).unwrap(),
+				manifest_file.to_str().map(ToString::to_string).unwrap(),
 				"pivot".to_string(),
 			);
 			let mut protocol_state =

--- a/src/qos_core/src/protocol/services/provision.rs
+++ b/src/qos_core/src/protocol/services/provision.rs
@@ -155,11 +155,15 @@ mod test {
 		approvals: Vec<Approval>,
 	}
 
-	fn setup(eph_file: &str, quorum_file: &str, manifest_file: &str) -> Setup {
+	fn setup(
+		eph_file: &Path,
+		quorum_file: &Path,
+		manifest_file: &Path,
+	) -> Setup {
 		let handles = Handles::new(
-			eph_file.to_string(),
-			quorum_file.to_string(),
-			manifest_file.to_string(),
+			eph_file.to_str().map(ToString::to_string).unwrap(),
+			quorum_file.to_str().map(ToString::to_string).unwrap(),
+			manifest_file.to_str().map(ToString::to_string).unwrap(),
 			"pivot".to_string(),
 		);
 		// 1) Create and write eph key
@@ -244,9 +248,9 @@ mod test {
 
 	#[test]
 	fn provision_works() {
-		let quorum_file: PathWrapper = "./provision_works.quorum.key".into();
-		let eph_file: PathWrapper = "./provision_works.eph.key".into();
-		let manifest_file: PathWrapper = "./provision_works.manifest".into();
+		let quorum_file = PathWrapper::from("./provision_works.quorum.key");
+		let eph_file = PathWrapper::from("./provision_works.eph.key");
+		let manifest_file = PathWrapper::from("./provision_works.manifest");
 
 		let Setup { quorum_pair, eph_pair, threshold, mut state, approvals } =
 			setup(&eph_file, &quorum_file, &manifest_file);
@@ -304,12 +308,12 @@ mod test {
 
 	#[test]
 	fn provision_rejects_the_wrong_key() {
-		let eph_file: PathWrapper =
-			"./provision_rejects_the_wrong_key.eph.key".into();
-		let quorum_file: PathWrapper =
-			"./provision_rejects_the_wrong_key.quorum.key".into();
-		let manifest_file: PathWrapper =
-			"./provision_rejects_the_wrong_key.manifest".into();
+		let eph_file =
+			PathWrapper::from("./provision_rejects_the_wrong_key.eph.key");
+		let quorum_file =
+			PathWrapper::from("./provision_rejects_the_wrong_key.quorum.key");
+		let manifest_file =
+			PathWrapper::from("./provision_rejects_the_wrong_key.manifest");
 
 		let Setup { eph_pair, threshold, mut state, approvals, .. } =
 			setup(&eph_file, &quorum_file, &manifest_file);
@@ -350,12 +354,15 @@ mod test {
 
 	#[test]
 	fn provision_rejects_if_a_shard_is_invalid() {
-		let eph_file: PathWrapper =
-			"./provision_rejects_if_a_shard_is_invalid.eph.key".into();
-		let quorum_file: PathWrapper =
-			"./provision_rejects_if_a_shard_is_invalid.quorum.key".into();
-		let manifest_file: PathWrapper =
-			"./provision_rejects_if_a_shard_is_invalid.manifest".into();
+		let eph_file = PathWrapper::from(
+			"./provision_rejects_if_a_shard_is_invalid.eph.key",
+		);
+		let quorum_file = PathWrapper::from(
+			"./provision_rejects_if_a_shard_is_invalid.quorum.key",
+		);
+		let manifest_file = PathWrapper::from(
+			"./provision_rejects_if_a_shard_is_invalid.manifest",
+		);
 		let Setup { quorum_pair, eph_pair, threshold, mut state, approvals } =
 			setup(&eph_file, &quorum_file, &manifest_file);
 
@@ -397,12 +404,15 @@ mod test {
 
 	#[test]
 	fn provisions_rejects_if_an_approval_is_invalid() {
-		let eph_file: PathWrapper =
-			"./provisions_rejects_if_an_approval_is_invalid.eph.key".into();
-		let quorum_file: PathWrapper =
-			"./provisions_rejects_if_an_approval_is_invalid.quorum.key".into();
-		let manifest_file: PathWrapper =
-			"./provisions_rejects_if_an_approval_is_invalid.manifest".into();
+		let eph_file = PathWrapper::from(
+			"./provisions_rejects_if_an_approval_is_invalid.eph.key",
+		);
+		let quorum_file = PathWrapper::from(
+			"./provisions_rejects_if_an_approval_is_invalid.quorum.key",
+		);
+		let manifest_file = PathWrapper::from(
+			"./provisions_rejects_if_an_approval_is_invalid.manifest",
+		);
 
 		let Setup {
 			quorum_pair,
@@ -434,12 +444,12 @@ mod test {
 
 	#[test]
 	fn provision_rejects_if_approval_is_not_from_share_set_member() {
-		let eph_file: PathWrapper =
-			"./provision_rejects_if_approval_is_not_from_share_set_member.eph.key".into();
-		let quorum_file: PathWrapper =
-			"./provision_rejects_if_approval_is_not_from_share_set_member.quorum.key".into();
-		let manifest_file: PathWrapper =
-			"./provision_rejects_if_approval_is_not_from_share_set_member.manifest".into();
+		let eph_file = PathWrapper::from(
+			"./provision_rejects_if_approval_is_not_from_share_set_member.eph.key");
+		let quorum_file = PathWrapper::from(
+			"./provision_rejects_if_approval_is_not_from_share_set_member.quorum.key");
+		let manifest_file = PathWrapper::from(
+			"./provision_rejects_if_approval_is_not_from_share_set_member.manifest");
 
 		let Setup {
 			quorum_pair,
@@ -477,12 +487,12 @@ mod test {
 	#[test]
 	fn provision_rejects_with_signature_error_if_approval_is_not_from_share_set_member_and_bad_signature(
 	) {
-		let eph_file: PathWrapper =
-			"./provision_rejects_with_signature_error_if_approval_is_not_from_share_set_member_and_bad_signature.eph.key".into();
-		let quorum_file: PathWrapper =
-			"./provision_rejects_with_signature_error_if_approval_is_not_from_share_set_member_and_bad_signature.quorum.key".into();
-		let manifest_file: PathWrapper =
-			"./provision_rejects_with_signature_error_if_approval_is_not_from_share_set_member_and_bad_signature.manifest".into();
+		let eph_file = PathWrapper::from(
+			"./provision_rejects_with_signature_error_if_approval_is_not_from_share_set_member_and_bad_signature.eph.key");
+		let quorum_file = PathWrapper::from(
+			"./provision_rejects_with_signature_error_if_approval_is_not_from_share_set_member_and_bad_signature.quorum.key");
+		let manifest_file = PathWrapper::from(
+			"./provision_rejects_with_signature_error_if_approval_is_not_from_share_set_member_and_bad_signature.manifest");
 
 		let Setup {
 			quorum_pair,

--- a/src/qos_core/src/protocol/state.rs
+++ b/src/qos_core/src/protocol/state.rs
@@ -86,6 +86,14 @@ impl ProtocolRoute {
 		)
 	}
 
+	pub fn version(current_phase: ProtocolPhase) -> Self {
+		ProtocolRoute::new(
+			Box::new(handlers::version),
+			current_phase,
+			current_phase,
+		)
+	}
+
 	pub fn manifest_envelope(current_phase: ProtocolPhase) -> Self {
 		ProtocolRoute::new(
 			Box::new(handlers::manifest_envelope),
@@ -217,16 +225,21 @@ impl ProtocolState {
 			ProtocolPhase::UnrecoverableError => {
 				vec![
 					ProtocolRoute::status(self.phase),
+					ProtocolRoute::version(self.phase),
 					ProtocolRoute::manifest_envelope(self.phase),
 					ProtocolRoute::live_attestation_doc(self.phase),
 				]
 			}
 			ProtocolPhase::GenesisBooted => {
-				vec![ProtocolRoute::status(self.phase)]
+				vec![
+					ProtocolRoute::status(self.phase),
+					ProtocolRoute::version(self.phase),
+				]
 			}
 			ProtocolPhase::WaitingForBootInstruction => vec![
 				// baseline routes
 				ProtocolRoute::status(self.phase),
+				ProtocolRoute::version(self.phase),
 				ProtocolRoute::manifest_envelope(self.phase),
 				// phase specific routes
 				ProtocolRoute::boot_genesis(self.phase),
@@ -237,6 +250,7 @@ impl ProtocolState {
 				vec![
 					// baseline routes
 					ProtocolRoute::status(self.phase),
+					ProtocolRoute::version(self.phase),
 					ProtocolRoute::live_attestation_doc(self.phase),
 					ProtocolRoute::manifest_envelope(self.phase),
 					// phase specific routes
@@ -247,6 +261,7 @@ impl ProtocolState {
 				vec![
 					// baseline routes
 					ProtocolRoute::status(self.phase),
+					ProtocolRoute::version(self.phase),
 					ProtocolRoute::live_attestation_doc(self.phase),
 					ProtocolRoute::manifest_envelope(self.phase),
 					// phase specific routes
@@ -257,6 +272,7 @@ impl ProtocolState {
 				vec![
 					// baseline routes
 					ProtocolRoute::status(self.phase),
+					ProtocolRoute::version(self.phase),
 					ProtocolRoute::live_attestation_doc(self.phase),
 					ProtocolRoute::manifest_envelope(self.phase),
 					// phase specific routes
@@ -332,6 +348,23 @@ mod handlers {
 	) -> ProtocolRouteResponse {
 		if let ProtocolMsg::StatusRequest = req {
 			Some(Ok(ProtocolMsg::StatusResponse(state.get_phase())))
+		} else {
+			None
+		}
+	}
+
+	/// QOS version and git commit of the running enclave. Captured at
+	/// compile time — `CARGO_PKG_VERSION` for the version, and the
+	/// `QOS_GIT_COMMIT` env var (set by `build.rs`) for the commit.
+	pub(super) fn version(
+		req: &ProtocolMsg,
+		_state: &mut ProtocolState,
+	) -> ProtocolRouteResponse {
+		if let ProtocolMsg::VersionRequest = req {
+			Some(Ok(ProtocolMsg::VersionResponse {
+				version: env!("CARGO_PKG_VERSION").to_string(),
+				commit: env!("QOS_GIT_COMMIT").to_string(),
+			}))
 		} else {
 			None
 		}

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -143,7 +143,6 @@ impl Reaper {
 	///
 	/// - If spawning the pivot errors.
 	/// - If waiting for the pivot errors.
-	#[allow(dead_code)]
 	pub async fn execute(
 		handles: &Handles,
 		nsm: Box<dyn NsmProvider + Send>,

--- a/src/qos_host/src/cli.rs
+++ b/src/qos_host/src/cli.rs
@@ -141,7 +141,7 @@ impl HostOpts {
 
 				Ok(SocketAddress::new_vsock(c, p, self.to_host_flag()))
 			}
-			(None, None, Some(u)) => Ok(SocketAddress::new_unix(u)),
+			(None, None, Some(u)) => Ok(SocketAddress::new_unix(u.as_str())),
 
 			_ => panic!("Invalid socket opts"),
 		}

--- a/src/qos_net/src/cli.rs
+++ b/src/qos_net/src/cli.rs
@@ -70,7 +70,7 @@ impl ProxyOpts {
 				StreamPool::new(address, pool_size)
 			}
 			(None, None, Some(u)) => {
-				let address = SocketAddress::new_unix(u);
+				let address = SocketAddress::new_unix(u.as_str());
 
 				StreamPool::new(address, pool_size)
 			}

--- a/src/qos_p256/src/lib.rs
+++ b/src/qos_p256/src/lib.rs
@@ -86,7 +86,7 @@ impl From<qos_hex::HexError> for P256Error {
 			qos_hex::HexError::InvalidUtf8(_) => {
 				P256Error::MasterSeedInvalidUtf8
 			}
-			_ => Self::QosHex(format!("{err:?}")),
+			err => Self::QosHex(format!("{err:?}")),
 		}
 	}
 }
@@ -527,8 +527,8 @@ mod test {
 
 	#[test]
 	fn public_key_to_file_roundtrip() {
-		let path: PathWrapper =
-			"/tmp/public_key_to_file_roundtrip.secret".into();
+		let path =
+			PathWrapper::from("/tmp/public_key_to_file_roundtrip.secret");
 		let alice_pair = P256Pair::generate().unwrap();
 		let alice_public = alice_pair.public_key();
 
@@ -566,8 +566,8 @@ mod test {
 
 	#[test]
 	fn master_seed_to_file_round_trip() {
-		let path: PathWrapper =
-			"/tmp/master_seed_to_file_round_trip.secret".into();
+		let path =
+			PathWrapper::from("/tmp/master_seed_to_file_round_trip.secret");
 
 		let alice_pair = P256Pair::generate().unwrap();
 		alice_pair.to_hex_file(&*path).unwrap();

--- a/src/qos_test_primitives/src/lib.rs
+++ b/src/qos_test_primitives/src/lib.rs
@@ -2,7 +2,9 @@
 
 use std::{
 	net::{Ipv4Addr, SocketAddrV4, TcpListener, TcpStream},
-	ops::Deref,
+	ops::{Deref, DerefMut},
+	path::Path,
+	process::Child,
 	thread,
 	time::Duration,
 };
@@ -16,11 +18,25 @@ const EXIT_DELAY: Duration = Duration::from_millis(50);
 
 /// Wrapper type for [`std::process::Child`] that kills the process on drop.
 #[derive(Debug)]
-pub struct ChildWrapper(pub std::process::Child);
+pub struct ChildWrapper(Child);
 
-impl From<std::process::Child> for ChildWrapper {
-	fn from(child: std::process::Child) -> Self {
+impl From<Child> for ChildWrapper {
+	fn from(child: Child) -> Self {
 		Self(child)
+	}
+}
+
+impl Deref for ChildWrapper {
+	type Target = Child;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+impl DerefMut for ChildWrapper {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		&mut self.0
 	}
 }
 
@@ -44,51 +60,36 @@ impl Drop for ChildWrapper {
 	}
 }
 
-#[derive(Debug)]
-enum Internal<'a> {
-	String(String),
-	Str(&'a str),
-}
-
-/// Wrapper type for [`std::path::Path`] that attempts to remove a file or
+/// Generic wrapper type for anything that implements [`std::convert::AsRef<std::path::Path>`] that attempts to remove a file or
 /// directory at the path on drop.
 #[derive(Debug)]
-pub struct PathWrapper<'a>(Internal<'a>);
+pub struct PathWrapper<P: AsRef<Path>>(P);
 
-impl<'a> From<&'a str> for PathWrapper<'a> {
-	fn from(path: &'a str) -> Self {
-		Self(Internal::Str(path))
+impl<P: AsRef<Path>> From<P> for PathWrapper<P> {
+	fn from(value: P) -> Self {
+		Self(value)
 	}
 }
 
-impl From<String> for PathWrapper<'_> {
-	fn from(path: String) -> Self {
-		Self(Internal::String(path))
-	}
-}
-
-impl Drop for PathWrapper<'_> {
+impl<P: AsRef<Path>> Drop for PathWrapper<P> {
 	fn drop(&mut self) {
-		let path = match &self.0 {
-			Internal::String(i) => i,
-			Internal::Str(i) => *i,
-		};
-
-		// Try removing it both as a file and as a directory. One of these
 		// will always fail
-		drop(std::fs::remove_dir_all(path));
-		drop(std::fs::remove_file(path));
+		drop(std::fs::remove_dir_all(&self.0));
+		drop(std::fs::remove_file(&self.0));
 	}
 }
 
-impl Deref for PathWrapper<'_> {
-	type Target = str;
+impl<P: AsRef<Path>> Deref for PathWrapper<P> {
+	type Target = Path;
 
 	fn deref(&self) -> &Self::Target {
-		match &self.0 {
-			Internal::String(i) => i,
-			Internal::Str(i) => i,
-		}
+		self.as_ref()
+	}
+}
+
+impl<P: AsRef<Path>> AsRef<Path> for PathWrapper<P> {
+	fn as_ref(&self) -> &Path {
+		self.0.as_ref()
 	}
 }
 


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

Closes [SYS-43](https://linear.app/turnkey/issue/SYS-43/add-qos-protocol-protocol-msg-to-query-versioncommit-info).

**Problem:** there's no way to identify what's running inside a QOS enclave. The host-side `--version` flag reflects the local binary, not the EIF.

**Solution:** add a `VersionRequest` / `VersionResponse { version, commit }` `ProtocolMsg` pair, mirroring `StatusRequest`. Read-only, registered as a baseline route in all six phases (parity with `Status`), so it answers even from `UnrecoverableError` for forensics.

- `qos_core`: new variants on `ProtocolMsg`, `ProtocolRoute::version()` constructor, inline handler in `state.rs`, registered across all phases.
- `qos_core/build.rs` (new): captures the git commit at build time. Reads `QOS_GIT_COMMIT` (set by the build caller — Makefile or StageX), falls back to `git rev-parse --short HEAD` for dev builds, defaults to `"unknown"`.
- `qos_client`: new `enclave-version` subcommand that sends the request and prints `version` + `commit`.
- `qos_test_primitives`: `PathWrapper` made generic over `AsRef<Path>`; `ChildWrapper` implements `Deref` / `DerefMut` / `Future`; `wait_for_usock` and `wait_for_tcp_sock` accept generic address types. Call sites updated across integration tests, `qos_core` handles tests, and `qos_client` tests.

## How I Tested These Changes

- Borsh round-trip unit tests for both new variants (`src/qos_core/src/protocol/msg.rs`).
- End-to-end integration test (`src/integration/tests/version.rs`): spins up `qos_core` + `qos_host`, posts `VersionRequest` to `/qos/message`, and verifies the response carries `CARGO_PKG_VERSION` and a non-empty commit.
- `cargo test -p qos_core` and `cargo test -p integration --test version` pass locally.

## Pre merge check list

- [x] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) — commit uses `feat!:`.
- [x] Communicate verification flow breaking changes especially thoroughly. The new variants are **appended** at the end of the `ProtocolMsg` enum, so all pre-existing Borsh discriminators are preserved. Verification flows are unaffected:
    - Can enclaves in a previous QOS version still key forward to this new version? **Yes** — `ExportKey` / `InjectKey` discriminators unchanged.
    - Can previous versions of QOS verify attestations from this new version? **Yes** — attestations are independent of `ProtocolMsg` encoding.
    - Can manifests generated by a previous version still be parsed by this one? **Yes** — manifest format unchanged.
    - Can previous approvals still be verified against a manifest? **Yes** — manifest signing payload unchanged.
    - Can a previous version of QOS still perform a boot standard on an enclave of this version? **Yes** — `BootStandardRequest` discriminator unchanged.

> Note: the ticket described this as "Bumps the Borsh wire format — adding a variant shifts existing variant indices." That would be true if the new variants were inserted in the middle; here they are appended at the end, so no existing discriminator shifts. Strictly speaking this is not a verification-flow-breaking change — the `!` in the commit is conservative. Happy to drop to plain `feat:` if reviewers prefer.