### PR TITLE
fix(qos_core): avoid undrained pivot stdio pipes

### DIFF
--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -199,7 +199,12 @@ impl Reaper {
 		let mut pivot = Command::new(handles.pivot_path());
 		pivot.env_clear();
 		pivot.args(&args[..]);
-		pivot.stdout(Stdio::piped()).stderr(Stdio::piped());
+		// Only pipe pivot output when it will be drained below.
+		if manifest.pivot.debug_mode {
+			pivot.stdout(Stdio::piped()).stderr(Stdio::piped());
+		} else {
+			pivot.stdout(Stdio::null()).stderr(Stdio::null());
+		}
 
 		loop {
 			let mut child = pivot.spawn().expect("Failed to spawn pivot");


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

When pivot debug mode is disabled, qos_core currently still starts the pivot with piped stdout and stderr. However, those pipes are only drained when `manifest.pivot.debug_mode` is true.

That means a pivot that writes enough output in non-debug mode can eventually block on a full pipe buffer. This change only pipes pivot output when debug mode is enabled, and uses `Stdio::null()` otherwise so child writes are safely discarded by the OS.

## How I Tested These Changes

- Ran `cargo fmt --all`
- Ran `git diff --check`

I also attempted:

- `cargo check -p qos_core -p qos_net --features qos_net/vm,qos_net/proxy`

That check reached an existing macOS VM build issue in `qos_core/src/io/mod.rs`, where `VsockAddr` and `SockAddrVm` have different sizes for a `transmute`.

## Pre merge check list

- [x] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - [x] Can enclaves in a previous QOS version still key forward to this new version?
    - [x] Can previous versions of QOS verify attestations from this new version?
    - [x] Can manifests generated by a previous version still be parsed by this one?
    - [x] Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - [x] Can a previous version of QOS still perform a boot standard on an enclave of this version?

This is not a verification flow breaking change. It only changes how pivot child-process stdout/stderr are configured when debug mode is disabled.