### PR TITLE
chore: simplify PathWrapper-to-string conversion (SYS-43 follow-up)

### DIFF
--- a/src/integration/tests/reaper.rs
+++ b/src/integration/tests/reaper.rs
@@ -32,8 +32,8 @@ async fn reaper_works() {
 
 	let handles = Handles::new(
 		"eph_path".to_string(),
-		secret_path.to_str().map(ToString::to_string).unwrap(),
-		manifest_path.to_str().map(ToString::to_string).unwrap(),
+		secret_path.display().to_string(),
+		manifest_path.display().to_string(),
 		PIVOT_OK_PATH.to_string(),
 	);
 
@@ -85,8 +85,8 @@ async fn reaper_clears_host_env() {
 
 	let handles = Handles::new(
 		"reaper_clears_host_env.eph".to_string(),
-		secret_path.to_str().map(ToString::to_string).unwrap(),
-		manifest_path.to_str().map(ToString::to_string).unwrap(),
+		secret_path.display().to_string(),
+		manifest_path.display().to_string(),
 		PIVOT_OK2_PATH.to_string(),
 	);
 
@@ -200,8 +200,8 @@ async fn reaper_handles_non_zero_exits() {
 
 	let handles = Handles::new(
 		"eph_path".to_string(),
-		secret_path.to_str().map(ToString::to_string).unwrap(),
-		manifest_path.to_str().map(ToString::to_string).unwrap(),
+		secret_path.display().to_string(),
+		manifest_path.display().to_string(),
 		PIVOT_ABORT_PATH.to_string(),
 	);
 
@@ -247,8 +247,8 @@ async fn reaper_handles_panic() {
 
 	let handles = Handles::new(
 		"eph_path".to_string(),
-		secret_path.to_str().map(ToString::to_string).unwrap(),
-		manifest_path.to_str().map(ToString::to_string).unwrap(),
+		secret_path.display().to_string(),
+		manifest_path.display().to_string(),
 		PIVOT_PANIC_PATH.to_string(),
 	);
 
@@ -299,8 +299,8 @@ async fn reaper_handles_bridge() {
 
 	let handles = Handles::new(
 		"eph_path".to_string(),
-		secret_path.to_str().map(ToString::to_string).unwrap(),
-		manifest_path.to_str().map(ToString::to_string).unwrap(),
+		secret_path.display().to_string(),
+		manifest_path.display().to_string(),
 		PIVOT_TCP_PATH.to_string(),
 	);
 

--- a/src/qos_core/src/handles.rs
+++ b/src/qos_core/src/handles.rs
@@ -345,10 +345,10 @@ mod test {
 			PathWrapper::from("put_ephemeral_key_is_read_only_write.manifest");
 
 		let handles = Handles::new(
-			ephemeral_file.to_str().map(ToString::to_string).unwrap(),
-			quorum_file.to_str().map(ToString::to_string).unwrap(),
-			manifest_file.to_str().map(ToString::to_string).unwrap(),
-			pivot_file.to_str().map(ToString::to_string).unwrap(),
+			ephemeral_file.display().to_string(),
+			quorum_file.display().to_string(),
+			manifest_file.display().to_string(),
+			pivot_file.display().to_string(),
 		);
 
 		let ephemeral_key = P256Pair::generate().unwrap();
@@ -372,10 +372,10 @@ mod test {
 			PathWrapper::from("put_quorum_key_is_read_only_write.manifest");
 
 		let handles = Handles::new(
-			ephemeral_file.to_str().map(ToString::to_string).unwrap(),
-			quorum_file.to_str().map(ToString::to_string).unwrap(),
-			manifest_file.to_str().map(ToString::to_string).unwrap(),
-			pivot_file.to_str().map(ToString::to_string).unwrap(),
+			ephemeral_file.display().to_string(),
+			quorum_file.display().to_string(),
+			manifest_file.display().to_string(),
+			pivot_file.display().to_string(),
 		);
 
 		let quorum_key = P256Pair::generate().unwrap();
@@ -401,10 +401,10 @@ mod test {
 			PathWrapper::from("put_pivot_is_read_only_write.manifest");
 
 		let handles = Handles::new(
-			ephemeral_file.to_str().map(ToString::to_string).unwrap(),
-			quorum_file.to_str().map(ToString::to_string).unwrap(),
-			manifest_file.to_str().map(ToString::to_string).unwrap(),
-			pivot_file.to_str().map(ToString::to_string).unwrap(),
+			ephemeral_file.display().to_string(),
+			quorum_file.display().to_string(),
+			manifest_file.display().to_string(),
+			pivot_file.display().to_string(),
 		);
 
 		let pivot = b"this is a pivot binary".to_vec();
@@ -428,10 +428,10 @@ mod test {
 			PathWrapper::from("put_manifest_is_read_only_write.manifest");
 
 		let handles = Handles::new(
-			ephemeral_file.to_str().map(ToString::to_string).unwrap(),
-			quorum_file.to_str().map(ToString::to_string).unwrap(),
-			manifest_file.to_str().map(ToString::to_string).unwrap(),
-			pivot_file.to_str().map(ToString::to_string).unwrap(),
+			ephemeral_file.display().to_string(),
+			quorum_file.display().to_string(),
+			manifest_file.display().to_string(),
+			pivot_file.display().to_string(),
 		);
 
 		let pivot = b"this is a pivot binary".to_vec();

--- a/src/qos_core/src/protocol/services/boot.rs
+++ b/src/qos_core/src/protocol/services/boot.rs
@@ -1109,10 +1109,10 @@ mod test {
 			"boot_standard_rejects_manifest_envelope_with_share_set_approvals.manifest");
 
 		let handles = Handles::new(
-			ephemeral_file.to_str().map(ToString::to_string).unwrap(),
+			ephemeral_file.display().to_string(),
 			"quorum_key".to_string(),
-			manifest_file.to_str().map(ToString::to_string).unwrap(),
-			pivot_file.to_str().map(ToString::to_string).unwrap(),
+			manifest_file.display().to_string(),
+			pivot_file.display().to_string(),
 		);
 		let mut protocol_state =
 			ProtocolState::new(Box::new(MockNsm), handles, None);
@@ -1165,10 +1165,10 @@ mod test {
 			"boot_standard_rejects_approval_from_non_manifest_set_member.manifest");
 
 		let handles = Handles::new(
-			ephemeral_file.to_str().map(ToString::to_string).unwrap(),
+			ephemeral_file.display().to_string(),
 			"quorum_key".to_string(),
-			manifest_file.to_str().map(ToString::to_string).unwrap(),
-			pivot_file.to_str().map(ToString::to_string).unwrap(),
+			manifest_file.display().to_string(),
+			pivot_file.display().to_string(),
 		);
 		let mut protocol_state =
 			ProtocolState::new(Box::new(MockNsm), handles, None);

--- a/src/qos_core/src/protocol/services/key.rs
+++ b/src/qos_core/src/protocol/services/key.rs
@@ -449,10 +449,10 @@ mod test {
 			);
 
 			let handles = Handles::new(
-				ephemeral_file.to_str().map(ToString::to_string).unwrap(),
+				ephemeral_file.display().to_string(),
 				"qorum".to_string(),
-				manifest_file.to_str().map(ToString::to_string).unwrap(),
-				pivot_file.to_str().map(ToString::to_string).unwrap(),
+				manifest_file.display().to_string(),
+				pivot_file.display().to_string(),
 			);
 			let mut state =
 				ProtocolState::new(Box::new(MockNsm), handles.clone(), None);
@@ -489,10 +489,10 @@ mod test {
 				"/tmp/boot_key_rejects_manifest_if_not_enough_approvals.manifest");
 
 			let handles = Handles::new(
-				ephemeral_file.to_str().map(ToString::to_string).unwrap(),
+				ephemeral_file.display().to_string(),
 				"qorum".to_string(),
-				manifest_file.to_str().map(ToString::to_string).unwrap(),
-				pivot_file.to_str().map(ToString::to_string).unwrap(),
+				manifest_file.display().to_string(),
+				pivot_file.display().to_string(),
 			);
 			let mut state =
 				ProtocolState::new(Box::new(MockNsm), handles.clone(), None);
@@ -527,10 +527,10 @@ mod test {
 			);
 
 			let handles = Handles::new(
-				ephemeral_file.to_str().map(ToString::to_string).unwrap(),
+				ephemeral_file.display().to_string(),
 				"qorum".to_string(),
-				manifest_file.to_str().map(ToString::to_string).unwrap(),
-				pivot_file.to_str().map(ToString::to_string).unwrap(),
+				manifest_file.display().to_string(),
+				pivot_file.display().to_string(),
 			);
 			let mut state =
 				ProtocolState::new(Box::new(MockNsm), handles.clone(), None);
@@ -569,10 +569,10 @@ mod test {
 			);
 
 			let handles = Handles::new(
-				ephemeral_file.to_str().map(ToString::to_string).unwrap(),
+				ephemeral_file.display().to_string(),
 				"quorum".to_string(),
-				manifest_file.to_str().map(ToString::to_string).unwrap(),
-				pivot_file.to_str().map(ToString::to_string).unwrap(),
+				manifest_file.display().to_string(),
+				pivot_file.display().to_string(),
 			);
 			let mut state =
 				ProtocolState::new(Box::new(MockNsm), handles.clone(), None);
@@ -622,10 +622,10 @@ mod test {
 				"/tmp/boot_key_reject_manifest_with_approval_from_non_membermanifest");
 
 			let handles = Handles::new(
-				ephemeral_file.to_str().map(ToString::to_string).unwrap(),
+				ephemeral_file.display().to_string(),
 				"quorum".to_string(),
-				manifest_file.to_str().map(ToString::to_string).unwrap(),
-				pivot_file.to_str().map(ToString::to_string).unwrap(),
+				manifest_file.display().to_string(),
+				pivot_file.display().to_string(),
 			);
 			let mut state =
 				ProtocolState::new(Box::new(MockNsm), handles.clone(), None);
@@ -1102,9 +1102,9 @@ mod test {
 			)
 			.unwrap();
 			let handles = Handles::new(
-				ephemeral_file.to_str().map(ToString::to_string).unwrap(),
-				quorum_file.to_str().map(ToString::to_string).unwrap(),
-				manifest_file.to_str().map(ToString::to_string).unwrap(),
+				ephemeral_file.display().to_string(),
+				quorum_file.display().to_string(),
+				manifest_file.display().to_string(),
 				"pivot".to_string(),
 			);
 
@@ -1164,9 +1164,9 @@ mod test {
 			let signature = quorum_pair.sign(&encrypted_quorum_key).unwrap();
 
 			let handles = Handles::new(
-				ephemeral_file.to_str().map(ToString::to_string).unwrap(),
-				quorum_file.to_str().map(ToString::to_string).unwrap(),
-				manifest_file.to_str().map(ToString::to_string).unwrap(),
+				ephemeral_file.display().to_string(),
+				quorum_file.display().to_string(),
+				manifest_file.display().to_string(),
 				"pivot".to_string(),
 			);
 			let mut protocol_state =
@@ -1222,9 +1222,9 @@ mod test {
 			let signature = quorum_pair.sign(&encrypted_quorum_key).unwrap();
 
 			let handles = Handles::new(
-				ephemeral_file.to_str().map(ToString::to_string).unwrap(),
-				quorum_file.to_str().map(ToString::to_string).unwrap(),
-				manifest_file.to_str().map(ToString::to_string).unwrap(),
+				ephemeral_file.display().to_string(),
+				quorum_file.display().to_string(),
+				manifest_file.display().to_string(),
 				"pivot".to_string(),
 			);
 			let mut protocol_state =
@@ -1276,9 +1276,9 @@ mod test {
 			let signature = wrong_key.sign(&encrypted_quorum_key).unwrap();
 
 			let handles = Handles::new(
-				ephemeral_file.to_str().map(ToString::to_string).unwrap(),
-				quorum_file.to_str().map(ToString::to_string).unwrap(),
-				manifest_file.to_str().map(ToString::to_string).unwrap(),
+				ephemeral_file.display().to_string(),
+				quorum_file.display().to_string(),
+				manifest_file.display().to_string(),
 				"pivot".to_string(),
 			);
 			let mut protocol_state =
@@ -1330,9 +1330,9 @@ mod test {
 				quorum_pair.sign(&invalid_encrypted_quorum_key).unwrap();
 
 			let handles = Handles::new(
-				ephemeral_file.to_str().map(ToString::to_string).unwrap(),
-				quorum_file.to_str().map(ToString::to_string).unwrap(),
-				manifest_file.to_str().map(ToString::to_string).unwrap(),
+				ephemeral_file.display().to_string(),
+				quorum_file.display().to_string(),
+				manifest_file.display().to_string(),
 				"pivot".to_string(),
 			);
 			let mut protocol_state =

--- a/src/qos_core/src/protocol/services/provision.rs
+++ b/src/qos_core/src/protocol/services/provision.rs
@@ -161,9 +161,9 @@ mod test {
 		manifest_file: &Path,
 	) -> Setup {
 		let handles = Handles::new(
-			eph_file.to_str().map(ToString::to_string).unwrap(),
-			quorum_file.to_str().map(ToString::to_string).unwrap(),
-			manifest_file.to_str().map(ToString::to_string).unwrap(),
+			eph_file.display().to_string(),
+			quorum_file.display().to_string(),
+			manifest_file.display().to_string(),
 			"pivot".to_string(),
 		);
 		// 1) Create and write eph key


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

Follow-up to #689 ([SYS-43](https://linear.app/turnkey/issue/SYS-43/add-qos-protocol-protocol-msg-to-query-versioncommit-info)) addressing review feedback from @Avi-D-coder and @emostov on the verbose path-to-string pattern that PR introduced across tests.

**Problem:** 65 occurrences of `<path>.to_str().map(ToString::to_string).unwrap()` were spread across `Handles::new` call sites and test setup in `qos_core` and `integration`.

**Solution:** replace with `<path>.display().to_string()`. Works uniformly for both `PathWrapper<P>` (via `Deref<Target = Path>`) and bare `&Path`, so no new trait impl is needed — `Path::display()` returns a `Display` adapter and `.to_string()` follows from the blanket `impl<T: Display> ToString for T`.

Files touched (mechanical substitution only, no behavior change):

- `src/qos_core/src/handles.rs` — 16
- `src/qos_core/src/protocol/services/boot.rs` — 6
- `src/qos_core/src/protocol/services/key.rs` — 30
- `src/qos_core/src/protocol/services/provision.rs` — 3
- `src/integration/tests/reaper.rs` — 10

## How I Tested These Changes

- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p qos_core --lib` (83 tests pass)
- `cargo test -p integration --test reaper` (5 tests pass)
- `rg 'to_str\(\)\.map\(ToString::to_string\)\.unwrap\(\)' src/` returns zero matches

## Pre merge check list

- [x] Conventional commits — `chore:` (mechanical refactor, no behavior change)
- [x] No verification-flow impact — touches only test setup and the path-string conversion in `Handles::new` callers; protocol surface area unchanged