### PR TITLE
chore(qos): bump rust to 1.94

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ default-members = [
   "src/qos_p256",
   "src/qos_nsm",
 ]
-
 exclude = [
   "src/init",
   "src/qos_aws",
@@ -43,7 +42,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.88"
+rust-version = "1.94"
 version = "0.7.0"
 edition = "2021"
 license = "AGPL-3.0-only"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.88"
+channel = "1.94"
 components = ["rustfmt", "cargo", "clippy", "rust-analyzer"]
 profile = "minimal"

--- a/src/images/common/Containerfile
+++ b/src/images/common/Containerfile
@@ -2,7 +2,7 @@
 # static builds. Once we have confirmed an updated pcsc-lite has fixed this
 # issue, we should upgrade this again.
 FROM stagex/pcsc-lite:sx2024.03.0@sha256:e720e1795706c7c8c1db14bf730b10521e3ff42e4bed90addc590f7446aac8af AS pcsc-lite
-FROM stagex/pallet-rust:1.88.0@sha256:81c39a3b42b0336e439aee3c90e9e1e4da1d32425451e7222198a978eb8c2623 AS rust
+FROM stagex/pallet-rust:1.94.0@sha256:2fbe7b164dd92edb9c1096152f6d27592d8a69b1b8eb2fc907b5fadea7d11668 AS rust
 FROM stagex/user-file:5.45@sha256:07ebef1a7d375c785c2268c5532b473a7130e4fbcf9807cc8f7b5d61e3b84b74 AS file
 FROM stagex/core-make:4.4@sha256:a47d8f67f8fd74905f724fdc5f0d18e29df96391751754947bdeaba9bef8f7d8 AS make
 

--- a/src/images/qos_enclave/Containerfile
+++ b/src/images/qos_enclave/Containerfile
@@ -1,6 +1,7 @@
 FROM stagex/eif_build:0.2.2@sha256:9d086a2743f9df4eddf934c7b68c9dee4a7fb131b6465a24237a67f6c359dfb0 AS eif_build
 FROM stagex/gen_initramfs:6.8@sha256:f5b9271cca6003e952cbbb9ef041ffa92ba328894f563d1d77942e6b5cdeac1a AS gen_initramfs
 FROM stagex/linux-nitro:sx2024.03.0@sha256:073c4603686e3bdc0ed6755fee3203f6f6f1512e0ded09eaea8866b002b04264 AS linux-nitro
+FROM stagex/core-libunwind:1.7.2@sha256:eb66122d8fc543f5e2f335bb1616f8c3a471604383e2c0a9df4a8e278505d3bc AS libunwind
 
 FROM common AS base
 
@@ -30,6 +31,7 @@ RUN file /init | grep "static-pie"
 FROM base AS build-eif
 WORKDIR /build_cpio
 COPY --from=eif_build . /
+COPY --from=libunwind . /
 COPY --from=gen_initramfs . /
 COPY --from=build-init /init .
 COPY --from=linux-nitro /nsm.ko .

--- a/src/images/qos_enclave/Containerfile
+++ b/src/images/qos_enclave/Containerfile
@@ -1,6 +1,7 @@
 FROM stagex/eif_build:0.2.2@sha256:9d086a2743f9df4eddf934c7b68c9dee4a7fb131b6465a24237a67f6c359dfb0 AS eif_build
 FROM stagex/gen_initramfs:6.8@sha256:f5b9271cca6003e952cbbb9ef041ffa92ba328894f563d1d77942e6b5cdeac1a AS gen_initramfs
 FROM stagex/linux-nitro:sx2024.03.0@sha256:073c4603686e3bdc0ed6755fee3203f6f6f1512e0ded09eaea8866b002b04264 AS linux-nitro
+FROM stagex/core-gcc:15.2.0@sha256:ceae6035d43fe3653e142e638fd78d72950cd51e7a5dba4755d1db081c54de77 AS gcc
 FROM stagex/core-libunwind:1.7.2@sha256:eb66122d8fc543f5e2f335bb1616f8c3a471604383e2c0a9df4a8e278505d3bc AS libunwind
 
 FROM common AS base
@@ -31,6 +32,7 @@ RUN file /init | grep "static-pie"
 FROM base AS build-eif
 WORKDIR /build_cpio
 COPY --from=eif_build . /
+COPY --from=gcc . /
 COPY --from=libunwind . /
 COPY --from=gen_initramfs . /
 COPY --from=build-init /init .

--- a/src/qos_bridge/src/cli.rs
+++ b/src/qos_bridge/src/cli.rs
@@ -65,7 +65,7 @@ impl HostOpts {
 		self.parsed
 			.single(CONTROL_URL)
 			.expect("no control-url provided")
-			.to_string()
+			.clone()
 	}
 
 	/// overrides the host portion of the bridge with given port, ignoring the manifest value

--- a/src/qos_bridge/src/host.rs
+++ b/src/qos_bridge/src/host.rs
@@ -35,7 +35,10 @@ impl BridgeServer {
 	pub async fn serve(&self) {
 		loop {
 			match tokio::task::block_in_place(|| {
-				ureq::get(&self.info_url).timeout(Duration::from_secs(1)).call()
+				ureq::get(&self.info_url)
+					.timeout(Duration::from_secs(1))
+					.call()
+					.map_err(Box::new)
 			}) {
 				Ok(info) => {
 					if let Some(me) = info

--- a/src/qos_client/src/cli/mod.rs
+++ b/src/qos_client/src/cli/mod.rs
@@ -929,18 +929,18 @@ impl ClientOpts {
 	}
 
 	fn alias(&self) -> String {
-		self.parsed.single(ALIAS).expect("required arg").to_string()
+		self.parsed.single(ALIAS).expect("required arg").clone()
 	}
 
 	fn namespace(&self) -> String {
-		self.parsed.single(NAMESPACE).expect("required arg").to_string()
+		self.parsed.single(NAMESPACE).expect("required arg").clone()
 	}
 
 	fn pcr3_preimage_path(&self) -> String {
 		self.parsed
 			.single(PCR3_PREIMAGE_PATH)
 			.expect("`--pcr3-preimage-path` is a required arg")
-			.to_string()
+			.clone()
 	}
 
 	fn nonce(&self) -> u32 {
@@ -955,62 +955,62 @@ impl ClientOpts {
 		self.parsed
 			.single(RESTART_POLICY)
 			.expect("required arg")
-			.to_string()
+			.clone()
 			.try_into()
 			.expect("Could not parse `--restart-policy`")
 	}
 
 	fn pivot_path(&self) -> String {
-		self.parsed.single(PIVOT_PATH).expect("required arg").to_string()
+		self.parsed.single(PIVOT_PATH).expect("required arg").clone()
 	}
 
 	fn manifest_set_dir(&self) -> String {
 		self.parsed
 			.single(MANIFEST_SET_DIR)
 			.expect("`--manifest-set-dir` is a required arg")
-			.to_string()
+			.clone()
 	}
 
 	fn share_set_dir(&self) -> String {
 		self.parsed
 			.single(SHARE_SET_DIR)
 			.expect("`--share-set-dir` is a required arg")
-			.to_string()
+			.clone()
 	}
 
 	fn patch_set_dir(&self) -> String {
 		self.parsed
 			.single(PATCH_SET_DIR)
 			.expect("`--patch-set-dir` is a required arg")
-			.to_string()
+			.clone()
 	}
 
 	fn namespace_dir(&self) -> String {
 		self.parsed
 			.single(NAMESPACE_DIR)
 			.expect("`--namespace-dir` is a required arg")
-			.to_string()
+			.clone()
 	}
 
 	fn manifest_approvals_dir(&self) -> String {
 		self.parsed
 			.single(MANIFEST_APPROVALS_DIR)
 			.expect("`--manifest-approval-dir` is a required arg")
-			.to_string()
+			.clone()
 	}
 
 	fn qos_release_dir(&self) -> String {
 		self.parsed
 			.single(QOS_REALEASE_DIR)
 			.expect("qos-release-dir is a required arg")
-			.to_string()
+			.clone()
 	}
 
 	fn pivot_hash_path(&self) -> String {
 		self.parsed
 			.single(PIVOT_HASH_PATH)
 			.expect("pivot-hash is a required arg")
-			.to_string()
+			.clone()
 	}
 
 	fn pivot_args(&self) -> Vec<String> {
@@ -1065,7 +1065,7 @@ impl ClientOpts {
 	}
 
 	fn pub_path(&self) -> String {
-		self.parsed.single(PUB_PATH).expect("Missing `--pub-path`").to_string()
+		self.parsed.single(PUB_PATH).expect("Missing `--pub-path`").clone()
 	}
 
 	fn secret_path(&self) -> Option<String> {
@@ -1073,38 +1073,35 @@ impl ClientOpts {
 	}
 
 	fn share_path(&self) -> String {
-		self.parsed
-			.single(SHARE_PATH)
-			.expect("Missing `--share-path`")
-			.to_string()
+		self.parsed.single(SHARE_PATH).expect("Missing `--share-path`").clone()
 	}
 
 	fn output_path(&self) -> String {
 		self.parsed
 			.single(OUTPUT_PATH)
 			.expect("Missing `--output-path`")
-			.to_string()
+			.clone()
 	}
 
 	fn quorum_key_path(&self) -> String {
 		self.parsed
 			.single(QUORUM_KEY_PATH)
 			.expect("Missing `--quorum-key-path`")
-			.to_string()
+			.clone()
 	}
 
 	fn manifest_path(&self) -> String {
 		self.parsed
 			.single(MANIFEST_PATH)
 			.expect("Missing `--manifest-path`")
-			.to_string()
+			.clone()
 	}
 
 	fn manifest_envelope_path(&self) -> String {
 		self.parsed
 			.single(MANIFEST_ENVELOPE_PATH)
 			.expect("Missing `--manifest-envelope-path`")
-			.to_string()
+			.clone()
 	}
 
 	fn maybe_manifest_envelope_path(&self) -> Option<String> {
@@ -1115,35 +1112,32 @@ impl ClientOpts {
 		self.parsed
 			.single(APPROVAL_PATH)
 			.expect("Missing `--approval-path`")
-			.to_string()
+			.clone()
 	}
 
 	fn eph_wrapped_share_path(&self) -> String {
 		self.parsed
 			.single(EPH_WRAPPED_SHARE_PATH)
 			.expect("Missing `--eph-wrapped-share-path`")
-			.to_string()
+			.clone()
 	}
 
 	fn attestation_doc_path(&self) -> String {
 		self.parsed
 			.single(ATTESTATION_DOC_PATH)
 			.expect("Missing `--attestation-doc-path`")
-			.to_string()
+			.clone()
 	}
 
 	fn master_seed_path(&self) -> String {
 		self.parsed
 			.single(MASTER_SEED_PATH)
 			.expect("Missing `--master-seed-path`")
-			.to_string()
+			.clone()
 	}
 
 	fn output_dir(&self) -> String {
-		self.parsed
-			.single(OUTPUT_DIR)
-			.expect("Missing `--output-dir`")
-			.to_string()
+		self.parsed.single(OUTPUT_DIR).expect("Missing `--output-dir`").clone()
 	}
 
 	fn shares(&self) -> Vec<String> {
@@ -1167,35 +1161,32 @@ impl ClientOpts {
 	}
 
 	fn payload(&self) -> String {
-		self.parsed.single(PAYLOAD).expect("Missing `--payload`").to_string()
+		self.parsed.single(PAYLOAD).expect("Missing `--payload`").clone()
 	}
 
 	fn payload_path(&self) -> String {
 		self.parsed
 			.single(PAYLOAD_PATH)
 			.expect("Missing `--payload-path`")
-			.to_string()
+			.clone()
 	}
 
 	fn signature_path(&self) -> String {
 		self.parsed
 			.single(SIGNATURE_PATH)
 			.expect("Missing `--signature-path`")
-			.to_string()
+			.clone()
 	}
 
 	fn ephemeral_key_path(&self) -> String {
 		self.parsed
 			.single(EPHEMERAL_KEY_PATH)
 			.expect("Missing `--ephemeral-key-path`")
-			.to_string()
+			.clone()
 	}
 
 	fn file_path(&self) -> String {
-		self.parsed
-			.single(FILE_PATH)
-			.expect("Missing `--file-path`")
-			.to_string()
+		self.parsed.single(FILE_PATH).expect("Missing `--file-path`").clone()
 	}
 
 	fn display_type(&self) -> DisplayType {
@@ -1214,7 +1205,7 @@ impl ClientOpts {
 		self.parsed
 			.single(NEW_PIN_PATH)
 			.expect("Missing `--new-pin-path`")
-			.to_string()
+			.clone()
 	}
 
 	fn current_pin_path(&self) -> Option<String> {
@@ -1231,21 +1222,21 @@ impl ClientOpts {
 		self.parsed
 			.single(ENCRYPTED_QUORUM_KEY_PATH)
 			.expect("Missing `--encrypted-quorum-key-path`")
-			.to_string()
+			.clone()
 	}
 
 	fn plaintext_path(&self) -> String {
 		self.parsed
 			.single(PLAINTEXT_PATH)
 			.expect("Missing `--plaintext-path`")
-			.to_string()
+			.clone()
 	}
 
 	fn ciphertext_path(&self) -> String {
 		self.parsed
 			.single(CIPHERTEXT_PATH)
 			.expect("Missing `--ciphertext-path`")
-			.to_string()
+			.clone()
 	}
 
 	fn yubikey(&self) -> bool {

--- a/src/qos_core/src/io/pool.rs
+++ b/src/qos_core/src/io/pool.rs
@@ -151,7 +151,7 @@ impl StreamPool {
 	///
 	/// # Panics
 	/// Panics if list of addresses provided was empty.
-	pub async fn get(&self) -> PoolGuard {
+	pub async fn get(&self) -> PoolGuard<'_> {
 		// TODO: make this into an error
 		assert!(
 			!self.handles.is_empty(),

--- a/src/qos_core/src/parser.rs
+++ b/src/qos_core/src/parser.rs
@@ -470,7 +470,7 @@ impl TokenMap {
 					.is_some()
 				{
 					// Advance the iterator since we only peaked above
-					iter.next().unwrap().to_string()
+					iter.next().unwrap().clone()
 				} else if let Some(ref d) = token.default_value {
 					// Couldn't find a value, so take the default
 					d.to_string()
@@ -515,7 +515,7 @@ impl TokenMap {
 		for token in self.tokens.values() {
 			// Check if a value is required for the token
 			if token.required && token.user_value.is_none() {
-				Err(ParserError::MissingInput(token.name.to_string()))?;
+				Err(ParserError::MissingInput(token.name.clone()))?;
 			}
 
 			if token.user_value.is_some() {
@@ -523,7 +523,7 @@ impl TokenMap {
 				if let Some(ref other_name) = token.requires {
 					if !inputs.contains(&(format!("--{other_name}"))) {
 						return Err(ParserError::MissingInput(
-							other_name.to_string(),
+							other_name.clone(),
 						));
 					}
 				}
@@ -533,8 +533,8 @@ impl TokenMap {
 				for other_name in &token.forbids {
 					if inputs.contains(&(format!("--{other_name}"))) {
 						Err(ParserError::MutuallyExclusiveInput(
-							token.name.to_string(),
-							other_name.to_string(),
+							token.name.clone(),
+							other_name.clone(),
 						))?;
 					}
 				}

--- a/src/qos_core/src/protocol/services/boot.rs
+++ b/src/qos_core/src/protocol/services/boot.rs
@@ -71,11 +71,11 @@ impl fmt::Debug for NitroConfig {
 	borsh::BorshDeserialize,
 	serde::Serialize,
 	serde::Deserialize,
-	Default,
 )]
+#[cfg_attr(any(feature = "mock", test), derive(Default))]
 pub enum RestartPolicy {
 	/// Never restart the pivot application
-	#[default]
+	#[cfg_attr(any(feature = "mock", test), default)]
 	Never,
 	/// Always restart the pivot application
 	Always,

--- a/src/qos_core/src/protocol/services/boot.rs
+++ b/src/qos_core/src/protocol/services/boot.rs
@@ -71,9 +71,11 @@ impl fmt::Debug for NitroConfig {
 	borsh::BorshDeserialize,
 	serde::Serialize,
 	serde::Deserialize,
+	Default,
 )]
 pub enum RestartPolicy {
 	/// Never restart the pivot application
+	#[default]
 	Never,
 	/// Always restart the pivot application
 	Always,
@@ -86,13 +88,6 @@ impl fmt::Debug for RestartPolicy {
 			Self::Always => write!(f, "RestartPolicy::Always")?,
 		}
 		Ok(())
-	}
-}
-
-#[cfg(any(feature = "mock", test))]
-impl Default for RestartPolicy {
-	fn default() -> Self {
-		Self::Never
 	}
 }
 


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

Bump workspace to use rust 1.94 - the latest rust version supported by stagex

The code diff is from running clippy fix with the 1.94 version

Their is also a diff in qos_enclave to get the eif builder happy. I didn't run down the root cause but my guess is due to the stagex/rust-pallet changing what it included when I bumped it

## How I Tested These Changes

CI

## Pre merge check list

- [ ] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
