### PR TITLE
Am/fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,19 +125,19 @@ If something goes wrong during a release and you want to retry, you can open a P
 ### Enclave
 
 - houses server for listening to the Host
-- contains logic for quorum key genesis, booting, and running a Enclave App
+- contains logic for quorum key genesis, booting, and running an Enclave App
 - see crate [`qos_core`](./src/qos_core/)
 
 ### Host
 
 - EC2 instance housing the nitro enclave
-- has client for talking to nitro enclave
-- has server for incoming request from outside world
+- has a client for talking to nitro enclave
+- has a server for incoming requests from outside world
 - see crate [`qos_host`](./src/qos_host/)
 
 #### Client
 
-- anything making request to host
+- anything making requests to host
 - see crate [`qos_client`](./src/qos_client/)
 
 ## Key Terms
@@ -160,7 +160,7 @@ The collection of members who can approve a manifest. In the typical instance pr
 
 ### Share Set
 
-The collection of members who each hold shares of the Quorum Key and thus provision an enclave by attesting and then posting their shares. When posting shares, these members will also provide a signature of the manifest. The signature is recorded in manifest envelope in order to leave an audit trail. This way, third parties can check which share set members actually participated in provisioning the quorum key
+The collection of members who each hold shares of the Quorum Key and thus provision an enclave by attesting and then posting their shares. When posting shares, these members will also provide a signature of the manifest. The signature is recorded in the manifest envelope in order to leave an audit trail. This way, third parties can check which share set members actually participated in provisioning the quorum key
 
 ### Ephemeral Key
 
@@ -180,14 +180,14 @@ A group of QuorumOS Nodes running the same Enclave App and using the same Quorum
 
 ### Pivot / Enclave App
 
-The application QuorumOS pivots to once it finishes booting. This applications binary hash and CLI arguments are specified in the Manifest file.
+The application QuorumOS pivots to once it finishes booting. This application's binary hash and CLI arguments are specified in the Manifest file.
 
 ## Provisioning
 
 There are two modes for provisioning:
 
 - [Boot Standard](docs/boot_standard.md): mode for provisioning an enclave with quorum key shares. This is commonly used if there is no instance from the same namespace to key forward from or if there is any change to the QuorumOS verification API that breaks Key Forwarding. Boot Standard is also required if the manifest set or share set change.
-- [Key Forward](docs/key_forward.md): mode for provisioning an enclave from an already provisionedq enclave of the same namespace. This allows QuorumOS to support horizontal scaling cloud workloads. Effectively, a pre-existing enclave will verify attestation and manifest for a new enclave and then forward its quorum key to the new enclave.
+- [Key Forward](docs/key_forward.md): mode for provisioning an enclave from an already provisioned enclave of the same namespace. This allows QuorumOS to support horizontal scaling cloud workloads. Effectively, a pre-existing enclave will verify attestation and manifest for a new enclave and then forward its quorum key to the new enclave.
 
 ### Remote Attestation
 

--- a/docs/debug_tips.md
+++ b/docs/debug_tips.md
@@ -43,7 +43,7 @@
     sudo chmod -R g+w /var/log/nitro_enclaves /run/nitro_enclaves /etc/nitro_enclaves
     sudo chown -R :admin /var/log/nitro_enclaves /run/nitro_enclaves /etc/nitro_enclaves
     sudo cp build/nitro_cli/x86_64-unknown-linux-musl/release/nitro-cli /usr/local/bin/
-    sudo cp bootstrapnitro-enclaves-allocator /usr/local/bin/
+    sudo cp bootstrap/nitro-enclaves-allocator /usr/local/bin/
     sudo cp bootstrap/allocator.yaml /etc/
     sed -i 's|/usr/bin|/usr/local/bin|g' bootstrap/nitro-enclaves-allocator.service
     sudo cp bootstrap/nitro-enclaves-allocator.service /etc/systemd/system/

--- a/docs/key_forward.md
+++ b/docs/key_forward.md
@@ -40,7 +40,7 @@ The details for how QOS nodes communicate with each other can vary, but for the 
         }
         ```
 
-3) The Original Node gets a `ExportKeyRequest` from the the Client.
+3) The Original Node gets a `ExportKeyRequest` from the Client.
 
     ```rust
     struct ExportKeyRequest {
@@ -53,12 +53,12 @@ The details for how QOS nodes communicate with each other can vary, but for the 
     1) Check the basic validity of the attestation doc (cert chain etc). Ensures that the attestation document is actually from an AWS controlled NSM module and the document's timestamp was recent.
     1) Check the signatures over the New Manifest. Ensures that K Manifest Set Members approved the New Manifest.
     1) Check that the Quorum Key of the Local Manifest matches the Quorum Key of the New Manifest. This ensures the request is for the correct Quorum Key.
-    1) Check that the Manifest Set of the New Manifest matches the Manifest Set of the Local Manifest. Ensures that the signatures are from a trusted Manifest Set. Note that there is still a vulnerability here if we have try to retire a Manifest Set because a critical threshold of it was compromised - that malicious Manifest Set could boot off of an Original Node - thus it's important to retire all Original Nodes ASAP that use compromised Manifest Sets.
+    1) Check that the Manifest Set of the New Manifest matches the Manifest Set of the Local Manifest. Ensures that the signatures are from a trusted Manifest Set. Note that there is still a vulnerability here if we try to retire a Manifest Set because a critical threshold of it was compromised - that malicious Manifest Set could boot off of an Original Node - thus it's important to retire all Original Nodes ASAP that use compromised Manifest Sets.
     1) Check that the Namespace of the Local Manifest matches the namespace of the New Manifest. Namespaces are a social construct, but we only want to allow forwarding a Quorum Key to Nodes in the same Namespace to help ensure that the nonce is not abused.
     1) Check that the nonce of the New Manifest is greater than or equal to the nonce of the Local Manifest. If they have the same nonce, we check that the Local Manifest has the same hash as an extra measure. Note that while the nonce is verified programmatically in this routine, its maintenance relative to other manifests in the namespace is a social coordination problem and is meant to be solved by the Manifest Set Members approving the manifest. In other words, we rely on the Manifest Set Members to correctly increment the nonce when any change is made to the latest manifest for a namespace.
     1) Check that the hash of the new manifest is in the `user_data` field of the attestation doc.
-    1) Check that PCR0, PCR1, PCR2, and PCR3 in the New Manifest match the PCRs in the attestation document. This ensures the New Manifest was used against a Nitro enclave booted with the intended version of QOS. Note that we assume the values for PCR{0, 1 , 2} correspond to a desired version of QOS because the Manifest Set Members had K approvals.
-    1) Check that PCR3 in the New Manifest is in the Local Manifests. PCR3 is the IAM role assigned to the EC2 host of the enclave. An IAM role contains an AWS organization's unique ID. By only using the approved PCR3 value we ensure that we only ever send the Quorum Key to an enclave that is controlled by the operator, not an enclave that some malicious entity runs that otherwise configured identically to one of the operator's enclaves.
+    1) Check that PCR0, PCR1, PCR2, and PCR3 in the New Manifest match the PCRs in the attestation document. This ensures the New Manifest was used against a Nitro enclave booted with the intended version of QOS. Note that we assume the values for PCR{0, 1, 2} correspond to a desired version of QOS because the Manifest Set Members had K approvals.
+    1) Check that PCR3 in the New Manifest is in the Local Manifests. PCR3 is the IAM role assigned to the EC2 host of the enclave. An IAM role contains an AWS organization's unique ID. By only using the approved PCR3 value we ensure that we only ever send the Quorum Key to an enclave that is controlled by the operator, not an enclave that some malicious entity runs that is otherwise configured identically to one of the operator's enclaves.
     1) Return the Quorum Key encrypted to the New Node's Ephemeral Key extracted from the attestation document and a signature over the encrypted payload. The Original Node uses its Quorum Key to create the signature.
 
         ```rust

--- a/docs/provision_yubikey.md
+++ b/docs/provision_yubikey.md
@@ -71,7 +71,7 @@ Note: Do not write the PIN to a file on disk. The process substitution syntax `<
 qos_client provision-yubikey --pub-path ~/path/to/output.pub
 ```
 
-When prompted, enter the PIN you set in Phase 2.
+When prompted, enter the PIN you set in step 2.
 
 The file at `--pub-path` will contain the hex-encoded public key. Share this `.pub` file with the ceremony coordinator — never share the PIN or the device itself.
 

--- a/src/qos_bridge/README.md
+++ b/src/qos_bridge/README.md
@@ -18,7 +18,6 @@ Provided a bridge configuration of
 }
 ```
 
-`cargo run -- --control-url http://localhost:3001/qos --usock /tmp/enclave-example/example.sock --
-host-port-override 4000`
+`cargo run -- --control-url http://localhost:3001/qos --usock /tmp/enclave-example/example.sock --host-port-override 4000`
 
 The pivot app will be available on `localhost:4000` via the bridge, and `localhost:3000` directly.


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

These are only updates to docs to fix typos in several `.MD` files.

While reading through these docs as a resource I came across a few typos that would improve readability if they were fixed. **Only documentation updates are included in these changes**.

## How I Tested These Changes

## Pre merge check list

- [x] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version? **YES** - no code changes
    - Can previous versions of QOS verify attestations from this new version? **YES** - no code changes
    - Can manifests generated by a previous version still be parsed by this one? **YES** - no code changes
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)? **YES** - no code changes
    - Can a previous version of QOS still perform a boot standard on an enclave of this version? **YES** - no code changes
