### PR TITLE
feat: add qos json manifest v2 and protocol msg

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,6 +17,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y pkg-config libpcsclite-dev
       - name: Run tests
         run: make -C src test
+      - name: Run legacy protocol compat tests
+        run: cargo test -p integration --features legacy-protocol-compat --test protocol_legacy_decode
 
   test-vm:
     name: test-vm

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ src/integration/mock/pivot-build-fingerprints.txt
 src/integration/pivot_ok2_works
 src/integration/pivot_ok_works
 src/integration/pivot_ok3_works
+src/integration/pivot_tcp_works
 
 local-enclave/ls
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,6 +1898,7 @@ dependencies = [
  "qos_core",
  "qos_crypto",
  "qos_hex",
+ "qos_json",
  "qos_nsm",
  "qos_p256",
  "qos_test_primitives",
@@ -1921,6 +1922,7 @@ dependencies = [
  "nix 0.30.1",
  "qos_crypto",
  "qos_hex",
+ "qos_json",
  "qos_nsm",
  "qos_p256",
  "qos_test_primitives",
@@ -1975,6 +1977,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "qos_json"
+version = "0.7.0"
+dependencies = [
+ "qos_hex",
+ "serde",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
 name = "qos_net"
 version = "0.7.0"
 dependencies = [
@@ -2013,6 +2025,8 @@ dependencies = [
  "hex-literal",
  "p384",
  "qos_hex",
+ "qos_json",
+ "serde",
  "serde_bytes",
  "sha2",
  "webpki",
@@ -2039,6 +2053,7 @@ dependencies = [
  "p256",
  "qos_hex",
  "qos_test_primitives",
+ "serde",
  "sha2",
  "zeroize",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,13 +1246,14 @@ dependencies = [
  "borsh",
  "futures",
  "nix 0.30.1",
- "qos_core",
- "qos_crypto",
- "qos_hex",
+ "qos_core 0.7.0",
+ "qos_core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "qos_crypto 0.7.0",
+ "qos_hex 0.7.0",
  "qos_host",
  "qos_net",
- "qos_nsm",
- "qos_p256",
+ "qos_nsm 0.7.0",
+ "qos_p256 0.7.0",
  "qos_test_primitives",
  "rand 0.9.2",
  "rustls",
@@ -1876,10 +1877,10 @@ dependencies = [
 name = "qos_bridge"
 version = "0.7.0"
 dependencies = [
- "qos_core",
- "qos_hex",
+ "qos_core 0.7.0",
+ "qos_hex 0.7.0",
  "qos_host",
- "qos_nsm",
+ "qos_nsm 0.7.0",
  "serde",
  "serde_json",
  "tokio",
@@ -1895,12 +1896,12 @@ dependencies = [
  "der",
  "lazy_static",
  "p256",
- "qos_core",
- "qos_crypto",
- "qos_hex",
+ "qos_core 0.7.0",
+ "qos_crypto 0.7.0",
+ "qos_hex 0.7.0",
  "qos_json",
- "qos_nsm",
- "qos_p256",
+ "qos_nsm 0.7.0",
+ "qos_p256 0.7.0",
  "qos_test_primitives",
  "rand_core 0.9.3",
  "rpassword",
@@ -1920,11 +1921,11 @@ dependencies = [
  "futures",
  "libc",
  "nix 0.30.1",
- "qos_crypto",
- "qos_hex",
+ "qos_crypto 0.7.0",
+ "qos_hex 0.7.0",
  "qos_json",
- "qos_nsm",
- "qos_p256",
+ "qos_nsm 0.7.0",
+ "qos_p256 0.7.0",
  "qos_test_primitives",
  "rustls",
  "serde",
@@ -1936,10 +1937,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "qos_core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "017f157e548e79837959754020270d5e42e9d1af089f0f3269a40bae9a39d0c1"
+dependencies = [
+ "aws-nitro-enclaves-nsm-api",
+ "borsh",
+ "futures",
+ "libc",
+ "nix 0.30.1",
+ "qos_crypto 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "qos_hex 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "qos_nsm 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "qos_p256 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "tokio",
+ "tokio-vsock",
+]
+
+[[package]]
 name = "qos_crypto"
 version = "0.7.0"
 dependencies = [
- "qos_hex",
+ "qos_hex 0.7.0",
+ "rand 0.9.2",
+ "sha2",
+ "thiserror 2.0.17",
+ "vsss-rs",
+]
+
+[[package]]
+name = "qos_crypto"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12bdf9f905ae4429bdcd97deb73a00fe6d2a896480a92fa9d92ff93ef1307f3c"
+dependencies = [
  "rand 0.9.2",
  "sha2",
  "thiserror 2.0.17",
@@ -1952,7 +1987,7 @@ version = "0.0.0"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
- "qos_crypto",
+ "qos_crypto 0.7.0",
 ]
 
 [[package]]
@@ -1963,14 +1998,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "qos_hex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7657a5e191e7f3c46876d54648a405e9ff5364124874daf7756372903c64a562"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "qos_host"
 version = "0.7.0"
 dependencies = [
  "axum",
  "borsh",
- "qos_core",
- "qos_hex",
- "qos_nsm",
+ "qos_core 0.7.0",
+ "qos_hex 0.7.0",
+ "qos_nsm 0.7.0",
  "serde",
  "serde_json",
  "tokio",
@@ -1980,7 +2024,7 @@ dependencies = [
 name = "qos_json"
 version = "0.7.0"
 dependencies = [
- "qos_hex",
+ "qos_hex 0.7.0",
  "serde",
  "serde_json",
  "sha2",
@@ -1995,7 +2039,7 @@ dependencies = [
  "futures",
  "hickory-resolver",
  "httparse",
- "qos_core",
+ "qos_core 0.7.0",
  "qos_test_primitives",
  "rand 0.9.2",
  "rustls",
@@ -2024,9 +2068,26 @@ dependencies = [
  "borsh",
  "hex-literal",
  "p384",
- "qos_hex",
+ "qos_hex 0.7.0",
  "qos_json",
  "serde",
+ "serde_bytes",
+ "sha2",
+ "webpki",
+ "x509-cert",
+]
+
+[[package]]
+name = "qos_nsm"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5ad7a2674c158d01ebba18ea1c381fcf4b66a6a196a7583b7b66eecf4c7e78e"
+dependencies = [
+ "aws-nitro-enclaves-cose",
+ "aws-nitro-enclaves-nsm-api",
+ "borsh",
+ "p384",
+ "qos_hex 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes",
  "sha2",
  "webpki",
@@ -2038,8 +2099,8 @@ name = "qos_nsm_fuzz"
 version = "0.0.0"
 dependencies = [
  "libfuzzer-sys",
- "qos_hex",
- "qos_nsm",
+ "qos_hex 0.7.0",
+ "qos_nsm 0.7.0",
 ]
 
 [[package]]
@@ -2051,9 +2112,25 @@ dependencies = [
  "hkdf",
  "hmac",
  "p256",
- "qos_hex",
+ "qos_hex 0.7.0",
  "qos_test_primitives",
  "serde",
+ "sha2",
+ "zeroize",
+]
+
+[[package]]
+name = "qos_p256"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf0ea50dbb89ece72cbc4821f0bb6e80a53575fef32a2f3dc3a99a8b99059844"
+dependencies = [
+ "aes-gcm",
+ "borsh",
+ "hkdf",
+ "hmac",
+ "p256",
+ "qos_hex 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2",
  "zeroize",
 ]
@@ -2064,7 +2141,7 @@ version = "0.0.0"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
- "qos_p256",
+ "qos_p256 0.7.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "src/qos_crypto",
   "src/qos_host",
   "src/qos_hex",
+  "src/qos_json",
   "src/qos_net",
   "src/qos_test_primitives",
   "src/qos_p256",
@@ -25,6 +26,7 @@ default-members = [
   "src/qos_crypto",
   "src/qos_host",
   "src/qos_hex",
+  "src/qos_json",
   "src/qos_net",
   "src/qos_test_primitives",
   "src/qos_p256",
@@ -105,6 +107,7 @@ qos_client = { path = "src/qos_client", version = "0.7.0", default-features = fa
 qos_core = { path = "src/qos_core", version = "0.7.0", default-features = false }
 qos_crypto = { path = "src/qos_crypto", version = "0.7.0", default-features = false }
 qos_hex = { path = "src/qos_hex", version = "0.7.0", default-features = false }
+qos_json = { path = "src/qos_json" }
 qos_net = { path = "src/qos_net", version = "0.7.0", default-features = false }
 qos_nsm = { path = "src/qos_nsm", version = "0.7.0", default-features = false }
 qos_p256 = { path = "src/qos_p256", version = "0.7.0" }

--- a/src/integration/Cargo.toml
+++ b/src/integration/Cargo.toml
@@ -14,6 +14,9 @@ unsafe_code = "deny"
 missing_errors_doc = "allow"
 module_name_repetitions = "allow"
 
+[features]
+legacy-protocol-compat = []
+
 [dependencies]
 qos_core = { workspace = true, features = ["mock"], default-features = false }
 qos_nsm = { workspace = true, features = ["mock"], default-features = false }
@@ -36,3 +39,4 @@ tokio-rustls = { workspace = true }
 [dev-dependencies]
 rand = { workspace = true, features = ["thread_rng"] }
 ureq = { workspace = true, features = ["json"] }
+qos_core_legacy = { package = "qos_core", version = "0.7", default-features = false }

--- a/src/integration/src/lib.rs
+++ b/src/integration/src/lib.rs
@@ -166,13 +166,13 @@ pub async fn wait_for_usock<P: AsRef<Path>>(path: P) {
 	for _ in 0..50 {
 		if std::fs::exists(path).unwrap() && client.try_connect().await.is_ok()
 		{
-			break;
+			return;
 		}
 
 		tokio::time::sleep(Duration::from_millis(100)).await;
 	}
 
-	eprintln!("warning: no usock found at path: {}", path.display())
+	panic!("unable to connect to usock at path: {}", path.display())
 }
 
 pub async fn wait_for_tcp_sock<Addr>(host_addr: &Addr)

--- a/src/integration/tests/host_bridge.rs
+++ b/src/integration/tests/host_bridge.rs
@@ -4,7 +4,7 @@ use std::{
 	time::Duration,
 };
 
-use integration::{wait_for_tcp_sock, PIVOT_TCP_PATH};
+use integration::{PIVOT_TCP_PATH, wait_for_tcp_sock};
 use qos_core::io::{HostBridge, SocketAddress, Stream, StreamPool};
 use qos_test_primitives::{ChildWrapper, find_free_port};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};

--- a/src/integration/tests/host_bridge.rs
+++ b/src/integration/tests/host_bridge.rs
@@ -1,9 +1,10 @@
 use std::{
 	net::{Ipv4Addr, SocketAddrV4},
 	process::Command,
+	time::Duration,
 };
 
-use integration::{wait_for_tcp_sock, wait_for_usock, PIVOT_TCP_PATH};
+use integration::{wait_for_tcp_sock, PIVOT_TCP_PATH};
 use qos_core::io::{HostBridge, SocketAddress, Stream, StreamPool};
 use qos_test_primitives::{find_free_port, ChildWrapper};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -22,29 +23,44 @@ async fn vsock_to_tcp_bridge_works() {
 		.unwrap()
 		.into();
 
-	HostBridge::new(pool, host_addr).vsock_to_tcp();
-	wait_for_usock(APP_USOCK).await;
+	// Wait for pivot to bind before probing the bridge. `wait_for_usock`
+	// opens a connection, and the bridge immediately forwards accepted
+	// streams to the pivot TCP address.
+	wait_for_tcp_sock(&format!("127.0.0.1:{port}")).await;
 
+	HostBridge::new(pool, host_addr).vsock_to_tcp();
+	wait_for_socket_path(APP_USOCK).await;
 	let mut stream = Stream::new(&SocketAddress::new_unix(APP_USOCK));
 	let mut stream2 = Stream::new(&SocketAddress::new_unix(APP_USOCK));
-	// Wait for pivot to bind. This needs to be ready before the streams try
-	// to connect
-	wait_for_tcp_sock(&format!("127.0.0.1:{port}")).await;
 	stream.connect().await.unwrap();
 	stream2.connect().await.unwrap();
 
 	// send b"hello" and expect it back
 	assert_eq!(5, stream.write(b"hello").await.unwrap());
 
+	// Read hello before sending the pivot's exit message. The pivot exits the
+	// process after echoing "done", which can otherwise race with this stream.
+	let mut buf = [0u8; 5];
+	assert_eq!(5, stream.read(&mut buf).await.unwrap());
+
 	// send b"done" and expect it back with pivot exiting
 	assert_eq!(4, stream2.write(b"done").await.unwrap());
 
-	// Read hello
-	let mut buf = [0u8; 5];
-	assert_eq!(5, stream.read(&mut buf).await.unwrap());
 	// Read done
 	let mut buf = [0u8; 4];
 	assert_eq!(4, stream2.read(&mut buf).await.unwrap());
 
 	assert!(pivot.wait().unwrap().success());
+}
+
+async fn wait_for_socket_path(path: &str) {
+	for _ in 0..50 {
+		if std::fs::exists(path).unwrap() {
+			return;
+		}
+
+		tokio::time::sleep(Duration::from_millis(100)).await;
+	}
+
+	panic!("unable to find usock at path: {path}");
 }

--- a/src/integration/tests/protocol_legacy_decode.rs
+++ b/src/integration/tests/protocol_legacy_decode.rs
@@ -1,0 +1,345 @@
+#![cfg(feature = "legacy-protocol-compat")]
+
+use borsh::BorshDeserialize;
+use qos_core::protocol::{
+	msg::ProtocolMsg as CurrentProtocolMsg,
+	services::{
+		boot::{
+			Approval, Manifest, ManifestEnvelope, ManifestSet, Namespace,
+			NitroConfig, PatchSet, PivotConfig, QuorumMember, RestartPolicy,
+			ShareSet,
+		},
+		genesis::{GenesisOutput, GenesisSet},
+	},
+	ProtocolError, ProtocolPhase,
+};
+use qos_core_legacy::protocol::{
+	msg::ProtocolMsg as LegacyProtocolMsg,
+	services::boot::{
+		Manifest as LegacyManifest, ManifestEnvelope as LegacyManifestEnvelope,
+		ManifestEnvelopeV0 as LegacyManifestEnvelopeV0,
+		ManifestV0 as LegacyManifestV0,
+	},
+};
+use qos_nsm::types::NsmResponse;
+
+fn sample_manifest() -> Manifest {
+	Manifest {
+		namespace: Namespace {
+			name: "compat-ns".to_string(),
+			nonce: 7,
+			quorum_key: vec![9; 33],
+		},
+		enclave: NitroConfig {
+			pcr0: vec![0; 48],
+			pcr1: vec![1; 48],
+			pcr2: vec![2; 48],
+			pcr3: vec![3; 48],
+			aws_root_certificate: vec![4; 16],
+			qos_commit: "compat-commit".to_string(),
+		},
+		pivot: PivotConfig {
+			hash: [7; 32],
+			restart: RestartPolicy::Never,
+			args: vec!["--flag".to_string(), "value".to_string()],
+			bridge_config: vec![],
+			debug_mode: false,
+		},
+		manifest_set: ManifestSet { threshold: 1, members: vec![] },
+		share_set: ShareSet { threshold: 1, members: vec![] },
+		patch_set: PatchSet { threshold: 0, members: vec![] },
+	}
+}
+
+fn sample_approval() -> Approval {
+	Approval {
+		signature: vec![1, 2, 3, 4],
+		member: qos_core::protocol::services::boot::QuorumMember {
+			alias: "compat-member".to_string(),
+			pub_key: vec![8; 33],
+		},
+	}
+}
+
+fn sample_manifest_envelope() -> ManifestEnvelope {
+	ManifestEnvelope {
+		manifest: sample_manifest(),
+		manifest_set_approvals: vec![sample_approval()],
+		share_set_approvals: vec![sample_approval()],
+	}
+}
+
+fn sample_manifest_v0() -> qos_core::protocol::services::boot::ManifestV0 {
+	qos_core::protocol::services::boot::ManifestV0 {
+		namespace: Namespace {
+			name: "compat-v0".to_string(),
+			nonce: 11,
+			quorum_key: vec![4; 33],
+		},
+		enclave: NitroConfig {
+			pcr0: vec![0; 48],
+			pcr1: vec![1; 48],
+			pcr2: vec![2; 48],
+			pcr3: vec![3; 48],
+			aws_root_certificate: vec![1; 16],
+			qos_commit: "compat-v0-commit".to_string(),
+		},
+		pivot: qos_core::protocol::services::boot::PivotConfigV0 {
+			hash: [3; 32],
+			restart: RestartPolicy::Always,
+			args: vec!["v0arg".to_string()],
+		},
+		manifest_set: ManifestSet { threshold: 1, members: vec![] },
+		share_set: ShareSet { threshold: 1, members: vec![] },
+		patch_set: PatchSet { threshold: 0, members: vec![] },
+	}
+}
+
+fn sample_manifest_envelope_v0(
+) -> qos_core::protocol::services::boot::ManifestEnvelopeV0 {
+	qos_core::protocol::services::boot::ManifestEnvelopeV0 {
+		manifest: sample_manifest_v0(),
+		manifest_set_approvals: vec![sample_approval()],
+		share_set_approvals: vec![sample_approval()],
+	}
+}
+
+fn sample_genesis_output() -> GenesisOutput {
+	GenesisOutput {
+		quorum_key: vec![3, 2, 1],
+		member_outputs: vec![],
+		recovery_permutations: vec![],
+		threshold: 2,
+		dr_key_wrapped_quorum_key: None,
+		quorum_key_hash: [22; 64],
+		test_message_ciphertext: vec![5; 8],
+		test_message_signature: vec![6; 8],
+		test_message: vec![7; 8],
+	}
+}
+
+fn sample_genesis_set() -> GenesisSet {
+	GenesisSet {
+		threshold: 2,
+		members: vec![
+			QuorumMember { alias: "a".to_string(), pub_key: vec![1; 33] },
+			QuorumMember { alias: "b".to_string(), pub_key: vec![2; 33] },
+		],
+	}
+}
+
+fn decode_legacy(msg: CurrentProtocolMsg) -> LegacyProtocolMsg {
+	let bytes = msg.to_borsh_wire().unwrap();
+	LegacyProtocolMsg::try_from_slice(&bytes).unwrap()
+}
+
+#[test]
+fn legacy_protocol_error_response_decodes() {
+	let decoded = decode_legacy(CurrentProtocolMsg::ProtocolErrorResponse(
+		ProtocolError::InvalidMsg,
+	));
+	assert!(matches!(decoded, LegacyProtocolMsg::ProtocolErrorResponse(_)));
+}
+
+#[test]
+fn legacy_status_variants_decode() {
+	let req = decode_legacy(CurrentProtocolMsg::StatusRequest);
+	assert!(matches!(req, LegacyProtocolMsg::StatusRequest));
+
+	let resp = decode_legacy(CurrentProtocolMsg::StatusResponse(
+		ProtocolPhase::WaitingForBootInstruction,
+	));
+	assert!(matches!(resp, LegacyProtocolMsg::StatusResponse(_)));
+}
+
+#[test]
+fn legacy_boot_standard_variants_decode() {
+	let req = decode_legacy(CurrentProtocolMsg::BootStandardRequest {
+		manifest_envelope: Box::new(sample_manifest_envelope().into()),
+		pivot: vec![1, 2, 3],
+	});
+	assert!(matches!(req, LegacyProtocolMsg::BootStandardRequest { .. }));
+
+	let resp = decode_legacy(CurrentProtocolMsg::BootStandardResponse {
+		nsm_response: NsmResponse::LockPCR,
+	});
+	assert!(matches!(resp, LegacyProtocolMsg::BootStandardResponse { .. }));
+}
+
+#[test]
+fn legacy_boot_genesis_variants_decode() {
+	let req = decode_legacy(CurrentProtocolMsg::BootGenesisRequest {
+		set: sample_genesis_set(),
+		dr_key: Some(vec![5; 33]),
+	});
+	assert!(matches!(req, LegacyProtocolMsg::BootGenesisRequest { .. }));
+
+	let resp = decode_legacy(CurrentProtocolMsg::BootGenesisResponse {
+		nsm_response: NsmResponse::LockPCR,
+		genesis_output: Box::new(sample_genesis_output()),
+	});
+	assert!(matches!(resp, LegacyProtocolMsg::BootGenesisResponse { .. }));
+}
+
+#[test]
+fn legacy_provision_variants_decode() {
+	let req = decode_legacy(CurrentProtocolMsg::ProvisionRequest {
+		share: vec![9; 32],
+		approval: sample_approval(),
+	});
+	assert!(matches!(req, LegacyProtocolMsg::ProvisionRequest { .. }));
+
+	let resp = decode_legacy(CurrentProtocolMsg::ProvisionResponse {
+		reconstructed: true,
+	});
+	assert!(matches!(
+		resp,
+		LegacyProtocolMsg::ProvisionResponse { reconstructed: true }
+	));
+}
+
+#[test]
+fn legacy_proxy_variants_decode() {
+	let req =
+		decode_legacy(CurrentProtocolMsg::ProxyRequest { data: vec![1; 5] });
+	assert!(matches!(req, LegacyProtocolMsg::ProxyRequest { .. }));
+
+	let resp =
+		decode_legacy(CurrentProtocolMsg::ProxyResponse { data: vec![2; 5] });
+	assert!(matches!(resp, LegacyProtocolMsg::ProxyResponse { .. }));
+}
+
+#[test]
+fn legacy_live_attestation_variants_decode() {
+	let req = decode_legacy(CurrentProtocolMsg::LiveAttestationDocRequest);
+	assert!(matches!(req, LegacyProtocolMsg::LiveAttestationDocRequest));
+
+	let resp = decode_legacy(CurrentProtocolMsg::LiveAttestationDocResponse {
+		nsm_response: NsmResponse::LockPCR,
+		manifest_envelope: Some(Box::new(sample_manifest_envelope().into())),
+	});
+	assert!(matches!(
+		resp,
+		LegacyProtocolMsg::LiveAttestationDocResponse { .. }
+	));
+}
+
+#[test]
+fn legacy_boot_key_forward_variants_decode() {
+	let req = decode_legacy(CurrentProtocolMsg::BootKeyForwardRequest {
+		manifest_envelope: Box::new(sample_manifest_envelope().into()),
+		pivot: vec![3, 2, 1],
+	});
+	assert!(matches!(req, LegacyProtocolMsg::BootKeyForwardRequest { .. }));
+
+	let resp = decode_legacy(CurrentProtocolMsg::BootKeyForwardResponse {
+		nsm_response: NsmResponse::LockPCR,
+	});
+	assert!(matches!(resp, LegacyProtocolMsg::BootKeyForwardResponse { .. }));
+}
+
+#[test]
+fn legacy_export_key_variants_decode() {
+	let req = decode_legacy(CurrentProtocolMsg::ExportKeyRequest {
+		manifest_envelope: Box::new(sample_manifest_envelope().into()),
+		cose_sign1_attestation_doc: vec![7; 24],
+	});
+	assert!(matches!(req, LegacyProtocolMsg::ExportKeyRequest { .. }));
+
+	let resp = decode_legacy(CurrentProtocolMsg::ExportKeyResponse {
+		encrypted_quorum_key: vec![8; 33],
+		signature: vec![9; 64],
+	});
+	assert!(matches!(resp, LegacyProtocolMsg::ExportKeyResponse { .. }));
+}
+
+#[test]
+fn legacy_inject_key_variants_decode() {
+	let req = decode_legacy(CurrentProtocolMsg::InjectKeyRequest {
+		encrypted_quorum_key: vec![4; 33],
+		signature: vec![5; 64],
+	});
+	assert!(matches!(req, LegacyProtocolMsg::InjectKeyRequest { .. }));
+
+	let resp = decode_legacy(CurrentProtocolMsg::InjectKeyResponse);
+	assert!(matches!(resp, LegacyProtocolMsg::InjectKeyResponse));
+}
+
+#[test]
+fn legacy_manifest_envelope_variants_decode() {
+	let req = decode_legacy(CurrentProtocolMsg::ManifestEnvelopeRequest);
+	assert!(matches!(req, LegacyProtocolMsg::ManifestEnvelopeRequest));
+
+	let resp = decode_legacy(CurrentProtocolMsg::ManifestEnvelopeResponse {
+		manifest_envelope: Box::new(Some(sample_manifest_envelope().into())),
+	});
+	assert!(matches!(resp, LegacyProtocolMsg::ManifestEnvelopeResponse { .. }));
+}
+
+#[test]
+fn legacy_0_7_cannot_decode_post_0_7_protocol_variants() {
+	let version_req =
+		CurrentProtocolMsg::VersionRequest.to_borsh_wire().unwrap();
+	assert!(LegacyProtocolMsg::try_from_slice(&version_req).is_err());
+
+	let version_resp = CurrentProtocolMsg::VersionResponse {
+		version: "0.7.0".to_string(),
+		commit: "abcdef1".to_string(),
+	}
+	.to_borsh_wire()
+	.unwrap();
+	assert!(LegacyProtocolMsg::try_from_slice(&version_resp).is_err());
+
+	let boot_json_envelope =
+		CurrentProtocolMsg::BootStandardJsonEnvelopeRequest {
+			manifest_envelope: Box::new(
+				qos_core::protocol::msg::JsonBytes::new(
+					sample_manifest_envelope().into(),
+				),
+			),
+			pivot: vec![1, 2, 3],
+		}
+		.to_borsh_wire()
+		.unwrap();
+	assert!(LegacyProtocolMsg::try_from_slice(&boot_json_envelope).is_err());
+}
+
+#[test]
+fn legacy_manifest_decodes_current_manifest_v1_borsh() {
+	let manifest = sample_manifest();
+	let bytes = borsh::to_vec(&manifest).unwrap();
+	let decoded = LegacyManifest::try_from_slice(&bytes).unwrap();
+	assert_eq!(decoded.namespace.name, "compat-ns");
+	assert_eq!(decoded.namespace.nonce, 7);
+	assert_eq!(decoded.pivot.args, vec!["--flag", "value"]);
+}
+
+#[test]
+fn legacy_manifest_envelope_decodes_current_envelope_v1_borsh() {
+	let envelope = sample_manifest_envelope();
+	let bytes = borsh::to_vec(&envelope).unwrap();
+	let decoded = LegacyManifestEnvelope::try_from_slice(&bytes).unwrap();
+	assert_eq!(decoded.manifest.namespace.name, "compat-ns");
+	assert_eq!(decoded.manifest_set_approvals.len(), 1);
+	assert_eq!(decoded.share_set_approvals.len(), 1);
+}
+
+#[test]
+fn legacy_manifest_v0_decodes_current_manifest_v0_borsh() {
+	let manifest_v0 = sample_manifest_v0();
+	let bytes = borsh::to_vec(&manifest_v0).unwrap();
+	let decoded = LegacyManifestV0::try_from_slice(&bytes).unwrap();
+	assert_eq!(decoded.namespace.name, "compat-v0");
+	assert_eq!(decoded.namespace.nonce, 11);
+	assert_eq!(decoded.pivot.args, vec!["v0arg"]);
+}
+
+#[test]
+fn legacy_manifest_envelope_v0_decodes_current_envelope_v0_borsh() {
+	let envelope_v0 = sample_manifest_envelope_v0();
+	let bytes = borsh::to_vec(&envelope_v0).unwrap();
+	let decoded = LegacyManifestEnvelopeV0::try_from_slice(&bytes).unwrap();
+	assert_eq!(decoded.manifest.namespace.name, "compat-v0");
+	assert_eq!(decoded.manifest_set_approvals.len(), 1);
+	assert_eq!(decoded.share_set_approvals.len(), 1);
+}

--- a/src/integration/tests/protocol_legacy_decode.rs
+++ b/src/integration/tests/protocol_legacy_decode.rs
@@ -2,6 +2,7 @@
 
 use borsh::BorshDeserialize;
 use qos_core::protocol::{
+	ProtocolError, ProtocolPhase,
 	msg::ProtocolMsg as CurrentProtocolMsg,
 	services::{
 		boot::{
@@ -11,7 +12,6 @@ use qos_core::protocol::{
 		},
 		genesis::{GenesisOutput, GenesisSet},
 	},
-	ProtocolError, ProtocolPhase,
 };
 use qos_core_legacy::protocol::{
 	msg::ProtocolMsg as LegacyProtocolMsg,
@@ -95,8 +95,8 @@ fn sample_manifest_v0() -> qos_core::protocol::services::boot::ManifestV0 {
 	}
 }
 
-fn sample_manifest_envelope_v0(
-) -> qos_core::protocol::services::boot::ManifestEnvelopeV0 {
+fn sample_manifest_envelope_v0()
+-> qos_core::protocol::services::boot::ManifestEnvelopeV0 {
 	qos_core::protocol::services::boot::ManifestEnvelopeV0 {
 		manifest: sample_manifest_v0(),
 		manifest_set_approvals: vec![sample_approval()],

--- a/src/integration/tests/reaper.rs
+++ b/src/integration/tests/reaper.rs
@@ -207,7 +207,7 @@ async fn reaper_handles_non_zero_exits() {
 
 	// Make sure we have written everything necessary to pivot, except the
 	// quorum key
-	handles.put_manifest_envelope(&Default::default()).unwrap();
+	handles.put_manifest_envelope(ManifestEnvelope::default()).unwrap();
 	assert!(handles.pivot_exists());
 
 	let enclave_socket = SocketAddress::new_unix(&usock);
@@ -254,7 +254,7 @@ async fn reaper_handles_panic() {
 
 	// Make sure we have written everything necessary to pivot, except the
 	// quorum key
-	handles.put_manifest_envelope(&Default::default()).unwrap();
+	handles.put_manifest_envelope(ManifestEnvelope::default()).unwrap();
 	assert!(handles.pivot_exists());
 
 	let enclave_socket = SocketAddress::new_unix(&usock);

--- a/src/integration/tests/version.rs
+++ b/src/integration/tests/version.rs
@@ -4,8 +4,8 @@ use qos_core::{
 	handles::Handles,
 	io::SocketAddress,
 	protocol::{
-		msg::{ProtocolMsg, ProtocolMsgEncoding},
 		ProtocolPhase,
+		msg::{ProtocolMsg, ProtocolMsgEncoding},
 	},
 	reaper::Reaper,
 };

--- a/src/integration/tests/version.rs
+++ b/src/integration/tests/version.rs
@@ -1,7 +1,12 @@
 use borsh::BorshDeserialize;
 use integration::{wait_for_tcp_sock, wait_for_usock, PIVOT_OK_PATH};
 use qos_core::{
-	handles::Handles, io::SocketAddress, protocol::msg::ProtocolMsg,
+	handles::Handles,
+	io::SocketAddress,
+	protocol::{
+		msg::{ProtocolMsg, ProtocolMsgEncoding},
+		ProtocolPhase,
+	},
 	reaper::Reaper,
 };
 use qos_host::host::HostServer;
@@ -16,6 +21,47 @@ use tokio::{
 	fs::{create_dir_all, remove_dir_all},
 	join, select,
 };
+
+#[derive(Clone, Copy)]
+enum TestEncoding {
+	Json,
+	Borsh,
+}
+
+fn encode_msg(msg: &ProtocolMsg, encoding: TestEncoding) -> Vec<u8> {
+	match encoding {
+		TestEncoding::Json => msg.to_json_wire().unwrap(),
+		TestEncoding::Borsh => msg.to_borsh_wire().unwrap(),
+	}
+}
+
+fn decode_msg(bytes: &[u8], encoding: TestEncoding) -> ProtocolMsg {
+	match encoding {
+		TestEncoding::Json => {
+			let (msg, detected) = ProtocolMsg::from_wire(bytes).unwrap();
+			assert_eq!(detected, ProtocolMsgEncoding::Json);
+			msg
+		}
+		TestEncoding::Borsh => ProtocolMsg::try_from_slice(bytes).unwrap(),
+	}
+}
+
+fn assert_version_response(msg: ProtocolMsg) {
+	match msg {
+		ProtocolMsg::VersionResponse { version, commit } => {
+			assert_eq!(version, env!("CARGO_PKG_VERSION"));
+			assert!(!commit.is_empty(), "commit should not be empty");
+		}
+		other => panic!("unexpected response: {other:?}"),
+	}
+}
+
+fn assert_status_response(msg: ProtocolMsg) {
+	assert_eq!(
+		msg,
+		ProtocolMsg::StatusResponse(ProtocolPhase::WaitingForBootInstruction)
+	);
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn version_request_returns_version_and_commit() -> Result<(), io::Error> {
@@ -92,19 +138,26 @@ async fn version_request_returns_version_and_commit() -> Result<(), io::Error> {
 	}
 
 	let url = format!("http://127.0.0.1:{HOST_PORT}/qos/message");
-	let req_bytes = borsh::to_vec(&ProtocolMsg::VersionRequest).unwrap();
-	let response = ureq::post(&url).send_bytes(&req_bytes).unwrap();
+	for encoding in [TestEncoding::Json, TestEncoding::Borsh] {
+		let req_bytes = encode_msg(&ProtocolMsg::VersionRequest, encoding);
+		let response = ureq::post(&url).send_bytes(&req_bytes).unwrap();
 
-	let mut buf = Vec::new();
-	response.into_reader().read_to_end(&mut buf).unwrap();
-	let decoded = ProtocolMsg::try_from_slice(&buf).unwrap();
+		let mut buf = Vec::new();
+		response.into_reader().read_to_end(&mut buf).unwrap();
+		let decoded = decode_msg(&buf, encoding);
 
-	match decoded {
-		ProtocolMsg::VersionResponse { version, commit } => {
-			assert_eq!(version, env!("CARGO_PKG_VERSION"));
-			assert!(!commit.is_empty(), "commit should not be empty");
-		}
-		other => panic!("unexpected response: {other:?}"),
+		assert_version_response(decoded);
+	}
+
+	for encoding in [TestEncoding::Json, TestEncoding::Borsh] {
+		let req_bytes = encode_msg(&ProtocolMsg::StatusRequest, encoding);
+		let response = ureq::post(&url).send_bytes(&req_bytes).unwrap();
+
+		let mut buf = Vec::new();
+		response.into_reader().read_to_end(&mut buf).unwrap();
+		let decoded = decode_msg(&buf, encoding);
+
+		assert_status_response(decoded);
 	}
 
 	qos_host_task.abort();

--- a/src/qos_bridge/src/host.rs
+++ b/src/qos_bridge/src/host.rs
@@ -43,8 +43,8 @@ impl BridgeServer {
 						.expect("unable to parse enclave info response")
 						.manifest_envelope
 					{
-						break self
-							.run_bridges(&me.manifest.pivot.bridge_config);
+						let manifest = me.manifest();
+						break self.run_bridges(manifest.bridge_config());
 					}
 				}
 				Err(err) => eprintln!("unable to query enclave: {err}"),
@@ -60,7 +60,7 @@ impl BridgeServer {
 		self.host_port_override.unwrap_or(port)
 	}
 
-	fn run_bridges(&self, configs: &Vec<BridgeConfig>) {
+	fn run_bridges(&self, configs: &[BridgeConfig]) {
 		for config in configs {
 			let (host_port, host_ip_str) = match config {
 				BridgeConfig::Client { port: _, host: _ } => {

--- a/src/qos_client/Cargo.toml
+++ b/src/qos_client/Cargo.toml
@@ -18,6 +18,7 @@ qos_crypto = { workspace = true, default-features = false }
 qos_hex = { workspace = true }
 qos_p256 = { workspace = true }
 qos_nsm = { workspace = true, default-features = false }
+qos_json = { workspace = true }
 
 # Third party
 ureq = { workspace = true }

--- a/src/qos_client/src/cli/mod.rs
+++ b/src/qos_client/src/cli/mod.rs
@@ -1958,4 +1958,16 @@ mod tests {
 		assert_eq!(opts.use_manifest_version(), 2);
 		assert_eq!(opts.patch_set_dir().as_deref(), Some("/tmp/patch-set"));
 	}
+
+	#[test]
+	fn generate_manifest_parses_manifest_version_1_explicitly() {
+		let mut args = generate_manifest_args();
+		args.extend(["--use-manifest-version".to_string(), "1".to_string()]);
+		let (cmd, parsed) = CommandParser::<Command>::parse(&mut args).unwrap();
+
+		assert_eq!(cmd, Command::GenerateManifest);
+		let opts = ClientOpts { parsed };
+		assert_eq!(opts.use_manifest_version(), 1);
+		assert_eq!(opts.patch_set_dir(), None);
+	}
 }

--- a/src/qos_client/src/cli/mod.rs
+++ b/src/qos_client/src/cli/mod.rs
@@ -76,6 +76,7 @@ const PLAINTEXT_PATH: &str = "plaintext-path";
 const OUTPUT_HEX: &str = "output-hex";
 const VALIDATION_TIME_OVERRIDE: &str = "validation-time-override";
 const JSON: &str = "json";
+const USE_MANIFEST_VERSION: &str = "use-manifest-version";
 
 pub(crate) enum DisplayType {
 	Manifest,
@@ -361,13 +362,19 @@ impl Command {
 		.takes_value(true)
 		.required(true)
 	}
-	fn patch_set_dir_token() -> Token {
+	fn patch_set_dir_optional_token() -> Token {
 		Token::new(
 			PATCH_SET_DIR,
 			"Director with public keys for members of the patch set.",
 		)
 		.takes_value(true)
-		.required(true)
+	}
+	fn use_manifest_version_token() -> Token {
+		Token::new(
+			USE_MANIFEST_VERSION,
+			"Manifest version for generate-manifest. Defaults to 1.",
+		)
+		.takes_value(true)
 	}
 	fn namespace_dir_token() -> Token {
 		Token::new(
@@ -680,11 +687,12 @@ impl Command {
 			.token(Self::manifest_path_token())
 			.token(Self::manifest_set_dir_token())
 			.token(Self::share_set_dir_token())
-			.token(Self::patch_set_dir_token())
+			.token(Self::patch_set_dir_optional_token())
 			.token(Self::quorum_key_path_token())
 			.token(Self::pivot_args_token())
 			.token(Self::bridge_config_token())
 			.token(Self::debug_mode_token())
+			.token(Self::use_manifest_version_token())
 	}
 
 	fn approve_manifest() -> Parser {
@@ -700,7 +708,7 @@ impl Command {
 			.token(Self::quorum_key_path_token())
 			.token(Self::manifest_set_dir_token())
 			.token(Self::share_set_dir_token())
-			.token(Self::patch_set_dir_token())
+			.token(Self::patch_set_dir_optional_token())
 			.token(Self::unsafe_auto_confirm_token())
 	}
 
@@ -978,11 +986,16 @@ impl ClientOpts {
 			.to_string()
 	}
 
-	fn patch_set_dir(&self) -> String {
+	fn patch_set_dir(&self) -> Option<String> {
+		self.parsed.single(PATCH_SET_DIR).map(ToString::to_string)
+	}
+
+	fn use_manifest_version(&self) -> u32 {
 		self.parsed
-			.single(PATCH_SET_DIR)
-			.expect("`--patch-set-dir` is a required arg")
-			.to_string()
+			.single(USE_MANIFEST_VERSION)
+			.map_or("1", String::as_str)
+			.parse::<u32>()
+			.expect("Could not parse `--use-manifest-version` as u32")
 	}
 
 	fn namespace_dir(&self) -> String {
@@ -1608,7 +1621,7 @@ mod handlers {
 	}
 
 	pub(super) fn generate_manifest(opts: &ClientOpts) {
-		if let Err(e) = services::generate_manifest(GenerateManifestArgs {
+		let args = GenerateManifestArgs {
 			nonce: opts.nonce(),
 			namespace: opts.namespace(),
 			restart_policy: opts.restart_policy(),
@@ -1623,7 +1636,18 @@ mod handlers {
 			quorum_key_path: opts.quorum_key_path(),
 			bridge_config: opts.bridge_config(),
 			debug_mode: opts.debug_mode(),
-		}) {
+		};
+		let result = match opts.use_manifest_version() {
+			1 => services::generate_manifest(args),
+			2 => services::generate_manifest_v2(args),
+			version => {
+				eprintln!(
+					"Error: unsupported manifest version {version}; expected 1 or 2"
+				);
+				std::process::exit(1);
+			}
+		};
+		if let Err(e) = result {
 			println!("Error: {e:?}");
 			std::process::exit(1);
 		}
@@ -1869,5 +1893,69 @@ mod handlers {
 			eprintln!("Error: {e:?}");
 			std::process::exit(1);
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use qos_core::parser::CommandParser;
+
+	use super::{ClientOpts, Command};
+
+	fn generate_manifest_args() -> Vec<String> {
+		vec![
+			"qos_client".to_string(),
+			"generate-manifest".to_string(),
+			"--nonce".to_string(),
+			"1".to_string(),
+			"--namespace".to_string(),
+			"ns".to_string(),
+			"--pivot-hash-path".to_string(),
+			"/tmp/pivot-hash".to_string(),
+			"--restart-policy".to_string(),
+			"never".to_string(),
+			"--qos-release-dir".to_string(),
+			"/tmp/qos-release".to_string(),
+			"--pcr3-preimage-path".to_string(),
+			"/tmp/pcr3".to_string(),
+			"--manifest-path".to_string(),
+			"/tmp/manifest".to_string(),
+			"--manifest-set-dir".to_string(),
+			"/tmp/manifest-set".to_string(),
+			"--share-set-dir".to_string(),
+			"/tmp/share-set".to_string(),
+			"--quorum-key-path".to_string(),
+			"/tmp/quorum-key".to_string(),
+			"--pivot-args".to_string(),
+			"[]".to_string(),
+		]
+	}
+
+	#[test]
+	fn generate_manifest_defaults_to_manifest_version_1() {
+		let mut args = generate_manifest_args();
+		let (cmd, parsed) = CommandParser::<Command>::parse(&mut args).unwrap();
+
+		assert_eq!(cmd, Command::GenerateManifest);
+		let opts = ClientOpts { parsed };
+		assert_eq!(opts.use_manifest_version(), 1);
+		assert_eq!(opts.patch_set_dir(), None);
+	}
+
+	#[test]
+	fn generate_manifest_parses_manifest_version_2() {
+		let mut args = generate_manifest_args();
+		args.extend([
+			"--use-manifest-version".to_string(),
+			"2".to_string(),
+			"--patch-set-dir".to_string(),
+			"/tmp/patch-set".to_string(),
+		]);
+		let (cmd, parsed) = CommandParser::<Command>::parse(&mut args).unwrap();
+
+		assert_eq!(cmd, Command::GenerateManifest);
+		let opts = ClientOpts { parsed };
+		assert_eq!(opts.use_manifest_version(), 2);
+		assert_eq!(opts.patch_set_dir().as_deref(), Some("/tmp/patch-set"));
 	}
 }

--- a/src/qos_client/src/cli/services.rs
+++ b/src/qos_client/src/cli/services.rs
@@ -8,7 +8,7 @@ use std::{
 use aws_nitro_enclaves_nsm_api::api::AttestationDoc;
 use borsh::BorshDeserialize;
 use qos_core::protocol::{
-	msg::ProtocolMsg,
+	msg::{JsonBytes, ProtocolMsg},
 	services::{
 		boot::{
 			Approval, BridgeConfig, Manifest as ManifestV1,
@@ -1279,6 +1279,35 @@ pub(crate) struct BootStandardArgs<P: AsRef<Path>> {
 	pub unsafe_skip_attestation: bool,
 }
 
+fn boot_standard_attestation_doc_with_fallback(
+	uri: &str,
+	manifest_envelope: VersionedManifestEnvelope,
+	pivot: Vec<u8>,
+) -> Result<Vec<u8>, Error> {
+	let req = ProtocolMsg::BootStandardJsonEnvelopeRequest {
+		manifest_envelope: Box::new(JsonBytes::new(manifest_envelope.clone())),
+		pivot: pivot.clone(),
+	};
+	if let Ok(ProtocolMsg::BootStandardResponse {
+		nsm_response: NsmResponse::Attestation { document },
+	}) = request::post_borsh(uri, &req)
+	{
+		return Ok(document);
+	}
+
+	let req = ProtocolMsg::BootStandardRequest {
+		manifest_envelope: Box::new(manifest_envelope),
+		pivot,
+	};
+	match request::post_borsh(uri, &req) {
+		Ok(ProtocolMsg::BootStandardResponse {
+			nsm_response: NsmResponse::Attestation { document },
+		}) => Ok(document),
+		Ok(r) => Err(Error::UnexpectedProtocolMsgResponse(format!("{r:?}"))),
+		Err(err) => Err(Error::UnexpectedProtocolMsgResponse(err)),
+	}
+}
+
 pub(crate) fn boot_standard<P: AsRef<Path>>(
 	BootStandardArgs {
 		uri,
@@ -1297,18 +1326,13 @@ pub(crate) fn boot_standard<P: AsRef<Path>>(
 		read_manifest_envelope_compat(manifest_envelope_path)?;
 	let manifest = manifest_envelope.clone().manifest();
 
-	let req = ProtocolMsg::BootStandardRequest {
-		manifest_envelope: Box::new(manifest_envelope),
-		pivot,
-	};
 	// Broadcast boot standard instruction and extract the attestation doc from
 	// the response.
-	let cose_sign1 = match request::post(&uri, &req).unwrap() {
-		ProtocolMsg::BootStandardResponse {
-			nsm_response: NsmResponse::Attestation { document },
-		} => document,
-		r => panic!("Unexpected response: {r:?}"),
-	};
+	let cose_sign1 = boot_standard_attestation_doc_with_fallback(
+		&uri,
+		manifest_envelope,
+		pivot,
+	)?;
 
 	let attestation_doc =
 		extract_attestation_doc(&cose_sign1, unsafe_skip_attestation, None);
@@ -1891,16 +1915,13 @@ pub(crate) fn dangerous_dev_boot<P: AsRef<Path>>(
 		}))
 	};
 
-	let req = ProtocolMsg::BootStandardRequest {
-		manifest_envelope: manifest_envelope.clone(),
+	let document = boot_standard_attestation_doc_with_fallback(
+		uri,
+		manifest_envelope.as_ref().clone(),
 		pivot,
-	};
-	let attestation_doc = match request::post(uri, &req).unwrap() {
-		ProtocolMsg::BootStandardResponse {
-			nsm_response: NsmResponse::Attestation { document },
-		} => extract_attestation_doc(&document, true, None),
-		r => panic!("Unexpected response: {r:?}"),
-	};
+	)
+	.unwrap();
+	let attestation_doc = extract_attestation_doc(&document, true, None);
 
 	// Pull out the ephemeral key or use the override
 	let eph_pub: P256Public = if let Some(eph_path) = unsafe_eph_path_override {

--- a/src/qos_client/src/cli/services.rs
+++ b/src/qos_client/src/cli/services.rs
@@ -1285,8 +1285,8 @@ fn boot_standard_attestation_doc_with_fallback(
 	pivot: Vec<u8>,
 ) -> Result<Vec<u8>, Error> {
 	let req = ProtocolMsg::BootStandardJsonEnvelopeRequest {
-		manifest_envelope: Box::new(JsonBytes::new(manifest_envelope.clone())),
-		pivot: pivot.clone(),
+		manifest_envelope: Box::new(JsonBytes::new(manifest_envelope)),
+		pivot,
 	};
 	if let Ok(ProtocolMsg::BootStandardResponse {
 		nsm_response: NsmResponse::Attestation { document },
@@ -1295,8 +1295,17 @@ fn boot_standard_attestation_doc_with_fallback(
 		return Ok(document);
 	}
 
+	let ProtocolMsg::BootStandardJsonEnvelopeRequest {
+		manifest_envelope,
+		pivot,
+	} = req
+	else {
+		unreachable!(
+			"request was constructed as BootStandardJsonEnvelopeRequest"
+		)
+	};
 	let req = ProtocolMsg::BootStandardRequest {
-		manifest_envelope: Box::new(manifest_envelope),
+		manifest_envelope: Box::new(manifest_envelope.into_inner()),
 		pivot,
 	};
 	match request::post_borsh(uri, &req) {
@@ -2594,6 +2603,11 @@ mod tests {
 		}
 	}
 
+	/// Return the v1 manifest for tests that intentionally build v1 fixtures.
+	///
+	/// # Panics
+	///
+	/// Panics if the fixture is not a v1 manifest.
 	fn v1_manifest(manifest: &VersionedManifest) -> &Manifest {
 		match manifest {
 			VersionedManifest::V1(manifest) => manifest,
@@ -2601,6 +2615,11 @@ mod tests {
 		}
 	}
 
+	/// Return the v1 manifest envelope for tests that intentionally build v1 fixtures.
+	///
+	/// # Panics
+	///
+	/// Panics if the fixture is not a v1 manifest envelope.
 	fn v1_manifest_envelope(
 		envelope: &VersionedManifestEnvelope,
 	) -> &ManifestEnvelope {
@@ -2610,6 +2629,12 @@ mod tests {
 		}
 	}
 
+	/// Return a mutable v1 manifest envelope for tests that intentionally build
+	/// v1 fixtures.
+	///
+	/// # Panics
+	///
+	/// Panics if the fixture is not a v1 manifest envelope.
 	fn v1_manifest_envelope_mut(
 		envelope: &mut VersionedManifestEnvelope,
 	) -> &mut ManifestEnvelope {

--- a/src/qos_client/src/cli/services.rs
+++ b/src/qos_client/src/cli/services.rs
@@ -11,9 +11,13 @@ use qos_core::protocol::{
 	msg::ProtocolMsg,
 	services::{
 		boot::{
-			Approval, BridgeConfig, Manifest, ManifestEnvelope, ManifestSet,
-			MemberPubKey, Namespace, NitroConfig, PatchSet, PivotConfig,
-			QuorumMember, RestartPolicy, ShareSet,
+			Approval, BridgeConfig, Manifest as ManifestV1,
+			ManifestEnvelope as ManifestEnvelopeV1, ManifestEnvelopeV0,
+			ManifestEnvelopeV2, ManifestSet, ManifestV2, ManifestVersion,
+			MemberPubKey, Namespace, NitroConfig, PatchSet,
+			PivotConfig as PivotConfigV1, PivotConfigV2, PivotEnv,
+			QuorumMember, RestartPolicy, ShareSet, VersionedManifest,
+			VersionedManifestEnvelope,
 		},
 		genesis::{GenesisOutput, GenesisSet},
 		key::EncryptedQuorumKey,
@@ -55,6 +59,10 @@ pub(crate) const SMARTCARD_FEAT_DISABLED_MSG: &str =
 
 const ENTER_PIN_PROMPT: &str = "Enter your pin: ";
 const TAP_MSG: &str = "Tap your YubiKey";
+
+type Manifest = ManifestV1;
+type ManifestEnvelope = ManifestEnvelopeV1;
+type PivotConfig = PivotConfigV1;
 
 /// Client errors.
 #[derive(Debug)]
@@ -143,6 +151,12 @@ pub enum Error {
 	/// Given quorum key seed does not match the hash of the expected quorum
 	/// key seed.
 	SecretDoesNotMatch,
+	/// v2 manifests cannot be represented in borsh.
+	ManifestV2NotConvertibleToBorsh,
+	/// v2 manifests do not support patch sets.
+	ManifestV2DoesNotSupportPatchSet,
+	/// v1/v0 manifests require patch sets.
+	ManifestV1RequiresPatchSet,
 }
 
 impl From<serde_json::Error> for Error {
@@ -750,7 +764,7 @@ pub(crate) struct GenerateManifestArgs<P: AsRef<Path>> {
 	pub pcr3_preimage_path: P,
 	pub share_set_dir: P,
 	pub manifest_set_dir: P,
-	pub patch_set_dir: P,
+	pub patch_set_dir: Option<P>,
 	pub quorum_key_path: P,
 	pub manifest_path: P,
 	pub pivot_args: Vec<String>,
@@ -786,18 +800,21 @@ pub(crate) fn generate_manifest<P: AsRef<Path>>(
 	let manifest_set = get_manifest_set(manifest_set_dir);
 	// Get share set keys & threshold
 	let share_set = get_share_set(share_set_dir);
+	let Some(patch_set_dir) = patch_set_dir else {
+		return Err(Error::ManifestV1RequiresPatchSet);
+	};
 	let patch_set = get_patch_set(patch_set_dir);
 	// Get quorum key from namespaces dir
 	let quorum_key = P256Public::from_hex_file(&quorum_key_path)
 		.map_err(Error::FailedToReadQuorumPublicKey)?;
 
-	let manifest = Manifest {
+	let manifest = ManifestV1 {
 		namespace: Namespace {
 			name: namespace,
 			nonce,
 			quorum_key: quorum_key.to_bytes(),
 		},
-		pivot: PivotConfig {
+		pivot: PivotConfigV1 {
 			hash: pivot_hash.try_into().expect("pivot hash was not 256 bits"),
 			restart: restart_policy,
 			args: pivot_args,
@@ -810,9 +827,71 @@ pub(crate) fn generate_manifest<P: AsRef<Path>>(
 		enclave: nitro_config,
 	};
 
+	let manifest = VersionedManifest::V1(manifest);
 	write_with_msg(
 		manifest_path.as_ref(),
-		&serde_json::to_vec(&manifest).expect("failed to serialize manifest"),
+		&manifest.to_storage_vec().expect("failed to serialize manifest"),
+		"Manifest",
+	);
+
+	Ok(())
+}
+
+pub(crate) fn generate_manifest_v2<P: AsRef<Path>>(
+	args: GenerateManifestArgs<P>,
+) -> Result<(), Error> {
+	let GenerateManifestArgs {
+		nonce,
+		namespace,
+		pivot_hash_path,
+		restart_policy,
+		qos_release_dir_path,
+		pcr3_preimage_path,
+		manifest_set_dir,
+		share_set_dir,
+		patch_set_dir,
+		quorum_key_path,
+		manifest_path,
+		pivot_args,
+		bridge_config,
+		debug_mode,
+	} = args;
+
+	if patch_set_dir.is_some() {
+		return Err(Error::ManifestV2DoesNotSupportPatchSet);
+	}
+
+	let nitro_config =
+		extract_nitro_config(qos_release_dir_path, pcr3_preimage_path);
+	let pivot_hash = extract_pivot_hash(pivot_hash_path);
+	let manifest_set = get_manifest_set(manifest_set_dir);
+	let share_set = get_share_set(share_set_dir);
+	let quorum_key = P256Public::from_hex_file(&quorum_key_path)
+		.map_err(Error::FailedToReadQuorumPublicKey)?;
+
+	let manifest = ManifestV2 {
+		version: ManifestVersion::V2,
+		namespace: Namespace {
+			name: namespace,
+			nonce,
+			quorum_key: quorum_key.to_bytes(),
+		},
+		pivot: PivotConfigV2 {
+			hash: pivot_hash.try_into().expect("pivot hash was not 256 bits"),
+			restart: restart_policy,
+			args: pivot_args,
+			env: PivotEnv::default(),
+			bridge_config,
+			debug_mode,
+		},
+		manifest_set,
+		share_set,
+		enclave: nitro_config,
+	};
+
+	write_with_msg(
+		manifest_path.as_ref(),
+		&qos_json::to_vec(&manifest).expect("failed to serialize manifest"),
 		"Manifest",
 	);
 
@@ -846,7 +925,7 @@ pub(crate) struct ApproveManifestArgs<P: AsRef<Path>> {
 	pub quorum_key_path: P,
 	pub manifest_set_dir: P,
 	pub share_set_dir: P,
-	pub patch_set_dir: P,
+	pub patch_set_dir: Option<P>,
 	pub alias: String,
 	pub unsafe_auto_confirm: bool,
 }
@@ -869,15 +948,23 @@ pub(crate) fn approve_manifest<P: AsRef<Path>>(
 		unsafe_auto_confirm,
 	} = args;
 
-	let manifest = read_manifest(&manifest_path)?;
+	let manifest = read_manifest_compat(&manifest_path)?;
 	let quorum_key = P256Public::from_hex_file(&quorum_key_path)
 		.map_err(Error::FailedToReadQuorumPublicKey)?;
+	let patch_set = match (&manifest, patch_set_dir) {
+		(VersionedManifest::V2(_), Some(_)) => {
+			return Err(Error::ManifestV2DoesNotSupportPatchSet);
+		}
+		(VersionedManifest::V2(_), None) => None,
+		(_, Some(patch_set_dir)) => Some(get_patch_set(patch_set_dir)),
+		(_, None) => return Err(Error::ManifestV1RequiresPatchSet),
+	};
 
 	if !approve_manifest_programmatic_verifications(
 		&manifest,
 		&get_manifest_set(manifest_set_dir),
 		&get_share_set(share_set_dir),
-		&get_patch_set(patch_set_dir),
+		patch_set.as_ref(),
 		&extract_nitro_config(qos_release_dir_path, pcr3_preimage_path),
 		&extract_pivot_hash(pivot_hash_path),
 		&quorum_key,
@@ -899,7 +986,7 @@ pub(crate) fn approve_manifest<P: AsRef<Path>>(
 	}
 
 	let approval = Approval {
-		signature: pair.sign(&manifest.qos_hash())?,
+		signature: pair.sign(&manifest.manifest_hash())?,
 		member: QuorumMember {
 			pub_key: pair.public_key_bytes()?,
 			alias: alias.clone(),
@@ -909,8 +996,8 @@ pub(crate) fn approve_manifest<P: AsRef<Path>>(
 	let approval_path = manifest_approvals_dir.as_ref().join(format!(
 		"{}-{}-{}.{}",
 		alias,
-		manifest.namespace.name.replace('/', "-"),
-		manifest.namespace.nonce,
+		manifest.namespace().name.replace('/', "-"),
+		manifest.namespace().nonce,
 		APPROVAL_EXT
 	));
 	write_with_msg(
@@ -925,46 +1012,57 @@ pub(crate) fn approve_manifest<P: AsRef<Path>>(
 }
 
 fn approve_manifest_programmatic_verifications(
-	manifest: &Manifest,
+	manifest: &VersionedManifest,
 	manifest_set: &ManifestSet,
 	share_set: &ShareSet,
-	patch_set: &PatchSet,
+	patch_set: Option<&PatchSet>,
 	nitro_config: &NitroConfig,
 	pivot_hash: &[u8],
 	quorum_key: &P256Public,
 ) -> bool {
 	// Verify manifest set composition
-	if manifest.manifest_set != *manifest_set {
+	if manifest.manifest_set() != manifest_set {
 		eprintln!("Manifest Set composition does not match");
 		return false;
 	}
 
 	// Verify share set composition
-	if manifest.share_set != *share_set {
+	if manifest.share_set() != share_set {
 		eprintln!("Share Set composition does not match");
 		return false;
 	}
 
 	// Verify share set composition
-	if manifest.patch_set != *patch_set {
-		eprintln!("Share Set composition does not match");
-		return false;
+	match manifest {
+		VersionedManifest::V2(_) => {}
+		VersionedManifest::V1(manifest) => {
+			if Some(&manifest.patch_set) != patch_set {
+				eprintln!("Patch Set composition does not match");
+				return false;
+			}
+		}
+		VersionedManifest::V0(manifest) => {
+			if Some(&manifest.patch_set) != patch_set {
+				eprintln!("Patch Set composition does not match");
+				return false;
+			}
+		}
 	}
 
 	// Verify pcrs 0, 1, 2, 3.
-	if manifest.enclave != *nitro_config {
+	if manifest.enclave() != nitro_config {
 		eprintln!("Nitro configuration does not match");
 		return false;
 	}
 
 	// Verify the pivot could be built deterministically
-	if manifest.pivot.hash != pivot_hash {
+	if manifest.pivot_hash().as_slice() != pivot_hash {
 		eprintln!("Pivot hash does not match");
 		return false;
 	}
 
 	// Verify the intended Quorum Key is being used
-	if manifest.namespace.quorum_key != quorum_key.to_bytes() {
+	if manifest.namespace().quorum_key != quorum_key.to_bytes() {
 		eprintln!("Quorum public key does not match");
 		return false;
 	}
@@ -973,7 +1071,7 @@ fn approve_manifest_programmatic_verifications(
 }
 
 fn approve_manifest_human_verifications<R, W>(
-	manifest: &Manifest,
+	manifest: &VersionedManifest,
 	prompter: &mut Prompter<R, W>,
 ) -> bool
 where
@@ -984,7 +1082,7 @@ where
 	{
 		let prompt = format!(
 			"Is this the correct namespace name: {}? (y/n)",
-			manifest.namespace.name
+			manifest.namespace().name
 		);
 		if !prompter.prompt_is_yes(&prompt) {
 			return false;
@@ -995,7 +1093,7 @@ where
 	{
 		let prompt = format!(
 			"Is this the correct namespace nonce: {}? (y/n)",
-			manifest.namespace.nonce
+			manifest.namespace().nonce
 		);
 		if !prompter.prompt_is_yes(&prompt) {
 			return false;
@@ -1006,7 +1104,7 @@ where
 	{
 		let prompt = format!(
 			"Is this the correct pivot restart policy: {:?}? (y/n)",
-			manifest.pivot.restart
+			manifest.restart()
 		);
 		if !prompter.prompt_is_yes(&prompt) {
 			return false;
@@ -1017,7 +1115,7 @@ where
 	{
 		let prompt = format!(
 			"Are these the correct pivot args:\n{:?}?\n(y/n)",
-			manifest.pivot.args
+			manifest.args()
 		);
 		if !prompter.prompt_is_yes(&prompt) {
 			return false;
@@ -1032,14 +1130,32 @@ pub(crate) fn generate_manifest_envelope<P: AsRef<Path>>(
 	manifest_path: P,
 	maybe_manifest_envelope_path: Option<String>,
 ) -> Result<(), Error> {
-	let manifest = read_manifest(&manifest_path)?;
+	let manifest = read_manifest_compat(&manifest_path)?;
 	let approvals = find_approvals(&manifest_approvals_dir, &manifest);
 
 	// Create manifest envelope
-	let manifest_envelope = ManifestEnvelope {
-		manifest,
-		manifest_set_approvals: approvals,
-		share_set_approvals: vec![],
+	let manifest_envelope = match manifest {
+		VersionedManifest::V2(manifest) => {
+			VersionedManifestEnvelope::V2(ManifestEnvelopeV2 {
+				manifest,
+				manifest_set_approvals: approvals,
+				share_set_approvals: vec![],
+			})
+		}
+		VersionedManifest::V1(manifest) => {
+			VersionedManifestEnvelope::V1(ManifestEnvelopeV1 {
+				manifest,
+				manifest_set_approvals: approvals,
+				share_set_approvals: vec![],
+			})
+		}
+		VersionedManifest::V0(manifest) => {
+			VersionedManifestEnvelope::V0(ManifestEnvelopeV0 {
+				manifest,
+				manifest_set_approvals: approvals,
+				share_set_approvals: vec![],
+			})
+		}
 	};
 
 	if let Err(e) = manifest_envelope.check_approvals() {
@@ -1053,7 +1169,8 @@ pub(crate) fn generate_manifest_envelope<P: AsRef<Path>>(
 	);
 	write_with_msg(
 		&path,
-		&serde_json::to_vec(&manifest_envelope)
+		&manifest_envelope
+			.to_storage_vec()
 			.expect("Failed to serialize manifest envelope"),
 		"Manifest Envelope",
 	);
@@ -1069,7 +1186,8 @@ pub(crate) fn boot_key_fwd<P: AsRef<Path>>(
 ) -> Result<(), Error> {
 	let pivot =
 		fs::read(pivot_path.as_ref()).map_err(Error::FailedToReadPivot)?;
-	let manifest_envelope = read_manifest_envelope(manifest_envelope_path)?;
+	let manifest_envelope =
+		read_manifest_envelope_compat(manifest_envelope_path)?;
 
 	let req = ProtocolMsg::BootKeyForwardRequest {
 		manifest_envelope: Box::new(manifest_envelope),
@@ -1099,7 +1217,8 @@ pub(crate) fn export_key<P: AsRef<Path>>(
 	attestation_doc_path: P,
 	encrypted_quorum_key_path: P,
 ) -> Result<(), Error> {
-	let manifest_envelope = read_manifest_envelope(manifest_envelope_path)?;
+	let manifest_envelope =
+		read_manifest_envelope_compat(manifest_envelope_path)?;
 	let cose_sign1_attestation_doc = fs::read(attestation_doc_path.as_ref())
 		.map_err(Error::FailedToReadAttestationDoc)?;
 
@@ -1174,8 +1293,9 @@ pub(crate) fn boot_standard<P: AsRef<Path>>(
 		fs::read(pivot_path.as_ref()).map_err(Error::FailedToReadPivot)?;
 
 	// Create manifest envelope
-	let manifest_envelope = read_manifest_envelope(manifest_envelope_path)?;
-	let manifest = manifest_envelope.manifest.clone();
+	let manifest_envelope =
+		read_manifest_envelope_compat(manifest_envelope_path)?;
+	let manifest = manifest_envelope.clone().manifest();
 
 	let req = ProtocolMsg::BootStandardRequest {
 		manifest_envelope: Box::new(manifest_envelope),
@@ -1199,10 +1319,10 @@ pub(crate) fn boot_standard<P: AsRef<Path>>(
 	} else {
 		verify_attestation_doc_against_user_input(
 			&attestation_doc,
-			&manifest.qos_hash(),
-			&manifest.enclave.pcr0,
-			&manifest.enclave.pcr1,
-			&manifest.enclave.pcr2,
+			&manifest.manifest_hash(),
+			&manifest.enclave().pcr0,
+			&manifest.enclave().pcr1,
+			&manifest.enclave().pcr2,
 			&extract_pcr3(pcr3_preimage_path),
 		)?;
 
@@ -1286,13 +1406,15 @@ pub(crate) fn proxy_re_encrypt_share<P: AsRef<Path>>(
 		unsafe_auto_confirm,
 	}: ProxyReEncryptShareArgs<P>,
 ) -> Result<(), Error> {
-	let manifest_envelope = read_manifest_envelope(&manifest_envelope_path)?;
+	let manifest_envelope =
+		read_manifest_envelope_compat(&manifest_envelope_path)?;
 	let attestation_doc =
 		read_attestation_doc(&attestation_doc_path, unsafe_skip_attestation)?;
 	let encrypted_share = std::fs::read(share_path)
 		.map_err(|e| Error::ReadShare(e.to_string()))?;
 
 	let pcr3_preimage = find_pcr3(&pcr3_preimage_path);
+	let manifest = manifest_envelope.clone().manifest();
 
 	// Verify the attestation doc matches up with the pcrs in the manifest
 	if unsafe_skip_attestation {
@@ -1300,10 +1422,10 @@ pub(crate) fn proxy_re_encrypt_share<P: AsRef<Path>>(
 	} else {
 		verify_attestation_doc_against_user_input(
 			&attestation_doc,
-			&manifest_envelope.manifest.qos_hash(),
-			&manifest_envelope.manifest.enclave.pcr0,
-			&manifest_envelope.manifest.enclave.pcr1,
-			&manifest_envelope.manifest.enclave.pcr2,
+			&manifest_envelope.manifest_hash(),
+			&manifest.enclave().pcr0,
+			&manifest.enclave().pcr1,
+			&manifest.enclave().pcr2,
 			&extract_pcr3(pcr3_preimage_path),
 		)?;
 	}
@@ -1358,7 +1480,7 @@ pub(crate) fn proxy_re_encrypt_share<P: AsRef<Path>>(
 
 	let approval = serde_json::to_vec(&Approval {
 		signature: pair
-			.sign(&manifest_envelope.manifest.qos_hash())
+			.sign(&manifest_envelope.manifest_hash())
 			.expect("Failed to sign"),
 		member,
 	})
@@ -1378,23 +1500,25 @@ pub(crate) fn proxy_re_encrypt_share<P: AsRef<Path>>(
 }
 
 fn proxy_re_encrypt_share_programmatic_verifications(
-	manifest_envelope: &ManifestEnvelope,
+	manifest_envelope: &VersionedManifestEnvelope,
 	manifest_set: &ManifestSet,
 	member: &QuorumMember,
 ) -> bool {
+	let manifest = manifest_envelope.clone().manifest();
+
 	if let Err(e) = manifest_envelope.check_approvals() {
 		eprintln!("Manifest envelope did not have valid approvals: {e:?}");
 		return false;
 	}
 
-	if manifest_envelope.manifest.manifest_set != *manifest_set {
+	if *manifest.manifest_set() != *manifest_set {
 		eprintln!(
 			"Manifest's manifest set does not match locally found Manifest Set"
 		);
 		return false;
 	}
 
-	if !manifest_envelope.manifest.share_set.members.contains(member) {
+	if !manifest.share_set().members.contains(member) {
 		eprintln!("The provided share set key and alias are not part of the Share Set");
 		return false;
 	}
@@ -1403,7 +1527,7 @@ fn proxy_re_encrypt_share_programmatic_verifications(
 }
 
 fn proxy_re_encrypt_share_human_verifications<R, W>(
-	manifest_envelope: &ManifestEnvelope,
+	manifest_envelope: &VersionedManifestEnvelope,
 	pcr3_preimage: &str,
 	prompter: &mut Prompter<R, W>,
 ) -> bool
@@ -1411,11 +1535,13 @@ where
 	R: BufRead,
 	W: Write,
 {
+	let manifest = manifest_envelope.clone().manifest();
+
 	// Check the namespace name
 	{
 		let prompt = format!(
 			"Is this the correct namespace name: {}? (y/n)",
-			manifest_envelope.manifest.namespace.name
+			manifest.namespace().name
 		);
 		if !prompter.prompt_is_yes(&prompt) {
 			return false;
@@ -1426,7 +1552,7 @@ where
 	{
 		let prompt = format!(
 			"Is this the correct namespace nonce: {}? (y/n)",
-			manifest_envelope.manifest.namespace.nonce
+			manifest.namespace().nonce
 		);
 		if !prompter.prompt_is_yes(&prompt) {
 			return false;
@@ -1445,7 +1571,7 @@ where
 
 	{
 		let mut approvers = manifest_envelope
-			.manifest_set_approvals
+			.manifest_set_approvals()
 			.iter()
 			.cloned()
 			.map(|m| m.member.alias)
@@ -1618,7 +1744,7 @@ pub(crate) fn display<P: AsRef<Path>>(
 ) -> Result<(), Error> {
 	match *display_type {
 		DisplayType::Manifest => {
-			let decoded = read_manifest(file_path)?;
+			let decoded = read_manifest_compat(file_path)?;
 
 			if json {
 				println!("{}", serde_json::to_string(&decoded).unwrap());
@@ -1627,7 +1753,7 @@ pub(crate) fn display<P: AsRef<Path>>(
 			}
 		}
 		DisplayType::ManifestEnvelope => {
-			let decoded = read_manifest_envelope(file_path)?;
+			let decoded = read_manifest_envelope_compat(file_path)?;
 
 			if json {
 				println!("{}", serde_json::to_string(&decoded).unwrap());
@@ -1652,7 +1778,7 @@ pub(crate) fn json_to_borsh<P: AsRef<Path>>(
 ) -> Result<(), Error> {
 	match *display_type {
 		DisplayType::Manifest => {
-			let manifest = read_manifest(&file_path)?;
+			let manifest = read_manifest_v1_compat(&file_path)?;
 			let borsh_bytes = borsh::to_vec(&manifest)?;
 			fs::write(&output_path, borsh_bytes).map_err(|e| {
 				Error::FailedToWrite {
@@ -1662,7 +1788,7 @@ pub(crate) fn json_to_borsh<P: AsRef<Path>>(
 			})?;
 		}
 		DisplayType::ManifestEnvelope => {
-			let envelope = read_manifest_envelope(&file_path)?;
+			let envelope = read_manifest_envelope_v1_compat(&file_path)?;
 			let borsh_bytes = borsh::to_vec(&envelope)?;
 			fs::write(&output_path, borsh_bytes).map_err(|e| {
 				Error::FailedToWrite {
@@ -1758,11 +1884,11 @@ pub(crate) fn dangerous_dev_boot<P: AsRef<Path>>(
 	let manifest_envelope = {
 		let signature =
 			quorum_pair.sign(&manifest.qos_hash()).expect("Failed to sign");
-		Box::new(ManifestEnvelope {
+		Box::new(VersionedManifestEnvelope::V1(ManifestEnvelope {
 			manifest,
 			manifest_set_approvals: vec![Approval { signature, member }],
 			share_set_approvals: vec![],
-		})
+		}))
 	};
 
 	let req = ProtocolMsg::BootStandardRequest {
@@ -1791,7 +1917,7 @@ pub(crate) fn dangerous_dev_boot<P: AsRef<Path>>(
 	// Create ShareSet approval
 	let approval = Approval {
 		signature: quorum_pair
-			.sign(&manifest_envelope.manifest.qos_hash())
+			.sign(&manifest_envelope.manifest_hash())
 			.expect("Failed to sign"),
 		member: QuorumMember {
 			pub_key: quorum_pair.public_key().to_bytes(),
@@ -2050,8 +2176,9 @@ fn get_genesis_set<P: AsRef<Path>>(dir: P) -> GenesisSet {
 
 fn find_approvals<P: AsRef<Path>>(
 	boot_dir: P,
-	manifest: &Manifest,
+	manifest: &VersionedManifest,
 ) -> Vec<Approval> {
+	let manifest_hash = manifest.manifest_hash();
 	let approvals: Vec<_> = find_file_paths(&boot_dir)
 		.iter()
 		.filter_map(|path| {
@@ -2070,7 +2197,7 @@ fn find_approvals<P: AsRef<Path>>(
 				});
 
 			assert!(
-				manifest.manifest_set.members.contains(&approval.member),
+				manifest.manifest_set().members.contains(&approval.member),
 				"Found approval from member ({:?}) not included in the Manifest Set",
 				approval.member.alias
 			);
@@ -2079,7 +2206,7 @@ fn find_approvals<P: AsRef<Path>>(
 				.expect("Failed to interpret pub key");
 			assert!(
 				pub_key
-					.verify(&manifest.qos_hash(), &approval.signature)
+					.verify(&manifest_hash, &approval.signature)
 					.is_ok(),
 				"Approval signature could not be verified against manifest"
 			);
@@ -2087,21 +2214,25 @@ fn find_approvals<P: AsRef<Path>>(
 			Some(approval)
 		})
 		.collect();
-	assert!(approvals.len() >= manifest.manifest_set.threshold as usize);
+	assert!(approvals.len() >= manifest.manifest_set().threshold as usize);
 
 	approvals
 }
 
-fn read_manifest<P: AsRef<Path>>(file: P) -> Result<Manifest, Error> {
+fn read_manifest_compat<P: AsRef<Path>>(
+	file: P,
+) -> Result<VersionedManifest, Error> {
 	let bytes = fs::read(file).map_err(Error::FailedToReadManifestFile)?;
+	VersionedManifest::try_from_slice_compat(&bytes).map_err(Error::from)
+}
 
-	// try getting Manifest from json
-	let result = serde_json::from_slice::<Manifest>(&bytes);
-	if result.is_err() {
-		// if not try the old formats
-		Manifest::try_from_slice_compat(&bytes).map_err(Error::from)
-	} else {
-		result.map_err(Error::from)
+fn read_manifest_v1_compat<P: AsRef<Path>>(
+	file: P,
+) -> Result<ManifestV1, Error> {
+	match read_manifest_compat(file)? {
+		VersionedManifest::V2(_) => Err(Error::ManifestV2NotConvertibleToBorsh),
+		VersionedManifest::V1(manifest) => Ok(manifest),
+		VersionedManifest::V0(manifest) => Ok(manifest.into()),
 	}
 }
 
@@ -2119,18 +2250,28 @@ fn read_attestation_doc<P: AsRef<Path>>(
 	))
 }
 
-fn read_manifest_envelope<P: AsRef<Path>>(
+fn read_manifest_envelope_compat<P: AsRef<Path>>(
 	file: P,
-) -> Result<ManifestEnvelope, Error> {
+) -> Result<VersionedManifestEnvelope, Error> {
 	let bytes = fs::read(file).map_err(Error::FailedToReadManifestFile)?;
 
-	// try getting Manifest from json
-	let result = serde_json::from_slice::<ManifestEnvelope>(&bytes);
-	if result.is_err() {
-		// if not try the old borsh format
-		ManifestEnvelope::try_from_slice_compat(&bytes).map_err(Error::from)
-	} else {
-		result.map_err(Error::from)
+	VersionedManifestEnvelope::try_from_slice_compat(&bytes)
+		.map_err(Error::from)
+}
+
+fn read_manifest_envelope_v1_compat<P: AsRef<Path>>(
+	file: P,
+) -> Result<ManifestEnvelopeV1, Error> {
+	match read_manifest_envelope_compat(file)? {
+		VersionedManifestEnvelope::V2(_) => {
+			Err(Error::ManifestV2NotConvertibleToBorsh)
+		}
+		VersionedManifestEnvelope::V1(envelope) => Ok(envelope),
+		VersionedManifestEnvelope::V0(envelope) => Ok(ManifestEnvelopeV1 {
+			manifest: envelope.manifest.into(),
+			manifest_set_approvals: envelope.manifest_set_approvals,
+			share_set_approvals: envelope.share_set_approvals,
+		}),
 	}
 }
 
@@ -2324,12 +2465,14 @@ mod tests {
 		services::boot::{
 			Approval, Manifest, ManifestEnvelope, ManifestSet, MemberPubKey,
 			Namespace, NitroConfig, PatchSet, PivotConfig, QuorumMember,
-			RestartPolicy, ShareSet,
+			RestartPolicy, ShareSet, VersionedManifest,
+			VersionedManifestEnvelope,
 		},
 		QosHash,
 	};
 	use qos_nsm::nitro::{cert_from_pem, AWS_ROOT_CERT_PEM};
 	use qos_p256::{P256Pair, P256Public};
+	use qos_test_primitives::PathWrapper;
 
 	use super::{
 		approve_manifest_human_verifications,
@@ -2339,13 +2482,13 @@ mod tests {
 	};
 
 	struct Setup {
-		manifest: Manifest,
+		manifest: VersionedManifest,
 		manifest_set: ManifestSet,
 		share_set: ShareSet,
 		nitro_config: NitroConfig,
 		pivot_hash: Vec<u8>,
 		quorum_key: P256Public,
-		manifest_envelope: ManifestEnvelope,
+		manifest_envelope: VersionedManifestEnvelope,
 		patch_set: PatchSet,
 	}
 	fn setup() -> Setup {
@@ -2381,7 +2524,7 @@ mod tests {
 		let pivot_hash = vec![5; 32];
 		let quorum_key: P256Public = P256Pair::generate().unwrap().public_key();
 
-		let manifest = Manifest {
+		let manifest_v1 = Manifest {
 			namespace: Namespace {
 				name: "test-namespace".to_string(),
 				nonce: 2,
@@ -2401,20 +2544,22 @@ mod tests {
 			patch_set: patch_set.clone(),
 			enclave: nitro_config.clone(),
 		};
+		let manifest = VersionedManifest::V1(manifest_v1.clone());
 
-		let manifest_envelope = ManifestEnvelope {
-			manifest: manifest.clone(),
-			manifest_set_approvals: std::iter::zip(
-				pairs[..2].iter(),
-				members.iter(),
-			)
-			.map(|(pair, member)| Approval {
-				signature: pair.sign(&manifest.qos_hash()).unwrap(),
-				member: member.clone(),
-			})
-			.collect(),
-			share_set_approvals: vec![],
-		};
+		let manifest_envelope =
+			VersionedManifestEnvelope::V1(ManifestEnvelope {
+				manifest: manifest_v1.clone(),
+				manifest_set_approvals: std::iter::zip(
+					pairs[..2].iter(),
+					members.iter(),
+				)
+				.map(|(pair, member)| Approval {
+					signature: pair.sign(&manifest_v1.qos_hash()).unwrap(),
+					member: member.clone(),
+				})
+				.collect(),
+				share_set_approvals: vec![],
+			});
 
 		Setup {
 			manifest,
@@ -2425,6 +2570,31 @@ mod tests {
 			quorum_key,
 			manifest_envelope,
 			patch_set,
+		}
+	}
+
+	fn v1_manifest(manifest: &VersionedManifest) -> &Manifest {
+		match manifest {
+			VersionedManifest::V1(manifest) => manifest,
+			_ => panic!("expected v1 manifest in test setup"),
+		}
+	}
+
+	fn v1_manifest_envelope(
+		envelope: &VersionedManifestEnvelope,
+	) -> &ManifestEnvelope {
+		match envelope {
+			VersionedManifestEnvelope::V1(envelope) => envelope,
+			_ => panic!("expected v1 manifest envelope in test setup"),
+		}
+	}
+
+	fn v1_manifest_envelope_mut(
+		envelope: &mut VersionedManifestEnvelope,
+	) -> &mut ManifestEnvelope {
+		match envelope {
+			VersionedManifestEnvelope::V1(envelope) => envelope,
+			_ => panic!("expected v1 manifest envelope in test setup"),
 		}
 	}
 
@@ -2448,7 +2618,7 @@ mod tests {
 				&manifest,
 				&manifest_set,
 				&share_set,
-				&patch_set,
+				Some(&patch_set),
 				&nitro_config,
 				&pivot_hash,
 				&quorum_key,
@@ -2475,7 +2645,7 @@ mod tests {
 				&manifest,
 				&manifest_set,
 				&share_set,
-				&patch_set,
+				Some(&patch_set),
 				&nitro_config,
 				&pivot_hash,
 				&quorum_key,
@@ -2502,7 +2672,7 @@ mod tests {
 				&manifest,
 				&manifest_set,
 				&share_set,
-				&patch_set,
+				Some(&patch_set),
 				&nitro_config,
 				&pivot_hash,
 				&quorum_key,
@@ -2528,7 +2698,7 @@ mod tests {
 				&manifest,
 				&manifest_set,
 				&share_set,
-				&patch_set,
+				Some(&patch_set),
 				&nitro_config,
 				&pivot_hash,
 				&quorum_key,
@@ -2554,7 +2724,7 @@ mod tests {
 				&manifest,
 				&manifest_set,
 				&share_set,
-				&patch_set,
+				Some(&patch_set),
 				&nitro_config,
 				&pivot_hash,
 				&quorum_key,
@@ -2580,7 +2750,7 @@ mod tests {
 				&manifest,
 				&manifest_set,
 				&share_set,
-				&patch_set,
+				Some(&patch_set),
 				&nitro_config,
 				&pivot_hash,
 				&quorum_key,
@@ -2606,7 +2776,7 @@ mod tests {
 				&manifest,
 				&manifest_set,
 				&share_set,
-				&patch_set,
+				Some(&patch_set),
 				&nitro_config,
 				&pivot_hash,
 				&quorum_key,
@@ -2632,7 +2802,7 @@ mod tests {
 				&manifest,
 				&manifest_set,
 				&share_set,
-				&patch_set,
+				Some(&patch_set),
 				&nitro_config,
 				&pivot_hash,
 				&quorum_key,
@@ -2658,7 +2828,7 @@ mod tests {
 				&manifest,
 				&manifest_set,
 				&share_set,
-				&patch_set,
+				Some(&patch_set),
 				&nitro_config,
 				&pivot_hash,
 				&quorum_key,
@@ -2684,7 +2854,7 @@ mod tests {
 				&manifest,
 				&manifest_set,
 				&share_set,
-				&patch_set,
+				Some(&patch_set),
 				&nitro_config,
 				&pivot_hash,
 				&quorum_key,
@@ -2710,7 +2880,7 @@ mod tests {
 				&manifest,
 				&manifest_set,
 				&share_set,
-				&patch_set,
+				Some(&patch_set),
 				&nitro_config,
 				&pivot_hash,
 				&quorum_key,
@@ -2852,7 +3022,7 @@ mod tests {
 				manifest_set, share_set, mut manifest_envelope, ..
 			} = setup();
 
-			manifest_envelope
+			v1_manifest_envelope_mut(&mut manifest_envelope)
 				.manifest_set_approvals
 				.get_mut(0)
 				.unwrap()
@@ -2872,7 +3042,7 @@ mod tests {
 				manifest_set, share_set, mut manifest_envelope, ..
 			} = setup();
 
-			manifest_envelope
+			v1_manifest_envelope_mut(&mut manifest_envelope)
 				.manifest_set_approvals
 				.get_mut(0)
 				.unwrap()
@@ -2893,7 +3063,10 @@ mod tests {
 				manifest_set, share_set, mut manifest_envelope, ..
 			} = setup();
 
-			manifest_envelope.manifest_set_approvals.pop().unwrap();
+			v1_manifest_envelope_mut(&mut manifest_envelope)
+				.manifest_set_approvals
+				.pop()
+				.unwrap();
 
 			let member = share_set.members[0].clone();
 			assert!(!proxy_re_encrypt_share_programmatic_verifications(
@@ -3111,6 +3284,10 @@ mod tests {
 		use std::fs;
 
 		use borsh::BorshDeserialize;
+		use qos_core::protocol::services::boot::{
+			ManifestEnvelopeV2, ManifestV2, ManifestVersion, PivotConfigV2,
+			PivotEnv,
+		};
 
 		use super::*;
 		use crate::cli::DisplayType;
@@ -3138,7 +3315,7 @@ mod tests {
 			// Read back and verify
 			let borsh_bytes = fs::read(&borsh_path).unwrap();
 			let decoded = Manifest::try_from_slice(&borsh_bytes).unwrap();
-			assert_eq!(decoded, manifest);
+			assert_eq!(decoded, *v1_manifest(&manifest));
 
 			// Cleanup
 			let _ = fs::remove_file(&json_path);
@@ -3169,7 +3346,7 @@ mod tests {
 			let borsh_bytes = fs::read(&borsh_path).unwrap();
 			let decoded =
 				ManifestEnvelope::try_from_slice(&borsh_bytes).unwrap();
-			assert_eq!(decoded, manifest_envelope);
+			assert_eq!(decoded, *v1_manifest_envelope(&manifest_envelope));
 
 			// Cleanup
 			let _ = fs::remove_file(&json_path);
@@ -3195,6 +3372,95 @@ mod tests {
 
 			// Cleanup
 			let _ = fs::remove_file(&json_path);
+		}
+
+		#[test]
+		fn rejects_v2_json_manifest() {
+			let Setup { manifest, .. } = setup();
+			let manifest = v1_manifest(&manifest).clone();
+			let temp_dir = std::env::temp_dir();
+			let json_path =
+				PathWrapper::from(temp_dir.join("test_manifest_v2.json"));
+			let borsh_path =
+				PathWrapper::from(temp_dir.join("test_manifest_v2.borsh"));
+			let v2 = ManifestV2 {
+				version: ManifestVersion::V2,
+				namespace: manifest.namespace,
+				pivot: PivotConfigV2 {
+					hash: manifest.pivot.hash,
+					restart: manifest.pivot.restart,
+					bridge_config: manifest.pivot.bridge_config,
+					debug_mode: manifest.pivot.debug_mode,
+					args: manifest.pivot.args,
+					env: PivotEnv::new(),
+				},
+				manifest_set: manifest.manifest_set,
+				share_set: manifest.share_set,
+				enclave: manifest.enclave,
+			};
+			fs::write(&json_path, qos_json::to_vec(&v2).unwrap()).unwrap();
+
+			let result = super::super::json_to_borsh(
+				&DisplayType::Manifest,
+				&json_path,
+				&borsh_path,
+			);
+
+			assert!(matches!(
+				result,
+				Err(super::super::Error::ManifestV2NotConvertibleToBorsh)
+			));
+		}
+
+		#[test]
+		fn rejects_v2_json_manifest_envelope() {
+			let Setup { manifest_envelope, .. } = setup();
+			let manifest_envelope = v1_manifest_envelope(&manifest_envelope);
+			let manifest = manifest_envelope.manifest.clone();
+			let temp_dir = std::env::temp_dir();
+			let json_path = PathWrapper::from(
+				temp_dir.join("test_manifest_envelope_v2.json"),
+			);
+			let borsh_path = PathWrapper::from(
+				temp_dir.join("test_manifest_envelope_v2.borsh"),
+			);
+			let v2_manifest = ManifestV2 {
+				version: ManifestVersion::V2,
+				namespace: manifest.namespace,
+				pivot: PivotConfigV2 {
+					hash: manifest.pivot.hash,
+					restart: manifest.pivot.restart,
+					bridge_config: manifest.pivot.bridge_config,
+					debug_mode: manifest.pivot.debug_mode,
+					args: manifest.pivot.args,
+					env: PivotEnv::new(),
+				},
+				manifest_set: manifest.manifest_set,
+				share_set: manifest.share_set,
+				enclave: manifest.enclave,
+			};
+			let v2_envelope = ManifestEnvelopeV2 {
+				manifest: v2_manifest,
+				manifest_set_approvals: manifest_envelope
+					.manifest_set_approvals
+					.clone(),
+				share_set_approvals: manifest_envelope
+					.share_set_approvals
+					.clone(),
+			};
+			fs::write(&json_path, qos_json::to_vec(&v2_envelope).unwrap())
+				.unwrap();
+
+			let result = super::super::json_to_borsh(
+				&DisplayType::ManifestEnvelope,
+				&json_path,
+				&borsh_path,
+			);
+
+			assert!(matches!(
+				result,
+				Err(super::super::Error::ManifestV2NotConvertibleToBorsh)
+			));
 		}
 	}
 

--- a/src/qos_client/src/cli/services.rs
+++ b/src/qos_client/src/cli/services.rs
@@ -8,8 +8,8 @@ use std::{
 use aws_nitro_enclaves_nsm_api::api::AttestationDoc;
 use borsh::BorshDeserialize;
 use qos_core::protocol::{
-	msg::{JsonBytes, ProtocolMsg},
 	QosHash,
+	msg::{JsonBytes, ProtocolMsg},
 	services::{
 		boot::{
 			Approval, BridgeConfig, Manifest as ManifestV1,
@@ -1555,7 +1555,9 @@ fn proxy_re_encrypt_share_programmatic_verifications(
 	}
 
 	if !manifest.share_set().members.contains(member) {
-		eprintln!("The provided share set key and alias are not part of the Share Set");
+		eprintln!(
+			"The provided share set key and alias are not part of the Share Set"
+		);
 		return false;
 	}
 
@@ -2251,9 +2253,7 @@ fn find_approvals<P: AsRef<Path>>(
 			let pub_key = P256Public::from_bytes(&approval.member.pub_key)
 				.expect("Failed to interpret pub key");
 			assert!(
-				pub_key
-					.verify(&manifest_hash, &approval.signature)
-					.is_ok(),
+				pub_key.verify(&manifest_hash, &approval.signature).is_ok(),
 				"Approval signature could not be verified against manifest"
 			);
 

--- a/src/qos_client/src/lib.rs
+++ b/src/qos_client/src/lib.rs
@@ -8,7 +8,7 @@ pub mod yubikey;
 pub mod request {
 	use std::io::Read;
 
-	use qos_core::protocol::msg::ProtocolMsg;
+	use qos_core::protocol::msg::{ProtocolMsg, ProtocolMsgEncoding};
 
 	const MAX_SIZE: u64 = u32::MAX as u64;
 	const ERROR_BODY_PREFIX_LIMIT: usize = 256;
@@ -21,10 +21,32 @@ pub mod request {
 	/// cannot be read, or deserialization fails.
 	///
 	pub fn post(url: &str, msg: &ProtocolMsg) -> Result<ProtocolMsg, String> {
+		post_wire(url, msg, ProtocolMsgEncoding::Json)
+	}
+
+	/// Post a [`qos_core::protocol::msg::ProtocolMsg`] using legacy Borsh
+	/// wire encoding.
+	///
+	/// # Errors
+	///
+	/// Returns an error string if the HTTP request fails, the response
+	/// cannot be read, or deserialization fails.
+	pub fn post_borsh(
+		url: &str,
+		msg: &ProtocolMsg,
+	) -> Result<ProtocolMsg, String> {
+		post_wire(url, msg, ProtocolMsgEncoding::Borsh)
+	}
+
+	fn post_wire(
+		url: &str,
+		msg: &ProtocolMsg,
+		encoding: ProtocolMsgEncoding,
+	) -> Result<ProtocolMsg, String> {
 		let mut buf: Vec<u8> = vec![];
 
 		let response = ureq::post(url)
-			.send_bytes(&msg.to_json_wire().map_err(|e| {
+			.send_bytes(&msg.to_wire(encoding).map_err(|e| {
 				format!("protocol message serialization error: {e:?}")
 			})?)
 			.map_err(|e| match e {

--- a/src/qos_client/src/lib.rs
+++ b/src/qos_client/src/lib.rs
@@ -8,7 +8,6 @@ pub mod yubikey;
 pub mod request {
 	use std::io::Read;
 
-	use borsh::BorshDeserialize;
 	use qos_core::protocol::msg::ProtocolMsg;
 
 	const MAX_SIZE: u64 = u32::MAX as u64;
@@ -21,18 +20,13 @@ pub mod request {
 	/// Returns an error string if the HTTP request fails, the response
 	/// cannot be read, or deserialization fails.
 	///
-	/// # Panics
-	/// Panics if the `msg` cannot be Borsh serialized.
-	/// Should never happen in practice because all protocol messages are
-	/// Borsh-serializable.
 	pub fn post(url: &str, msg: &ProtocolMsg) -> Result<ProtocolMsg, String> {
 		let mut buf: Vec<u8> = vec![];
 
 		let response = ureq::post(url)
-			.send_bytes(
-				&borsh::to_vec(msg)
-					.expect("ProtocolMsg can always be serialized. qed."),
-			)
+			.send_bytes(&msg.to_json_wire().map_err(|e| {
+				format!("protocol message serialization error: {e:?}")
+			})?)
 			.map_err(|e| match e {
 				ureq::Error::Status(code, r) => {
 					let body = r.into_string();
@@ -51,7 +45,7 @@ pub mod request {
 			},
 		)?;
 
-		let decoded_response = ProtocolMsg::try_from_slice(&buf).map_err(|e| {
+		let decoded_response = ProtocolMsg::from_wire_any(&buf).map_err(|e| {
 			let body_prefix = String::from_utf8_lossy(
 				&buf[..std::cmp::min(buf.len(), ERROR_BODY_PREFIX_LIMIT)],
 			);

--- a/src/qos_client/tests/golden_artifacts.rs
+++ b/src/qos_client/tests/golden_artifacts.rs
@@ -410,6 +410,16 @@ fn assert_success(output: &Output) {
 	);
 }
 
+fn assert_failure(output: &Output) {
+	assert!(
+		!output.status.success(),
+		"qos_client unexpectedly succeeded\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+		output.status.code(),
+		String::from_utf8_lossy(&output.stdout),
+		String::from_utf8_lossy(&output.stderr),
+	);
+}
+
 fn assert_file_json_exact(path: &std::path::Path, expected: &str) {
 	let actual = std::fs::read_to_string(path).unwrap();
 	assert_eq!(actual, expected);
@@ -494,4 +504,263 @@ fn golden_manifest_approval_and_envelope_raw_bytes() {
 		MANIFEST_V0_BORSH_LEN,
 		MANIFEST_V0_BORSH_SHA256_HEX,
 	);
+}
+
+#[test]
+fn v2_commands_generate_approve_and_envelope_use_json_hash() {
+	use qos_core::protocol::services::boot::{
+		Approval, ManifestEnvelopeV2, ManifestV2, ManifestVersion,
+	};
+	use qos_p256::P256Public;
+
+	let fixture = Fixture::new("v2_commands");
+
+	assert_success(&run_qos_client([
+		"pivot-hash",
+		"--output-path",
+		fixture.pivot_hash_path.to_str().unwrap(),
+		"--pivot-path",
+		fixture.pivot_path.to_str().unwrap(),
+	]));
+
+	assert_success(&run_qos_client([
+		"generate-manifest",
+		"--use-manifest-version",
+		"2",
+		"--nonce",
+		"31",
+		"--namespace",
+		"production/signer",
+		"--restart-policy",
+		"always",
+		"--manifest-path",
+		fixture.manifest_path.to_str().unwrap(),
+		"--pivot-hash-path",
+		fixture.pivot_hash_path.to_str().unwrap(),
+		"--qos-release-dir",
+		fixture.qos_release_dir.to_str().unwrap(),
+		"--pcr3-preimage-path",
+		fixture.pcr3_preimage_path.to_str().unwrap(),
+		"--pivot-args",
+		"[--config,/etc/config.json]",
+		"--manifest-set-dir",
+		fixture.manifest_set.to_str().unwrap(),
+		"--share-set-dir",
+		fixture.share_set.to_str().unwrap(),
+		"--quorum-key-path",
+		fixture.quorum_key_path.to_str().unwrap(),
+		"--debug-mode",
+		"true",
+		"--bridge-config",
+		"[{\"type\":\"server\",\"port\":3000,\"host\":\"0.0.0.0\"}]",
+	]));
+
+	let manifest_json: serde_json::Value =
+		serde_json::from_slice(&std::fs::read(&fixture.manifest_path).unwrap())
+			.unwrap();
+	assert_eq!(manifest_json["version"], "v2");
+	assert!(manifest_json.get("patchSet").is_none());
+
+	let manifest: ManifestV2 =
+		serde_json::from_value(manifest_json.clone()).unwrap();
+	assert_eq!(manifest.version, ManifestVersion::V2);
+	let manifest_hash = qos_json::hash(&manifest).unwrap();
+
+	assert_success(&run_qos_client([
+		"approve-manifest",
+		"--alias",
+		"dev",
+		"--manifest-approvals-dir",
+		fixture.approvals_dir.to_str().unwrap(),
+		"--manifest-path",
+		fixture.manifest_path.to_str().unwrap(),
+		"--manifest-set-dir",
+		fixture.manifest_set.to_str().unwrap(),
+		"--share-set-dir",
+		fixture.share_set.to_str().unwrap(),
+		"--pcr3-preimage-path",
+		fixture.pcr3_preimage_path.to_str().unwrap(),
+		"--pivot-hash-path",
+		fixture.pivot_hash_path.to_str().unwrap(),
+		"--qos-release-dir",
+		fixture.qos_release_dir.to_str().unwrap(),
+		"--quorum-key-path",
+		fixture.quorum_key_path.to_str().unwrap(),
+		"--secret-path",
+		fixture.secret_path.to_str().unwrap(),
+		"--unsafe-auto-confirm",
+	]));
+
+	let approval: Approval =
+		serde_json::from_slice(&std::fs::read(&fixture.approval_path).unwrap())
+			.unwrap();
+	let pub_key = P256Public::from_bytes(&approval.member.pub_key).unwrap();
+	assert!(pub_key.verify(&manifest_hash, &approval.signature).is_ok());
+
+	assert_success(&run_qos_client([
+		"generate-manifest-envelope",
+		"--manifest-approvals-dir",
+		fixture.approvals_dir.to_str().unwrap(),
+		"--manifest-path",
+		fixture.manifest_path.to_str().unwrap(),
+	]));
+
+	let envelope: ManifestEnvelopeV2 =
+		serde_json::from_slice(&std::fs::read(&fixture.envelope_path).unwrap())
+			.unwrap();
+	assert_eq!(envelope.manifest.version, ManifestVersion::V2);
+	assert_eq!(envelope.manifest_set_approvals.len(), 1);
+	assert!(P256Public::from_bytes(
+		&envelope.manifest_set_approvals[0].member.pub_key
+	)
+	.unwrap()
+	.verify(&manifest_hash, &envelope.manifest_set_approvals[0].signature)
+	.is_ok());
+}
+
+#[test]
+fn v2_commands_json_to_borsh_rejected() {
+	let fixture = Fixture::new("v2_json_to_borsh_rejected");
+
+	assert_success(&run_qos_client([
+		"pivot-hash",
+		"--output-path",
+		fixture.pivot_hash_path.to_str().unwrap(),
+		"--pivot-path",
+		fixture.pivot_path.to_str().unwrap(),
+	]));
+
+	assert_success(&run_qos_client([
+		"generate-manifest",
+		"--use-manifest-version",
+		"2",
+		"--nonce",
+		"31",
+		"--namespace",
+		"production/signer",
+		"--restart-policy",
+		"always",
+		"--manifest-path",
+		fixture.manifest_path.to_str().unwrap(),
+		"--pivot-hash-path",
+		fixture.pivot_hash_path.to_str().unwrap(),
+		"--qos-release-dir",
+		fixture.qos_release_dir.to_str().unwrap(),
+		"--pcr3-preimage-path",
+		fixture.pcr3_preimage_path.to_str().unwrap(),
+		"--pivot-args",
+		"[--config,/etc/config.json]",
+		"--manifest-set-dir",
+		fixture.manifest_set.to_str().unwrap(),
+		"--share-set-dir",
+		fixture.share_set.to_str().unwrap(),
+		"--quorum-key-path",
+		fixture.quorum_key_path.to_str().unwrap(),
+		"--debug-mode",
+		"true",
+		"--bridge-config",
+		"[{\"type\":\"server\",\"port\":3000,\"host\":\"0.0.0.0\"}]",
+	]));
+
+	assert_success(&run_qos_client([
+		"approve-manifest",
+		"--alias",
+		"dev",
+		"--manifest-approvals-dir",
+		fixture.approvals_dir.to_str().unwrap(),
+		"--manifest-path",
+		fixture.manifest_path.to_str().unwrap(),
+		"--manifest-set-dir",
+		fixture.manifest_set.to_str().unwrap(),
+		"--share-set-dir",
+		fixture.share_set.to_str().unwrap(),
+		"--pcr3-preimage-path",
+		fixture.pcr3_preimage_path.to_str().unwrap(),
+		"--pivot-hash-path",
+		fixture.pivot_hash_path.to_str().unwrap(),
+		"--qos-release-dir",
+		fixture.qos_release_dir.to_str().unwrap(),
+		"--quorum-key-path",
+		fixture.quorum_key_path.to_str().unwrap(),
+		"--secret-path",
+		fixture.secret_path.to_str().unwrap(),
+		"--unsafe-auto-confirm",
+	]));
+
+	assert_success(&run_qos_client([
+		"generate-manifest-envelope",
+		"--manifest-approvals-dir",
+		fixture.approvals_dir.to_str().unwrap(),
+		"--manifest-path",
+		fixture.manifest_path.to_str().unwrap(),
+	]));
+
+	let manifest_out = run_qos_client([
+		"json-to-borsh",
+		"--display-type",
+		"manifest",
+		"--file-path",
+		fixture.manifest_path.to_str().unwrap(),
+		"--output-path",
+		fixture.manifest_borsh_path.to_str().unwrap(),
+	]);
+	assert_failure(&manifest_out);
+
+	let envelope_out = run_qos_client([
+		"json-to-borsh",
+		"--display-type",
+		"manifest-envelope",
+		"--file-path",
+		fixture.envelope_path.to_str().unwrap(),
+		"--output-path",
+		fixture.envelope_borsh_path.to_str().unwrap(),
+	]);
+	assert_failure(&envelope_out);
+}
+
+#[test]
+fn v1_generate_manifest_without_patch_set_fails_cleanly() {
+	let fixture = Fixture::new("v1_missing_patch_set");
+
+	assert_success(&run_qos_client([
+		"pivot-hash",
+		"--output-path",
+		fixture.pivot_hash_path.to_str().unwrap(),
+		"--pivot-path",
+		fixture.pivot_path.to_str().unwrap(),
+	]));
+
+	let output = run_qos_client([
+		"generate-manifest",
+		"--nonce",
+		"31",
+		"--namespace",
+		"production/signer",
+		"--restart-policy",
+		"always",
+		"--manifest-path",
+		fixture.manifest_path.to_str().unwrap(),
+		"--pivot-hash-path",
+		fixture.pivot_hash_path.to_str().unwrap(),
+		"--qos-release-dir",
+		fixture.qos_release_dir.to_str().unwrap(),
+		"--pcr3-preimage-path",
+		fixture.pcr3_preimage_path.to_str().unwrap(),
+		"--pivot-args",
+		"[]",
+		"--manifest-set-dir",
+		fixture.manifest_set.to_str().unwrap(),
+		"--share-set-dir",
+		fixture.share_set.to_str().unwrap(),
+		"--quorum-key-path",
+		fixture.quorum_key_path.to_str().unwrap(),
+	]);
+
+	assert_failure(&output);
+	let combined = format!(
+		"{}{}",
+		String::from_utf8_lossy(&output.stdout),
+		String::from_utf8_lossy(&output.stderr)
+	);
+	assert!(combined.contains("ManifestV1RequiresPatchSet"));
 }

--- a/src/qos_client/tests/golden_artifacts.rs
+++ b/src/qos_client/tests/golden_artifacts.rs
@@ -507,6 +507,7 @@ fn golden_manifest_approval_and_envelope_raw_bytes() {
 }
 
 #[test]
+#[allow(clippy::too_many_lines)]
 fn v2_commands_generate_approve_and_envelope_use_json_hash() {
 	use qos_core::protocol::services::boot::{
 		Approval, ManifestEnvelopeV2, ManifestV2, ManifestVersion,
@@ -610,12 +611,14 @@ fn v2_commands_generate_approve_and_envelope_use_json_hash() {
 			.unwrap();
 	assert_eq!(envelope.manifest.version, ManifestVersion::V2);
 	assert_eq!(envelope.manifest_set_approvals.len(), 1);
-	assert!(P256Public::from_bytes(
-		&envelope.manifest_set_approvals[0].member.pub_key
-	)
-	.unwrap()
-	.verify(&manifest_hash, &envelope.manifest_set_approvals[0].signature)
-	.is_ok());
+	assert!(
+		P256Public::from_bytes(
+			&envelope.manifest_set_approvals[0].member.pub_key
+		)
+		.unwrap()
+		.verify(&manifest_hash, &envelope.manifest_set_approvals[0].signature)
+		.is_ok()
+	);
 }
 
 #[test]

--- a/src/qos_core/Cargo.toml
+++ b/src/qos_core/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 [dependencies]
 qos_crypto = { workspace = true }
 qos_hex = { workspace = true, features = ["serde"] }
+qos_json = { workspace = true }
 qos_p256 = { workspace = true }
 qos_nsm = { workspace = true, default-features = false }
 

--- a/src/qos_core/src/handles.rs
+++ b/src/qos_core/src/handles.rs
@@ -8,7 +8,9 @@ use std::{
 
 use qos_p256::P256Pair;
 
-use crate::protocol::{ProtocolError, services::boot::VersionedManifestEnvelope};
+use crate::protocol::{
+	ProtocolError, services::boot::VersionedManifestEnvelope,
+};
 
 /// Handle for accessing the quorum key.
 #[derive(Debug, Clone)]

--- a/src/qos_core/src/handles.rs
+++ b/src/qos_core/src/handles.rs
@@ -8,7 +8,9 @@ use std::{
 
 use qos_p256::P256Pair;
 
-use crate::protocol::{services::boot::ManifestEnvelope, ProtocolError};
+use crate::protocol::{
+	services::boot::VersionedManifestEnvelope, ProtocolError,
+};
 
 /// Handle for accessing the quorum key.
 #[derive(Debug, Clone)]
@@ -182,11 +184,12 @@ impl Handles {
 	/// Errors if the Manifest has not been put.
 	pub fn get_manifest_envelope(
 		&self,
-	) -> Result<ManifestEnvelope, ProtocolError> {
+	) -> Result<VersionedManifestEnvelope, ProtocolError> {
 		let contents = fs::read(&self.manifest)
 			.map_err(|_| ProtocolError::FailedToGetManifestEnvelope)?;
-		let manifest = serde_json::from_slice(&contents)
-			.map_err(|_| ProtocolError::FailedToGetManifestEnvelope)?;
+		let manifest =
+			VersionedManifestEnvelope::try_from_slice_compat(&contents)
+				.map_err(|_| ProtocolError::FailedToGetManifestEnvelope)?;
 
 		Ok(manifest)
 	}
@@ -196,13 +199,18 @@ impl Handles {
 	/// # Errors
 	///
 	/// Errors if the Manifest has already been put.
-	pub fn put_manifest_envelope(
+	pub fn put_manifest_envelope<E>(
 		&self,
-		manifest_envelope: &ManifestEnvelope,
-	) -> Result<(), ProtocolError> {
+		manifest_envelope: E,
+	) -> Result<(), ProtocolError>
+	where
+		E: Into<VersionedManifestEnvelope>,
+	{
+		let manifest_envelope = manifest_envelope.into();
 		Self::write_as_read_only(
 			&self.manifest,
-			&serde_json::to_vec(manifest_envelope)
+			&manifest_envelope
+				.to_storage_vec()
 				.map_err(|_| ProtocolError::FailedToPutManifestEnvelope)?,
 			ProtocolError::FailedToPutManifestEnvelope,
 		)
@@ -213,7 +221,7 @@ impl Handles {
 	/// **Warning**: This should not be used after pivoting. It is only meant to
 	/// be used when updating the manifest envelope while provisioning.
 	pub(crate) fn mutate_manifest_envelope<
-		F: FnOnce(ManifestEnvelope) -> ManifestEnvelope,
+		F: FnOnce(VersionedManifestEnvelope) -> VersionedManifestEnvelope,
 	>(
 		&self,
 		mutate: F,
@@ -229,7 +237,8 @@ impl Handles {
 		)?;
 		fs::write(
 			&self.manifest,
-			serde_json::to_vec(&manifest_envelope)
+			manifest_envelope
+				.to_storage_vec()
 				.map_err(|_| ProtocolError::FailedToPutManifestEnvelope)?,
 		)
 		.map_err(|_| ProtocolError::FailedToPutManifestEnvelope)?;
@@ -327,8 +336,8 @@ mod test {
 
 	use super::*;
 	use crate::protocol::services::boot::{
-		Manifest, ManifestSet, Namespace, NitroConfig, PatchSet, PivotConfig,
-		RestartPolicy, ShareSet,
+		Manifest, ManifestEnvelope, ManifestSet, Namespace, NitroConfig,
+		PatchSet, PivotConfig, RestartPolicy, ShareSet,
 	};
 
 	#[test]
@@ -464,11 +473,12 @@ mod test {
 			patch_set: PatchSet::default(),
 		};
 
-		let manifest_envelope = ManifestEnvelope {
-			manifest,
-			manifest_set_approvals: vec![],
-			share_set_approvals: vec![],
-		};
+		let manifest_envelope =
+			VersionedManifestEnvelope::V1(ManifestEnvelope {
+				manifest,
+				manifest_set_approvals: vec![],
+				share_set_approvals: vec![],
+			});
 
 		let result = handles.put_manifest_envelope(&manifest_envelope);
 		let error =
@@ -477,6 +487,6 @@ mod test {
 		assert!(result.is_ok());
 		assert_eq!(error, ProtocolError::CannotModifyPostPivotStatic);
 		assert!(handles.manifest_envelope_exists());
-		assert!(handles.get_manifest_envelope().unwrap() == manifest_envelope);
+		assert_eq!(handles.get_manifest_envelope().unwrap(), manifest_envelope);
 	}
 }

--- a/src/qos_core/src/lib.rs
+++ b/src/qos_core/src/lib.rs
@@ -58,4 +58,4 @@ pub const SEC_APP_SOCK: &str = "./local-enclave/sec_app.sock";
 #[cfg(feature = "vm")]
 pub const SEC_APP_SOCK: &str = "/sec_app.sock";
 /// Default socket connect timeout in milliseconds
-pub const DEFAULT_SOCKET_TIMEOUT_MS: &str = "5000";
+pub const DEFAULT_SOCKET_TIMEOUT_MS: &str = "20000";

--- a/src/qos_core/src/protocol/error.rs
+++ b/src/qos_core/src/protocol/error.rs
@@ -9,7 +9,16 @@ use crate::{
 };
 
 /// A error from protocol execution.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+#[derive(
+	Debug,
+	Clone,
+	PartialEq,
+	Eq,
+	BorshSerialize,
+	BorshDeserialize,
+	serde::Serialize,
+	serde::Deserialize,
+)]
 pub enum ProtocolError {
 	/// A encrypted quorum key share sent to the enclave was invalid.
 	InvalidShare,
@@ -141,8 +150,10 @@ pub enum ProtocolError {
 	/// The manifest has a lower nonce then the current manifest.
 	LowNonce {
 		/// Expected minimum nonce value.
+		#[serde(with = "qos_json::string_or_numeric")]
 		expected: u32,
 		/// Actual nonce value.
+		#[serde(with = "qos_json::string_or_numeric")]
 		actual: u32,
 	},
 	/// The manifests have different PCR3 values.

--- a/src/qos_core/src/protocol/msg.rs
+++ b/src/qos_core/src/protocol/msg.rs
@@ -1,6 +1,10 @@
 //! Enclave executor message types.
 
+use std::ops::{Deref, DerefMut};
+
+use borsh::{BorshDeserialize, BorshSerialize};
 use qos_nsm::types::NsmResponse;
+use serde::{de::DeserializeOwned, Serialize};
 
 use crate::protocol::{
 	services::{
@@ -9,6 +13,66 @@ use crate::protocol::{
 	},
 	ProtocolError,
 };
+
+/// Borsh wrapper that carries a Rust value as JSON bytes on the wire.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct JsonBytes<T>(T);
+
+impl<T> JsonBytes<T> {
+	/// Wrap a value for JSON-byte Borsh transport.
+	#[must_use]
+	pub fn new(value: T) -> Self {
+		Self(value)
+	}
+
+	/// Consume the wrapper and return the inner value.
+	#[must_use]
+	pub fn into_inner(self) -> T {
+		self.0
+	}
+}
+
+impl<T> Deref for JsonBytes<T> {
+	type Target = T;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+impl<T> DerefMut for JsonBytes<T> {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		&mut self.0
+	}
+}
+
+impl<T> BorshSerialize for JsonBytes<T>
+where
+	T: Serialize,
+{
+	fn serialize<W: borsh::io::Write>(
+		&self,
+		writer: &mut W,
+	) -> borsh::io::Result<()> {
+		let bytes =
+			serde_json::to_vec(&self.0).map_err(borsh::io::Error::other)?;
+		BorshSerialize::serialize(&bytes, writer)
+	}
+}
+
+impl<T> BorshDeserialize for JsonBytes<T>
+where
+	T: DeserializeOwned,
+{
+	fn deserialize_reader<R: borsh::io::Read>(
+		reader: &mut R,
+	) -> borsh::io::Result<Self> {
+		let bytes = Vec::<u8>::deserialize_reader(reader)?;
+		let value =
+			serde_json::from_slice(&bytes).map_err(borsh::io::Error::other)?;
+		Ok(Self(value))
+	}
+}
 
 /// Encoding used for a protocol message on the host/enclave wire.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -186,6 +250,16 @@ pub enum ProtocolMsg {
 		/// neither was available at build time.
 		commit: String,
 	},
+
+	/// Borsh-only standard boot request with a JSON/storage-encoded manifest
+	/// envelope and raw pivot bytes.
+	#[serde(skip)]
+	BootStandardJsonEnvelopeRequest {
+		/// Manifest envelope encoded as JSON bytes in Borsh.
+		manifest_envelope: Box<JsonBytes<VersionedManifestEnvelope>>,
+		/// Pivot binary.
+		pivot: Vec<u8>,
+	},
 }
 
 impl ProtocolMsg {
@@ -276,6 +350,9 @@ impl std::fmt::Display for ProtocolMsg {
 			}
 			Self::BootStandardRequest { .. } => {
 				write!(f, "BootStandardRequest")
+			}
+			Self::BootStandardJsonEnvelopeRequest { .. } => {
+				write!(f, "BootStandardJsonEnvelopeRequest")
 			}
 			Self::BootStandardResponse { .. } => {
 				write!(f, "BootStandardResponse")
@@ -495,5 +572,50 @@ mod test {
 		assert_eq!(encoding, ProtocolMsgEncoding::Json);
 		assert_eq!(decoded, msg);
 		assert!(msg.to_borsh_wire().is_err());
+	}
+
+	#[test]
+	fn boot_standard_json_envelope_request_is_borsh_only() {
+		let envelope = VersionedManifestEnvelope::V2(ManifestEnvelopeV2 {
+			manifest: ManifestV2 {
+				version: ManifestVersion::V2,
+				namespace: Namespace {
+					name: "test".to_string(),
+					nonce: 1,
+					quorum_key: vec![7; 33],
+				},
+				pivot: PivotConfigV2 {
+					hash: [9; 32],
+					restart: RestartPolicy::Never,
+					bridge_config: vec![],
+					debug_mode: false,
+					args: vec![],
+					env: PivotEnv::new(),
+				},
+				manifest_set: ManifestSet { threshold: 1, members: vec![] },
+				share_set: ShareSet { threshold: 1, members: vec![] },
+				enclave: NitroConfig {
+					pcr0: vec![0; 48],
+					pcr1: vec![1; 48],
+					pcr2: vec![2; 48],
+					pcr3: vec![3; 48],
+					aws_root_certificate: vec![],
+					qos_commit: "commit".to_string(),
+				},
+			},
+			manifest_set_approvals: vec![],
+			share_set_approvals: vec![],
+		});
+		let msg = ProtocolMsg::BootStandardJsonEnvelopeRequest {
+			manifest_envelope: Box::new(JsonBytes::new(envelope)),
+			pivot: vec![1, 2, 3, 4],
+		};
+
+		let encoded = msg.to_borsh_wire().unwrap();
+		let (decoded, encoding) = ProtocolMsg::from_wire(&encoded).unwrap();
+
+		assert_eq!(encoding, ProtocolMsgEncoding::Borsh);
+		assert_eq!(decoded, msg);
+		assert!(msg.to_json_wire().is_err());
 	}
 }

--- a/src/qos_core/src/protocol/msg.rs
+++ b/src/qos_core/src/protocol/msg.rs
@@ -4,7 +4,7 @@ use std::ops::{Deref, DerefMut};
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use qos_nsm::types::NsmResponse;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 
 use crate::protocol::{
 	ProtocolError,

--- a/src/qos_core/src/protocol/msg.rs
+++ b/src/qos_core/src/protocol/msg.rs
@@ -92,6 +92,7 @@ pub enum ProtocolMsgEncoding {
 	serde::Serialize,
 	serde::Deserialize,
 )]
+#[serde(rename_all = "camelCase")]
 pub enum ProtocolMsg {
 	/// A error from executing the protocol.
 	ProtocolErrorResponse(ProtocolError),

--- a/src/qos_core/src/protocol/msg.rs
+++ b/src/qos_core/src/protocol/msg.rs
@@ -92,7 +92,6 @@ pub enum ProtocolMsgEncoding {
 	serde::Serialize,
 	serde::Deserialize,
 )]
-#[serde(rename_all = "camelCase")]
 pub enum ProtocolMsg {
 	/// A error from executing the protocol.
 	ProtocolErrorResponse(ProtocolError),

--- a/src/qos_core/src/protocol/msg.rs
+++ b/src/qos_core/src/protocol/msg.rs
@@ -4,14 +4,31 @@ use qos_nsm::types::NsmResponse;
 
 use crate::protocol::{
 	services::{
-		boot::{Approval, ManifestEnvelope},
+		boot::{Approval, VersionedManifestEnvelope},
 		genesis::{GenesisOutput, GenesisSet},
 	},
 	ProtocolError,
 };
 
+/// Encoding used for a protocol message on the host/enclave wire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProtocolMsgEncoding {
+	/// Canonical QOS JSON.
+	Json,
+	/// Legacy Borsh.
+	Borsh,
+}
+
 /// Message types for communicating with protocol executor.
-#[derive(Debug, PartialEq, borsh::BorshSerialize, borsh::BorshDeserialize)]
+#[derive(
+	Debug,
+	PartialEq,
+	borsh::BorshSerialize,
+	borsh::BorshDeserialize,
+	serde::Serialize,
+	serde::Deserialize,
+)]
+#[serde(rename_all = "camelCase")]
 pub enum ProtocolMsg {
 	/// A error from executing the protocol.
 	ProtocolErrorResponse(ProtocolError),
@@ -24,8 +41,9 @@ pub enum ProtocolMsg {
 	/// Execute Standard Boot.
 	BootStandardRequest {
 		/// Manifest with approvals
-		manifest_envelope: Box<ManifestEnvelope>,
+		manifest_envelope: Box<VersionedManifestEnvelope>,
 		/// Pivot binary
+		#[serde(with = "qos_hex::serde")]
 		pivot: Vec<u8>,
 	},
 	/// Response for Standard Boot.
@@ -40,6 +58,11 @@ pub enum ProtocolMsg {
 		set: GenesisSet,
 		/// Optionally include a `qos_p256::P256Public` key for encrypting the
 		/// quorum key too. Intended for disaster recovery.
+		#[serde(
+			default,
+			skip_serializing_if = "Option::is_none",
+			with = "qos_hex::serde::option"
+		)]
 		dr_key: Option<Vec<u8>>,
 	},
 	/// Response for Genesis Boot.
@@ -53,6 +76,7 @@ pub enum ProtocolMsg {
 	/// Post a quorum key shard
 	ProvisionRequest {
 		/// Quorum Key share encrypted to the Ephemeral Key.
+		#[serde(with = "qos_hex::serde")]
 		share: Vec<u8>,
 		/// Approval of the manifest from a member of the share set.
 		approval: Approval,
@@ -68,12 +92,14 @@ pub enum ProtocolMsg {
 	ProxyRequest {
 		/// Encoded data that will be sent from the nitro enclave server to
 		/// the secure app.
+		#[serde(with = "qos_hex::serde")]
 		data: Vec<u8>,
 	},
 	/// Response to the proxy request
 	ProxyResponse {
 		/// Encoded data the secure app responded with to the nitro enclave
 		/// server.
+		#[serde(with = "qos_hex::serde")]
 		data: Vec<u8>,
 	},
 
@@ -85,14 +111,16 @@ pub enum ProtocolMsg {
 		/// COSE SIGN1 structure with Attestation Doc
 		nsm_response: NsmResponse,
 		/// Manifest Envelope, if it exists, otherwise None.
-		manifest_envelope: Option<Box<ManifestEnvelope>>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		manifest_envelope: Option<Box<VersionedManifestEnvelope>>,
 	},
 
 	/// Execute a key forward attestation request
 	BootKeyForwardRequest {
 		/// Manifest with approvals
-		manifest_envelope: Box<ManifestEnvelope>,
+		manifest_envelope: Box<VersionedManifestEnvelope>,
 		/// Pivot binary
+		#[serde(with = "qos_hex::serde")]
 		pivot: Vec<u8>,
 	},
 	/// Response to a key forward attestation request
@@ -104,18 +132,21 @@ pub enum ProtocolMsg {
 	/// Request a quorum key as part of the "key forwarding" flow.
 	ExportKeyRequest {
 		/// Manifest of the enclave requesting the quorum key.
-		manifest_envelope: Box<ManifestEnvelope>,
+		manifest_envelope: Box<VersionedManifestEnvelope>,
 		/// Attestation document from the enclave requesting the quorum key. We
 		/// assume this attestation document contains a hash of the given
 		/// manifest in the user data field.
+		#[serde(with = "qos_hex::serde")]
 		cose_sign1_attestation_doc: Vec<u8>,
 	},
 	/// Response to [`Self::ExportKeyRequest`]
 	ExportKeyResponse {
 		/// Quorum key encrypted to the Ephemeral Key from the submitted
 		/// attestation document.
+		#[serde(with = "qos_hex::serde")]
 		encrypted_quorum_key: Vec<u8>,
 		/// Signature over the encrypted quorum key.
+		#[serde(with = "qos_hex::serde")]
 		signature: Vec<u8>,
 	},
 
@@ -123,8 +154,10 @@ pub enum ProtocolMsg {
 	InjectKeyRequest {
 		/// Quorum key encrypted to the Ephemeral Key of the enclave this
 		/// request is being sent to.
+		#[serde(with = "qos_hex::serde")]
 		encrypted_quorum_key: Vec<u8>,
 		/// Signature over the encrypted quorum key.
+		#[serde(with = "qos_hex::serde")]
 		signature: Vec<u8>,
 	},
 	/// Successful response to [`Self::InjectKeyRequest`].
@@ -136,7 +169,8 @@ pub enum ProtocolMsg {
 	ManifestEnvelopeResponse {
 		/// The manifest envelope used to boot the enclave. This will be `None`
 		/// if the manifest envelope does not exist.
-		manifest_envelope: Box<Option<ManifestEnvelope>>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		manifest_envelope: Box<Option<VersionedManifestEnvelope>>,
 	},
 
 	/// Request the QOS version and git commit of the running enclave.
@@ -152,6 +186,82 @@ pub enum ProtocolMsg {
 		/// neither was available at build time.
 		commit: String,
 	},
+}
+
+impl ProtocolMsg {
+	/// Decode a protocol message from canonical JSON or legacy Borsh bytes.
+	///
+	/// JSON is attempted first because it is the preferred wire format and it
+	/// can represent v2 manifests. Borsh remains accepted for backwards
+	/// compatibility with existing hosts and clients.
+	///
+	/// # Errors
+	///
+	/// Returns [`ProtocolError::ProtocolMsgDeserialization`] when `bytes`
+	/// cannot be decoded as either canonical JSON or legacy Borsh.
+	pub fn from_wire(
+		bytes: &[u8],
+	) -> Result<(Self, ProtocolMsgEncoding), ProtocolError> {
+		if let Ok(msg) = qos_json::from_slice(bytes) {
+			return Ok((msg, ProtocolMsgEncoding::Json));
+		}
+
+		<Self as borsh::BorshDeserialize>::try_from_slice(bytes)
+			.map(|msg| (msg, ProtocolMsgEncoding::Borsh))
+			.map_err(|_| ProtocolError::ProtocolMsgDeserialization)
+	}
+
+	/// Decode a protocol message from canonical JSON or legacy Borsh bytes,
+	/// discarding the detected encoding.
+	///
+	/// # Errors
+	///
+	/// Returns [`ProtocolError::ProtocolMsgDeserialization`] when `bytes`
+	/// cannot be decoded as either canonical JSON or legacy Borsh.
+	pub fn from_wire_any(bytes: &[u8]) -> Result<Self, ProtocolError> {
+		Self::from_wire(bytes).map(|(msg, _)| msg)
+	}
+
+	/// Encode this message in the requested wire format.
+	///
+	/// Legacy Borsh encoding cannot represent v2 manifests and returns an
+	/// error for messages that contain them.
+	///
+	/// # Errors
+	///
+	/// Returns [`ProtocolError::InvalidMsg`] when the message cannot be
+	/// encoded in the requested wire format.
+	pub fn to_wire(
+		&self,
+		encoding: ProtocolMsgEncoding,
+	) -> Result<Vec<u8>, ProtocolError> {
+		match encoding {
+			ProtocolMsgEncoding::Json => {
+				qos_json::to_vec(self).map_err(|_| ProtocolError::InvalidMsg)
+			}
+			ProtocolMsgEncoding::Borsh => {
+				borsh::to_vec(self).map_err(|_| ProtocolError::InvalidMsg)
+			}
+		}
+	}
+
+	/// Encode this message as canonical QOS JSON.
+	///
+	/// # Errors
+	///
+	/// Returns [`ProtocolError::InvalidMsg`] if JSON encoding fails.
+	pub fn to_json_wire(&self) -> Result<Vec<u8>, ProtocolError> {
+		self.to_wire(ProtocolMsgEncoding::Json)
+	}
+
+	/// Encode this message as legacy Borsh.
+	///
+	/// # Errors
+	///
+	/// Returns [`ProtocolError::InvalidMsg`] if Borsh encoding fails.
+	pub fn to_borsh_wire(&self) -> Result<Vec<u8>, ProtocolError> {
+		self.to_wire(ProtocolMsgEncoding::Borsh)
+	}
 }
 
 impl std::fmt::Display for ProtocolMsg {
@@ -247,8 +357,14 @@ impl std::fmt::Display for ProtocolMsg {
 #[cfg(test)]
 mod test {
 	use borsh::BorshDeserialize;
+	use std::collections::BTreeSet;
 
 	use super::*;
+	use crate::protocol::services::boot::{
+		ManifestEnvelopeV2, ManifestSet, ManifestV2, ManifestVersion,
+		Namespace, NitroConfig, PivotConfigV2, PivotEnv, RestartPolicy,
+		ShareSet,
+	};
 
 	#[test]
 	fn boot_genesis_response_deserialize() {
@@ -300,5 +416,84 @@ mod test {
 		let decoded = ProtocolMsg::try_from_slice(&vec).unwrap();
 
 		assert_eq!(msg, decoded);
+	}
+
+	#[test]
+	fn json_wire_round_trips_numeric_protocol_payloads() {
+		let msg = ProtocolMsg::BootGenesisResponse {
+			nsm_response: NsmResponse::DescribeNSM {
+				version_major: 1,
+				version_minor: 2,
+				version_patch: 3,
+				module_id: "module".to_string(),
+				max_pcrs: 32,
+				locked_pcrs: BTreeSet::from([0, 1, 2]),
+				digest: qos_nsm::types::NsmDigest::SHA384,
+			},
+			genesis_output: Box::new(GenesisOutput {
+				quorum_key: vec![3, 2, 1],
+				member_outputs: vec![],
+				recovery_permutations: vec![],
+				threshold: 2,
+				dr_key_wrapped_quorum_key: None,
+				quorum_key_hash: [22; 64],
+				test_message_ciphertext: vec![],
+				test_message_signature: vec![],
+				test_message: vec![],
+			}),
+		};
+
+		let encoded = msg.to_json_wire().unwrap();
+		let (decoded, encoding) = ProtocolMsg::from_wire(&encoded).unwrap();
+
+		assert_eq!(encoding, ProtocolMsgEncoding::Json);
+		assert_eq!(decoded, msg);
+	}
+
+	#[test]
+	fn v2_manifest_envelope_is_json_wire_only() {
+		let manifest = ManifestV2 {
+			version: ManifestVersion::V2,
+			namespace: Namespace {
+				name: "test".to_string(),
+				nonce: 1,
+				quorum_key: vec![7; 33],
+			},
+			pivot: PivotConfigV2 {
+				hash: [9; 32],
+				restart: RestartPolicy::Never,
+				bridge_config: vec![],
+				debug_mode: false,
+				args: vec![],
+				env: PivotEnv::new(),
+			},
+			manifest_set: ManifestSet { threshold: 1, members: vec![] },
+			share_set: ShareSet { threshold: 1, members: vec![] },
+			enclave: NitroConfig {
+				pcr0: vec![0; 48],
+				pcr1: vec![1; 48],
+				pcr2: vec![2; 48],
+				pcr3: vec![3; 48],
+				aws_root_certificate: vec![],
+				qos_commit: "commit".to_string(),
+			},
+		};
+		let msg = ProtocolMsg::BootStandardRequest {
+			manifest_envelope: Box::new(VersionedManifestEnvelope::V2(
+				ManifestEnvelopeV2 {
+					manifest,
+					manifest_set_approvals: vec![],
+					share_set_approvals: vec![],
+				},
+			)),
+			pivot: vec![],
+		};
+
+		let encoded = msg.to_json_wire().unwrap();
+		let (decoded, encoding) = ProtocolMsg::from_wire(&encoded).unwrap();
+
+		assert_eq!(encoding, ProtocolMsgEncoding::Json);
+		assert_eq!(decoded, msg);
+		assert!(msg.to_borsh_wire().is_err());
 	}
 }

--- a/src/qos_core/src/protocol/msg.rs
+++ b/src/qos_core/src/protocol/msg.rs
@@ -438,9 +438,9 @@ mod test {
 
 	use super::*;
 	use crate::protocol::services::boot::{
-		ManifestEnvelopeV2, ManifestSet, ManifestV2, ManifestVersion,
-		Namespace, NitroConfig, PivotConfigV2, PivotEnv, RestartPolicy,
-		ShareSet,
+		Manifest, ManifestEnvelope, ManifestEnvelopeV2, ManifestSet,
+		ManifestV2, ManifestVersion, Namespace, NitroConfig, PatchSet,
+		PivotConfig, PivotConfigV2, PivotEnv, RestartPolicy, ShareSet,
 	};
 
 	#[test]
@@ -617,5 +617,49 @@ mod test {
 		assert_eq!(encoding, ProtocolMsgEncoding::Borsh);
 		assert_eq!(decoded, msg);
 		assert!(msg.to_json_wire().is_err());
+	}
+
+	#[test]
+	fn borsh_variant_discriminants_preserve_legacy_boot_standard_request() {
+		let msg = ProtocolMsg::BootStandardRequest {
+			manifest_envelope: Box::new(VersionedManifestEnvelope::V1(
+				ManifestEnvelope {
+					manifest: Manifest {
+						namespace: Namespace {
+							name: "test".to_string(),
+							nonce: 1,
+							quorum_key: vec![7; 33],
+						},
+						pivot: PivotConfig {
+							hash: [9; 32],
+							restart: RestartPolicy::Never,
+							args: vec![],
+							bridge_config: vec![],
+							debug_mode: false,
+						},
+						enclave: NitroConfig {
+							pcr0: vec![0; 48],
+							pcr1: vec![1; 48],
+							pcr2: vec![2; 48],
+							pcr3: vec![3; 48],
+							aws_root_certificate: vec![],
+							qos_commit: "commit".to_string(),
+						},
+						manifest_set: ManifestSet {
+							threshold: 1,
+							members: vec![],
+						},
+						share_set: ShareSet { threshold: 1, members: vec![] },
+						patch_set: PatchSet { threshold: 0, members: vec![] },
+					},
+					manifest_set_approvals: vec![],
+					share_set_approvals: vec![],
+				},
+			)),
+			pivot: vec![1, 2, 3, 4],
+		};
+
+		let encoded = msg.to_borsh_wire().unwrap();
+		assert_eq!(encoded.first().copied(), Some(3));
 	}
 }

--- a/src/qos_core/src/protocol/processor.rs
+++ b/src/qos_core/src/protocol/processor.rs
@@ -1,7 +1,5 @@
 //! Quorum protocol processor
 
-use borsh::BorshDeserialize;
-
 use super::{
 	error::ProtocolError, msg::ProtocolMsg, SharedProtocolState,
 	MAX_ENCODED_MSG_LEN,
@@ -25,20 +23,91 @@ impl ProtocolProcessor {
 impl RequestProcessor for ProtocolProcessor {
 	async fn process(&self, req_bytes: &[u8]) -> Vec<u8> {
 		if req_bytes.len() > MAX_ENCODED_MSG_LEN {
-			return borsh::to_vec(&ProtocolMsg::ProtocolErrorResponse(
+			return ProtocolMsg::ProtocolErrorResponse(
 				ProtocolError::OversizedPayload,
-			))
-			.expect("ProtocolMsg can always be serialized. qed.");
+			)
+			.to_json_wire()
+			.expect("ProtocolMsg can always serialize to JSON. qed.");
 		}
 
-		let Ok(msg_req) = ProtocolMsg::try_from_slice(req_bytes) else {
-			return borsh::to_vec(&ProtocolMsg::ProtocolErrorResponse(
+		let Ok((msg_req, encoding)) = ProtocolMsg::from_wire(req_bytes) else {
+			return ProtocolMsg::ProtocolErrorResponse(
 				ProtocolError::ProtocolMsgDeserialization,
-			))
-			.expect("ProtocolMsg can always be serialized. qed.");
+			)
+			.to_json_wire()
+			.expect("ProtocolMsg can always serialize to JSON. qed.");
 		};
 
 		let mut state = self.state.write().await;
-		tokio::task::block_in_place(|| state.handle_msg(&msg_req))
+		let response =
+			tokio::task::block_in_place(|| state.handle_msg_response(&msg_req));
+		response.to_wire(encoding).unwrap_or_else(|_| {
+			ProtocolMsg::ProtocolErrorResponse(ProtocolError::InvalidMsg)
+				.to_json_wire()
+				.expect("ProtocolMsg can always serialize to JSON. qed.")
+		})
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use borsh::BorshDeserialize;
+	use qos_nsm::mock::MockNsm;
+
+	use super::*;
+	use crate::{
+		handles::Handles,
+		protocol::{ProtocolPhase, ProtocolState},
+		server::RequestProcessor,
+	};
+
+	fn test_state() -> SharedProtocolState {
+		let root = std::env::temp_dir().join(format!(
+			"qos-protocol-processor-test-{}",
+			std::process::id()
+		));
+		std::fs::create_dir_all(&root).unwrap();
+		ProtocolState::new(
+			Box::new(MockNsm),
+			Handles::new(
+				root.join("ephemeral").to_string_lossy().into_owned(),
+				root.join("quorum").to_string_lossy().into_owned(),
+				root.join("manifest").to_string_lossy().into_owned(),
+				root.join("pivot").to_string_lossy().into_owned(),
+			),
+			None,
+		)
+		.shared()
+	}
+
+	#[tokio::test(flavor = "multi_thread")]
+	async fn json_request_gets_json_response() {
+		let processor = ProtocolProcessor::new(test_state());
+		let req = ProtocolMsg::StatusRequest.to_json_wire().unwrap();
+		let resp = processor.process(&req).await;
+
+		let (msg, encoding) = ProtocolMsg::from_wire(&resp).unwrap();
+		assert_eq!(encoding, super::super::msg::ProtocolMsgEncoding::Json);
+		assert_eq!(
+			msg,
+			ProtocolMsg::StatusResponse(
+				ProtocolPhase::WaitingForBootInstruction
+			)
+		);
+	}
+
+	#[tokio::test(flavor = "multi_thread")]
+	async fn borsh_request_gets_borsh_response() {
+		let processor = ProtocolProcessor::new(test_state());
+		let req = ProtocolMsg::StatusRequest.to_borsh_wire().unwrap();
+		let resp = processor.process(&req).await;
+
+		let msg = ProtocolMsg::try_from_slice(&resp).unwrap();
+		assert_eq!(
+			msg,
+			ProtocolMsg::StatusResponse(
+				ProtocolPhase::WaitingForBootInstruction
+			)
+		);
 	}
 }

--- a/src/qos_core/src/protocol/services/attestation.rs
+++ b/src/qos_core/src/protocol/services/attestation.rs
@@ -3,7 +3,7 @@ use qos_nsm::{
 	NsmProvider,
 };
 
-use crate::protocol::{ProtocolError, ProtocolState, QosHash};
+use crate::protocol::{ProtocolError, ProtocolState};
 
 pub(in crate::protocol) fn live_attestation_doc(
 	state: &mut ProtocolState,
@@ -11,7 +11,7 @@ pub(in crate::protocol) fn live_attestation_doc(
 	let ephemeral_public_key =
 		state.handles.get_ephemeral_key()?.public_key().to_bytes();
 	let manifest_hash =
-		state.handles.get_manifest_envelope()?.manifest.qos_hash().to_vec();
+		state.handles.get_manifest_envelope()?.manifest_hash().to_vec();
 
 	Ok(get_post_boot_attestation_doc(
 		&*state.attestor,

--- a/src/qos_core/src/protocol/services/boot.rs
+++ b/src/qos_core/src/protocol/services/boot.rs
@@ -11,9 +11,14 @@ use crate::protocol::{
 };
 
 pub mod env;
+pub mod manifest;
 pub use env::{
 	PivotEnv, PivotEnvValue, PivotEnvVarName, MAX_PIVOT_ENV_NAME_LEN,
 	MAX_PIVOT_ENV_VALUE_LEN, MAX_PIVOT_ENV_VARS,
+};
+pub use manifest::v2::{ManifestEnvelopeV2, ManifestV2, PivotConfigV2};
+pub use manifest::{
+	ManifestVersion, VersionedManifest, VersionedManifestEnvelope,
 };
 
 /// Enclave configuration specific to AWS Nitro.
@@ -112,6 +117,7 @@ impl TryFrom<String> for RestartPolicy {
 #[derive(
 	PartialEq,
 	Eq,
+	Debug,
 	Clone,
 	serde::Serialize,
 	serde::Deserialize,
@@ -124,6 +130,7 @@ pub enum BridgeConfig {
 	/// Server hosting bridge, connections go INTO the enclave app on given port and host binding
 	Server {
 		/// The port to listen on, matching on host and app sides
+		#[serde(with = "qos_json::string_or_numeric")]
 		port: u16,
 		/// The host ip to listen on, use `0.0.0.0` for any
 		host: String,
@@ -133,9 +140,11 @@ pub enum BridgeConfig {
 	/// *NOTE*: currently **unimplemented** and results in boot panic if set.
 	Client {
 		/// Port to connect to when app initiates outgoing connections.
+		#[serde(with = "qos_json::string_or_numeric")]
 		port: u16,
 		/// Host name to connect to when app initiates outgoing connections.
 		/// If `None` an internal protocol is used to determine the destination (**unimplemented**)
+		#[serde(default, skip_serializing_if = "Option::is_none")]
 		host: Option<String>,
 	},
 }
@@ -287,6 +296,7 @@ impl fmt::Debug for QuorumMember {
 #[cfg_attr(any(feature = "mock", test), derive(Default))]
 pub struct ManifestSet {
 	/// The threshold, K, of signatures necessary to have quorum.
+	#[serde(with = "qos_json::string_or_numeric")]
 	pub threshold: u32,
 	/// Members composing the set. The length of this, N, must be gte to the
 	/// `threshold`, K.
@@ -308,6 +318,7 @@ pub struct ManifestSet {
 #[cfg_attr(any(feature = "mock", test), derive(Default))]
 pub struct ShareSet {
 	/// The threshold, K, of signatures necessary to have quorum.
+	#[serde(with = "qos_json::string_or_numeric")]
 	pub threshold: u32,
 	/// Members composing the set. The length of this, N, must be gte to the
 	/// `threshold`, K.
@@ -356,6 +367,7 @@ impl fmt::Debug for MemberPubKey {
 #[cfg_attr(any(feature = "mock", test), derive(Default))]
 pub struct PatchSet {
 	/// The threshold, K, of signatures necessary to have quorum.
+	#[serde(with = "qos_json::string_or_numeric")]
 	pub threshold: u32,
 	/// Public keys of members composing the set. The length of this, N, must
 	/// be gte to the `threshold`, K.
@@ -382,6 +394,7 @@ pub struct Namespace {
 	/// manifests for this namespace have been created. This is used to prevent
 	/// downgrade attacks - quorum members should only approve a manifest that
 	/// has the highest nonce.
+	#[serde(with = "qos_json::string_or_numeric")]
 	pub nonce: u32,
 	/// Quorum Key
 	#[serde(with = "qos_hex::serde")]
@@ -443,6 +456,7 @@ pub struct Manifest {
 	Clone,
 	borsh::BorshSerialize,
 	borsh::BorshDeserialize,
+	serde::Serialize,
 	serde::Deserialize,
 )]
 #[serde(rename_all = "camelCase")]
@@ -577,7 +591,14 @@ pub struct ManifestEnvelope {
 
 /// [`ManifestV0`] with accompanying [`Approval`]s.
 #[derive(
-	PartialEq, Eq, Debug, Clone, borsh::BorshSerialize, borsh::BorshDeserialize,
+	PartialEq,
+	Eq,
+	Debug,
+	Clone,
+	borsh::BorshSerialize,
+	borsh::BorshDeserialize,
+	serde::Serialize,
+	serde::Deserialize,
 )]
 #[cfg_attr(any(feature = "mock", test), derive(Default))]
 pub struct ManifestEnvelopeV0 {
@@ -603,6 +624,7 @@ impl ManifestEnvelope {
 	/// [`ProtocolError::NotEnoughApprovals`] if fewer than the threshold
 	/// number of members approved.
 	pub fn check_approvals(&self) -> Result<(), ProtocolError> {
+		let manifest_hash = self.manifest.qos_hash();
 		let mut uniq_members = HashSet::new();
 		for approval in &self.manifest_set_approvals {
 			let member_pub_key =
@@ -610,7 +632,7 @@ impl ManifestEnvelope {
 
 			// Ensure that this is a valid signature from the member
 			let is_valid_signature = member_pub_key
-				.verify(&self.manifest.qos_hash(), &approval.signature)
+				.verify(&manifest_hash, &approval.signature)
 				.is_ok();
 			if !is_valid_signature {
 				return Err(ProtocolError::InvalidManifestApproval(
@@ -668,16 +690,16 @@ impl ManifestEnvelope {
 
 pub(in crate::protocol::services) fn put_manifest_and_pivot(
 	state: &mut ProtocolState,
-	manifest_envelope: &ManifestEnvelope,
+	manifest_envelope: &VersionedManifestEnvelope,
 	pivot: &[u8],
 ) -> Result<NsmResponse, ProtocolError> {
 	// 1. Check signatures over the manifest envelope.
 	manifest_envelope.check_approvals()?;
-	if !manifest_envelope.share_set_approvals.is_empty() {
+	if !manifest_envelope.share_set_approvals().is_empty() {
 		return Err(ProtocolError::BadShareSetApprovals);
 	}
 	let actual_hash = sha_256(pivot);
-	let expected_hash = manifest_envelope.manifest.pivot.hash;
+	let expected_hash = *manifest_envelope.pivot_hash();
 	if actual_hash != expected_hash {
 		return Err(ProtocolError::InvalidPivotHash {
 			expected: qos_hex::encode(&expected_hash),
@@ -697,7 +719,7 @@ pub(in crate::protocol::services) fn put_manifest_and_pivot(
 	let nsm_response = attestation::get_post_boot_attestation_doc(
 		&*state.attestor,
 		ephemeral_key.public_key().to_bytes(),
-		manifest_envelope.manifest.qos_hash().to_vec(),
+		manifest_envelope.manifest_hash().to_vec(),
 	);
 
 	// 4. Return the NSM Response containing COSE Sign1 encoded attestation
@@ -707,10 +729,12 @@ pub(in crate::protocol::services) fn put_manifest_and_pivot(
 
 pub(in crate::protocol) fn boot_standard(
 	state: &mut ProtocolState,
-	manifest_envelope: &ManifestEnvelope,
+	manifest_envelope: impl Into<VersionedManifestEnvelope>,
 	pivot: &[u8],
 ) -> Result<NsmResponse, ProtocolError> {
-	let nsm_response = put_manifest_and_pivot(state, manifest_envelope, pivot)?;
+	let manifest_envelope = manifest_envelope.into();
+	let nsm_response =
+		put_manifest_and_pivot(state, &manifest_envelope, pivot)?;
 	Ok(nsm_response)
 }
 
@@ -980,7 +1004,10 @@ mod test {
 		assert!(Path::new(&pivot_file).exists());
 		assert!(Path::new(&ephemeral_file).exists());
 
-		assert_eq!(handles.get_manifest_envelope().unwrap(), manifest_envelope);
+		assert_eq!(
+			handles.get_manifest_envelope().unwrap(),
+			VersionedManifestEnvelope::V1(manifest_envelope)
+		);
 
 		std::fs::remove_file(pivot_file).unwrap();
 		std::fs::remove_file(ephemeral_file).unwrap();

--- a/src/qos_core/src/protocol/services/boot/manifest.rs
+++ b/src/qos_core/src/protocol/services/boot/manifest.rs
@@ -1,0 +1,639 @@
+//! Versioned manifest helpers.
+
+use std::io::Error;
+
+use borsh::{BorshDeserialize, BorshSerialize};
+
+use crate::protocol::{Hash256, ProtocolError, QosHash};
+
+use super::{
+	Approval, BridgeConfig, Manifest, ManifestEnvelope, ManifestEnvelopeV0,
+	ManifestSet, ManifestV0, Namespace, NitroConfig, RestartPolicy, ShareSet,
+};
+
+pub mod v2;
+
+pub use v2::{ManifestEnvelopeV2, ManifestV2};
+
+/// Schema marker included only in v2 manifests.
+#[derive(
+	PartialEq, Eq, Debug, Clone, Copy, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "camelCase")]
+pub enum ManifestVersion {
+	/// Explicitly versioned JSON manifest schema.
+	V2,
+}
+
+/// Hash a serde value using canonical QOS JSON.
+///
+/// # Panics
+///
+/// Panics if `value` fails serialization, which would indicate a bug because
+/// callers pass serde-serializable protocol types.
+#[must_use]
+pub fn canonical_json_hash<T: serde::Serialize>(value: &T) -> Hash256 {
+	qos_json::hash(value).expect("Implements serde serialize")
+}
+
+/// A manifest decoded with schema version preserved.
+#[derive(PartialEq, Eq, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+pub enum VersionedManifest {
+	/// Explicitly versioned JSON manifest schema.
+	V2(ManifestV2),
+	/// Backwards-compatible manifest schema.
+	V1(Manifest),
+	/// Legacy original manifest schema.
+	V0(ManifestV0),
+}
+
+impl From<ManifestV2> for VersionedManifest {
+	fn from(value: ManifestV2) -> Self {
+		Self::V2(value)
+	}
+}
+
+impl From<Manifest> for VersionedManifest {
+	fn from(value: Manifest) -> Self {
+		Self::V1(value)
+	}
+}
+
+impl From<ManifestV0> for VersionedManifest {
+	fn from(value: ManifestV0) -> Self {
+		Self::V0(value)
+	}
+}
+
+// NOTE: This is intentionally "illegal" for the v2 variant: v2 is JSON-only,
+// but we still implement Borsh traits on the enum for v1/v0 backcompat.
+impl BorshSerialize for VersionedManifest {
+	fn serialize<W: borsh::io::Write>(
+		&self,
+		writer: &mut W,
+	) -> borsh::io::Result<()> {
+		match self {
+			Self::V2(_) => Err(borsh::io::Error::other(
+				"manifest v2 is json-only and cannot be borsh serialized",
+			)),
+			Self::V1(manifest) => manifest.serialize(writer),
+			Self::V0(manifest) => manifest.serialize(writer),
+		}
+	}
+}
+
+impl BorshDeserialize for VersionedManifest {
+	fn deserialize_reader<R: borsh::io::Read>(
+		reader: &mut R,
+	) -> borsh::io::Result<Self> {
+		let mut buf = vec![];
+		reader.read_to_end(&mut buf)?;
+		if let Ok(manifest) = Manifest::try_from_slice(&buf) {
+			return Ok(Self::V1(manifest));
+		}
+		if let Ok(manifest) = ManifestV0::try_from_slice(&buf) {
+			return Ok(Self::V0(manifest));
+		}
+		Err(borsh::io::Error::other("failed to decode borsh manifest as v1/v0"))
+	}
+}
+
+#[allow(missing_docs)]
+impl VersionedManifest {
+	#[must_use]
+	pub fn manifest_hash(&self) -> Hash256 {
+		match self {
+			Self::V2(manifest) => canonical_json_hash(manifest),
+			Self::V1(manifest) => manifest.qos_hash(),
+			Self::V0(manifest) => manifest.qos_hash(),
+		}
+	}
+
+	#[must_use]
+	pub fn namespace(&self) -> &Namespace {
+		match self {
+			Self::V2(manifest) => &manifest.namespace,
+			Self::V1(manifest) => &manifest.namespace,
+			Self::V0(manifest) => &manifest.namespace,
+		}
+	}
+
+	#[must_use]
+	pub fn manifest_set(&self) -> &ManifestSet {
+		match self {
+			Self::V2(manifest) => &manifest.manifest_set,
+			Self::V1(manifest) => &manifest.manifest_set,
+			Self::V0(manifest) => &manifest.manifest_set,
+		}
+	}
+
+	#[must_use]
+	pub fn share_set(&self) -> &ShareSet {
+		match self {
+			Self::V2(manifest) => &manifest.share_set,
+			Self::V1(manifest) => &manifest.share_set,
+			Self::V0(manifest) => &manifest.share_set,
+		}
+	}
+
+	#[must_use]
+	pub fn enclave(&self) -> &NitroConfig {
+		match self {
+			Self::V2(manifest) => &manifest.enclave,
+			Self::V1(manifest) => &manifest.enclave,
+			Self::V0(manifest) => &manifest.enclave,
+		}
+	}
+
+	#[must_use]
+	pub fn pivot_hash(&self) -> &Hash256 {
+		match self {
+			Self::V2(manifest) => &manifest.pivot.hash,
+			Self::V1(manifest) => &manifest.pivot.hash,
+			Self::V0(manifest) => &manifest.pivot.hash,
+		}
+	}
+
+	#[must_use]
+	pub fn restart(&self) -> RestartPolicy {
+		match self {
+			Self::V2(manifest) => manifest.pivot.restart,
+			Self::V1(manifest) => manifest.pivot.restart,
+			Self::V0(manifest) => manifest.pivot.restart,
+		}
+	}
+
+	#[must_use]
+	pub fn args(&self) -> &[String] {
+		match self {
+			Self::V2(manifest) => &manifest.pivot.args,
+			Self::V1(manifest) => &manifest.pivot.args,
+			Self::V0(manifest) => &manifest.pivot.args,
+		}
+	}
+
+	#[must_use]
+	pub fn bridge_config(&self) -> &[BridgeConfig] {
+		match self {
+			Self::V2(manifest) => &manifest.pivot.bridge_config,
+			Self::V1(manifest) => &manifest.pivot.bridge_config,
+			Self::V0(_) => &[],
+		}
+	}
+
+	#[must_use]
+	pub fn debug_mode(&self) -> bool {
+		match self {
+			Self::V2(manifest) => manifest.pivot.debug_mode,
+			Self::V1(manifest) => manifest.pivot.debug_mode,
+			Self::V0(_) => false,
+		}
+	}
+
+	/// Read a manifest while preserving the recognized schema version.
+	///
+	/// # Errors
+	///
+	/// Returns an [`std::io::Error`] when the bytes cannot be decoded as any
+	/// supported manifest schema or encoding.
+	pub fn try_from_slice_compat(buf: &[u8]) -> Result<Self, Error> {
+		if let Ok(manifest) = serde_json::from_slice::<ManifestV2>(buf) {
+			return Ok(Self::V2(manifest));
+		}
+		if let Ok(manifest) = serde_json::from_slice::<Manifest>(buf) {
+			return Ok(Self::V1(manifest));
+		}
+		if let Ok(manifest) = serde_json::from_slice::<ManifestV0>(buf) {
+			return Ok(Self::V0(manifest));
+		}
+		if let Ok(manifest) = Manifest::try_from_slice(buf) {
+			return Ok(Self::V1(manifest));
+		}
+
+		ManifestV0::try_from_slice(buf)
+			.map(Self::V0)
+			.map_err(|e| Error::other(e.to_string()))
+	}
+
+	/// Serialize this manifest using its storage encoding.
+	///
+	/// # Errors
+	///
+	/// Returns an [`std::io::Error`] when serialization fails.
+	pub fn to_storage_vec(&self) -> Result<Vec<u8>, Error> {
+		match self {
+			Self::V2(manifest) => qos_json::to_vec(manifest)
+				.map_err(|e| Error::other(e.to_string())),
+			Self::V1(manifest) => serde_json::to_vec(manifest)
+				.map_err(|e| Error::other(e.to_string())),
+			Self::V0(manifest) => serde_json::to_vec(manifest)
+				.map_err(|e| Error::other(e.to_string())),
+		}
+	}
+}
+
+/// A manifest envelope decoded with schema version preserved.
+#[derive(PartialEq, Eq, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+pub enum VersionedManifestEnvelope {
+	/// Explicitly versioned JSON manifest envelope schema.
+	V2(ManifestEnvelopeV2),
+	/// Backwards-compatible manifest envelope schema.
+	V1(ManifestEnvelope),
+	/// Legacy original manifest envelope schema.
+	V0(ManifestEnvelopeV0),
+}
+
+impl From<ManifestEnvelopeV2> for VersionedManifestEnvelope {
+	fn from(value: ManifestEnvelopeV2) -> Self {
+		Self::V2(value)
+	}
+}
+
+impl From<ManifestEnvelope> for VersionedManifestEnvelope {
+	fn from(value: ManifestEnvelope) -> Self {
+		Self::V1(value)
+	}
+}
+
+impl From<&ManifestEnvelope> for VersionedManifestEnvelope {
+	fn from(value: &ManifestEnvelope) -> Self {
+		Self::V1(value.clone())
+	}
+}
+
+impl From<ManifestEnvelopeV0> for VersionedManifestEnvelope {
+	fn from(value: ManifestEnvelopeV0) -> Self {
+		Self::V0(value)
+	}
+}
+
+impl From<&VersionedManifestEnvelope> for VersionedManifestEnvelope {
+	fn from(value: &VersionedManifestEnvelope) -> Self {
+		value.clone()
+	}
+}
+
+impl From<&Box<VersionedManifestEnvelope>> for VersionedManifestEnvelope {
+	fn from(value: &Box<VersionedManifestEnvelope>) -> Self {
+		(**value).clone()
+	}
+}
+
+// NOTE: Same backcompat carve-out as VersionedManifest above: the enum keeps
+// a Borsh impl for v1/v0, while v2 explicitly errors.
+impl BorshSerialize for VersionedManifestEnvelope {
+	fn serialize<W: borsh::io::Write>(
+		&self,
+		writer: &mut W,
+	) -> borsh::io::Result<()> {
+		match self {
+			Self::V2(_) => Err(borsh::io::Error::other("manifest envelope v2 is json-only and cannot be borsh serialized")),
+			Self::V1(envelope) => envelope.serialize(writer),
+			Self::V0(envelope) => envelope.serialize(writer),
+		}
+	}
+}
+
+impl BorshDeserialize for VersionedManifestEnvelope {
+	fn deserialize_reader<R: borsh::io::Read>(
+		reader: &mut R,
+	) -> borsh::io::Result<Self> {
+		let mut buf = vec![];
+		reader.read_to_end(&mut buf)?;
+		if let Ok(envelope) = ManifestEnvelope::try_from_slice(&buf) {
+			return Ok(Self::V1(envelope));
+		}
+		if let Ok(envelope) = ManifestEnvelopeV0::try_from_slice(&buf) {
+			return Ok(Self::V0(envelope));
+		}
+		Err(borsh::io::Error::other(
+			"failed to decode borsh manifest envelope as v1/v0",
+		))
+	}
+}
+
+#[allow(missing_docs)]
+impl VersionedManifestEnvelope {
+	#[must_use]
+	pub fn manifest(self) -> VersionedManifest {
+		match self {
+			Self::V2(envelope) => VersionedManifest::V2(envelope.manifest),
+			Self::V1(envelope) => VersionedManifest::V1(envelope.manifest),
+			Self::V0(envelope) => VersionedManifest::V0(envelope.manifest),
+		}
+	}
+
+	#[must_use]
+	pub fn manifest_set_approvals(&self) -> &[Approval] {
+		match self {
+			Self::V2(envelope) => &envelope.manifest_set_approvals,
+			Self::V1(envelope) => &envelope.manifest_set_approvals,
+			Self::V0(envelope) => &envelope.manifest_set_approvals,
+		}
+	}
+
+	#[must_use]
+	pub fn share_set_approvals(&self) -> &[Approval] {
+		match self {
+			Self::V2(envelope) => &envelope.share_set_approvals,
+			Self::V1(envelope) => &envelope.share_set_approvals,
+			Self::V0(envelope) => &envelope.share_set_approvals,
+		}
+	}
+
+	#[must_use]
+	pub fn manifest_hash(&self) -> Hash256 {
+		match self {
+			Self::V2(envelope) => canonical_json_hash(&envelope.manifest),
+			Self::V1(envelope) => envelope.manifest.qos_hash(),
+			Self::V0(envelope) => envelope.manifest.qos_hash(),
+		}
+	}
+
+	#[must_use]
+	pub fn manifest_set(&self) -> &ManifestSet {
+		match self {
+			Self::V2(envelope) => &envelope.manifest.manifest_set,
+			Self::V1(envelope) => &envelope.manifest.manifest_set,
+			Self::V0(envelope) => &envelope.manifest.manifest_set,
+		}
+	}
+
+	#[must_use]
+	pub fn pivot_hash(&self) -> &Hash256 {
+		match self {
+			Self::V2(envelope) => &envelope.manifest.pivot.hash,
+			Self::V1(envelope) => &envelope.manifest.pivot.hash,
+			Self::V0(envelope) => &envelope.manifest.pivot.hash,
+		}
+	}
+
+	/// Verify manifest-set approvals against the embedded manifest hash and
+	/// threshold policy.
+	///
+	/// # Errors
+	///
+	/// Returns a [`ProtocolError`] when signatures are invalid, members are
+	/// unauthorized, duplicate approvals exist, or the threshold is not met.
+	pub fn check_approvals(&self) -> Result<(), ProtocolError> {
+		let manifest_hash = self.manifest_hash();
+		let mut uniq_members = std::collections::HashSet::new();
+
+		for approval in self.manifest_set_approvals() {
+			let member_pub_key =
+				qos_p256::P256Public::from_bytes(&approval.member.pub_key)?;
+			let is_valid_signature = member_pub_key
+				.verify(&manifest_hash, &approval.signature)
+				.is_ok();
+			if !is_valid_signature {
+				return Err(ProtocolError::InvalidManifestApproval(
+					approval.clone(),
+				));
+			}
+			if !self.manifest_set().members.contains(&approval.member) {
+				return Err(ProtocolError::NotManifestSetMember);
+			}
+			if !uniq_members.insert(approval.member.qos_hash()) {
+				return Err(ProtocolError::DuplicateApproval);
+			}
+		}
+
+		if uniq_members.len() < self.manifest_set().threshold as usize {
+			return Err(ProtocolError::NotEnoughApprovals);
+		}
+
+		Ok(())
+	}
+
+	/// Read a manifest envelope while preserving the recognized schema version.
+	///
+	/// # Errors
+	///
+	/// Returns an [`std::io::Error`] when the bytes cannot be decoded as any
+	/// supported manifest envelope schema or encoding.
+	pub fn try_from_slice_compat(buf: &[u8]) -> Result<Self, Error> {
+		if let Ok(envelope) = serde_json::from_slice::<ManifestEnvelopeV2>(buf)
+		{
+			return Ok(Self::V2(envelope));
+		}
+		if let Ok(envelope) = serde_json::from_slice::<ManifestEnvelope>(buf) {
+			return Ok(Self::V1(envelope));
+		}
+		if let Ok(envelope) = serde_json::from_slice::<ManifestEnvelopeV0>(buf)
+		{
+			return Ok(Self::V0(envelope));
+		}
+		if let Ok(envelope) = ManifestEnvelope::try_from_slice(buf) {
+			return Ok(Self::V1(envelope));
+		}
+
+		ManifestEnvelopeV0::try_from_slice(buf)
+			.map(Self::V0)
+			.map_err(|e| Error::other(e.to_string()))
+	}
+
+	/// Serialize this manifest envelope using its storage encoding.
+	///
+	/// # Errors
+	///
+	/// Returns an [`std::io::Error`] when serialization fails.
+	pub fn to_storage_vec(&self) -> Result<Vec<u8>, Error> {
+		match self {
+			Self::V2(envelope) => qos_json::to_vec(envelope)
+				.map_err(|e| Error::other(e.to_string())),
+			Self::V1(envelope) => serde_json::to_vec(envelope)
+				.map_err(|e| Error::other(e.to_string())),
+			Self::V0(envelope) => serde_json::to_vec(envelope)
+				.map_err(|e| Error::other(e.to_string())),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use qos_p256::P256Pair;
+
+	use super::*;
+	use crate::protocol::{
+		services::boot::{
+			MemberPubKey, PatchSet, PivotConfig, PivotConfigV0, PivotEnv,
+			QuorumMember,
+		},
+		QosHash,
+	};
+
+	fn sample_member(pair: &P256Pair) -> QuorumMember {
+		QuorumMember {
+			alias: "member-1".to_string(),
+			pub_key: pair.public_key().to_bytes(),
+		}
+	}
+
+	fn sample_v2_manifest(member: QuorumMember) -> ManifestV2 {
+		ManifestV2 {
+			version: ManifestVersion::V2,
+			namespace: Namespace {
+				name: "test-namespace".to_string(),
+				nonce: 42,
+				quorum_key: vec![7; 33],
+			},
+			pivot: v2::PivotConfigV2 {
+				hash: [9; 32],
+				restart: RestartPolicy::Never,
+				bridge_config: vec![],
+				debug_mode: false,
+				args: vec!["--foo".to_string()],
+				env: PivotEnv::new(),
+			},
+			manifest_set: ManifestSet {
+				threshold: 1,
+				members: vec![member.clone()],
+			},
+			share_set: ShareSet { threshold: 1, members: vec![member] },
+			enclave: NitroConfig {
+				pcr0: vec![0; 48],
+				pcr1: vec![1; 48],
+				pcr2: vec![2; 48],
+				pcr3: vec![3; 48],
+				aws_root_certificate: vec![],
+				qos_commit: "commit".to_string(),
+			},
+		}
+	}
+
+	fn sample_v1_manifest(member: QuorumMember) -> Manifest {
+		Manifest {
+			namespace: Namespace {
+				name: "test-namespace".to_string(),
+				nonce: 42,
+				quorum_key: vec![7; 33],
+			},
+			pivot: PivotConfig {
+				hash: [9; 32],
+				restart: RestartPolicy::Never,
+				bridge_config: vec![],
+				debug_mode: false,
+				args: vec!["--foo".to_string()],
+			},
+			manifest_set: ManifestSet {
+				threshold: 1,
+				members: vec![member.clone()],
+			},
+			share_set: ShareSet { threshold: 1, members: vec![member.clone()] },
+			enclave: NitroConfig {
+				pcr0: vec![0; 48],
+				pcr1: vec![1; 48],
+				pcr2: vec![2; 48],
+				pcr3: vec![3; 48],
+				aws_root_certificate: vec![],
+				qos_commit: "commit".to_string(),
+			},
+			patch_set: PatchSet {
+				threshold: 1,
+				members: vec![MemberPubKey { pub_key: member.pub_key }],
+			},
+		}
+	}
+
+	fn sample_v0_manifest(member: QuorumMember) -> ManifestV0 {
+		ManifestV0 {
+			namespace: Namespace {
+				name: "test-namespace".to_string(),
+				nonce: 42,
+				quorum_key: vec![7; 33],
+			},
+			pivot: PivotConfigV0 {
+				hash: [9; 32],
+				restart: RestartPolicy::Never,
+				args: vec!["--foo".to_string()],
+			},
+			manifest_set: ManifestSet {
+				threshold: 1,
+				members: vec![member.clone()],
+			},
+			share_set: ShareSet { threshold: 1, members: vec![member.clone()] },
+			enclave: NitroConfig {
+				pcr0: vec![0; 48],
+				pcr1: vec![1; 48],
+				pcr2: vec![2; 48],
+				pcr3: vec![3; 48],
+				aws_root_certificate: vec![],
+				qos_commit: "commit".to_string(),
+			},
+			patch_set: PatchSet {
+				threshold: 1,
+				members: vec![MemberPubKey { pub_key: member.pub_key }],
+			},
+		}
+	}
+
+	#[test]
+	fn v2_manifest_decode_and_hash_uses_canonical_json() {
+		let pair = P256Pair::generate().unwrap();
+		let manifest = sample_v2_manifest(sample_member(&pair));
+		let bytes = qos_json::to_vec(&manifest).unwrap();
+
+		let decoded = VersionedManifest::try_from_slice_compat(&bytes).unwrap();
+		assert!(matches!(decoded, VersionedManifest::V2(_)));
+		assert_eq!(decoded.manifest_hash(), canonical_json_hash(&manifest));
+	}
+
+	#[test]
+	fn v2_envelope_decode_and_approval_verification_uses_json_hash() {
+		let pair = P256Pair::generate().unwrap();
+		let member = sample_member(&pair);
+		let manifest = sample_v2_manifest(member.clone());
+		let manifest_hash = canonical_json_hash(&manifest);
+		let envelope = ManifestEnvelopeV2 {
+			manifest,
+			manifest_set_approvals: vec![Approval {
+				signature: pair.sign(&manifest_hash).unwrap(),
+				member,
+			}],
+			share_set_approvals: vec![],
+		};
+		let bytes = qos_json::to_vec(&envelope).unwrap();
+
+		let decoded =
+			VersionedManifestEnvelope::try_from_slice_compat(&bytes).unwrap();
+		assert!(matches!(decoded, VersionedManifestEnvelope::V2(_)));
+		assert_eq!(decoded.manifest_hash(), manifest_hash);
+		assert!(decoded.check_approvals().is_ok());
+	}
+
+	#[test]
+	fn hash_dispatch_uses_borsh_for_v1_v0() {
+		let pair = P256Pair::generate().unwrap();
+		let member = sample_member(&pair);
+		let v1 = sample_v1_manifest(member.clone());
+		let v0 = sample_v0_manifest(member);
+
+		assert_eq!(
+			VersionedManifest::V1(v1.clone()).manifest_hash(),
+			v1.qos_hash()
+		);
+		assert_eq!(
+			VersionedManifest::V0(v0.clone()).manifest_hash(),
+			v0.qos_hash()
+		);
+	}
+
+	#[test]
+	fn borsh_serialization_rejects_v2_variants() {
+		let pair = P256Pair::generate().unwrap();
+		let member = sample_member(&pair);
+		let v2_manifest = sample_v2_manifest(member.clone());
+		let v2_envelope = ManifestEnvelopeV2 {
+			manifest: v2_manifest.clone(),
+			manifest_set_approvals: vec![],
+			share_set_approvals: vec![],
+		};
+
+		assert!(borsh::to_vec(&VersionedManifest::V2(v2_manifest)).is_err());
+		assert!(
+			borsh::to_vec(&VersionedManifestEnvelope::V2(v2_envelope)).is_err()
+		);
+	}
+}

--- a/src/qos_core/src/protocol/services/boot/manifest.rs
+++ b/src/qos_core/src/protocol/services/boot/manifest.rs
@@ -37,7 +37,7 @@ pub fn canonical_json_hash<T: serde::Serialize>(value: &T) -> Hash256 {
 }
 
 /// A manifest decoded with schema version preserved.
-#[derive(PartialEq, Eq, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(PartialEq, Eq, Debug, Clone, serde::Serialize)]
 #[serde(untagged)]
 pub enum VersionedManifest {
 	/// Explicitly versioned JSON manifest schema.
@@ -46,6 +46,34 @@ pub enum VersionedManifest {
 	V1(Manifest),
 	/// Legacy original manifest schema.
 	V0(ManifestV0),
+}
+
+impl<'de> serde::Deserialize<'de> for VersionedManifest {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
+		// Do not use serde's derived `untagged` deserializer here. It replays a
+		// buffered content representation for each variant, which cannot drive
+		// `serde_json::value::RawValue` used by QOS JSON numeric helpers.
+		let raw =
+			<Box<serde_json::value::RawValue>>::deserialize(deserializer)?;
+		let bytes = raw.get().as_bytes();
+
+		if let Ok(manifest) = serde_json::from_slice::<ManifestV2>(bytes) {
+			return Ok(Self::V2(manifest));
+		}
+		if let Ok(manifest) = serde_json::from_slice::<Manifest>(bytes) {
+			return Ok(Self::V1(manifest));
+		}
+		if let Ok(manifest) = serde_json::from_slice::<ManifestV0>(bytes) {
+			return Ok(Self::V0(manifest));
+		}
+
+		Err(serde::de::Error::custom(
+			"data did not match any versioned manifest schema",
+		))
+	}
 }
 
 impl From<ManifestV2> for VersionedManifest {
@@ -99,8 +127,8 @@ impl BorshDeserialize for VersionedManifest {
 	}
 }
 
-#[allow(missing_docs)]
 impl VersionedManifest {
+	/// Return the manifest hash using the encoding for the embedded schema.
 	#[must_use]
 	pub fn manifest_hash(&self) -> Hash256 {
 		match self {
@@ -110,6 +138,7 @@ impl VersionedManifest {
 		}
 	}
 
+	/// Return the manifest namespace.
 	#[must_use]
 	pub fn namespace(&self) -> &Namespace {
 		match self {
@@ -119,6 +148,7 @@ impl VersionedManifest {
 		}
 	}
 
+	/// Return the manifest set authorized to approve manifest changes.
 	#[must_use]
 	pub fn manifest_set(&self) -> &ManifestSet {
 		match self {
@@ -128,6 +158,7 @@ impl VersionedManifest {
 		}
 	}
 
+	/// Return the share set authorized to approve share material.
 	#[must_use]
 	pub fn share_set(&self) -> &ShareSet {
 		match self {
@@ -137,6 +168,7 @@ impl VersionedManifest {
 		}
 	}
 
+	/// Return the enclave configuration.
 	#[must_use]
 	pub fn enclave(&self) -> &NitroConfig {
 		match self {
@@ -146,6 +178,7 @@ impl VersionedManifest {
 		}
 	}
 
+	/// Return the expected pivot binary hash.
 	#[must_use]
 	pub fn pivot_hash(&self) -> &Hash256 {
 		match self {
@@ -155,6 +188,7 @@ impl VersionedManifest {
 		}
 	}
 
+	/// Return the pivot restart policy.
 	#[must_use]
 	pub fn restart(&self) -> RestartPolicy {
 		match self {
@@ -164,6 +198,7 @@ impl VersionedManifest {
 		}
 	}
 
+	/// Return the pivot command-line arguments.
 	#[must_use]
 	pub fn args(&self) -> &[String] {
 		match self {
@@ -173,6 +208,7 @@ impl VersionedManifest {
 		}
 	}
 
+	/// Return bridge configuration entries, or an empty slice for v0 manifests.
 	#[must_use]
 	pub fn bridge_config(&self) -> &[BridgeConfig] {
 		match self {
@@ -182,6 +218,7 @@ impl VersionedManifest {
 		}
 	}
 
+	/// Return whether pivot debug mode is enabled.
 	#[must_use]
 	pub fn debug_mode(&self) -> bool {
 		match self {
@@ -234,7 +271,7 @@ impl VersionedManifest {
 }
 
 /// A manifest envelope decoded with schema version preserved.
-#[derive(PartialEq, Eq, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(PartialEq, Eq, Debug, Clone, serde::Serialize)]
 #[serde(untagged)]
 pub enum VersionedManifestEnvelope {
 	/// Explicitly versioned JSON manifest envelope schema.
@@ -243,6 +280,39 @@ pub enum VersionedManifestEnvelope {
 	V1(ManifestEnvelope),
 	/// Legacy original manifest envelope schema.
 	V0(ManifestEnvelopeV0),
+}
+
+impl<'de> serde::Deserialize<'de> for VersionedManifestEnvelope {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
+		// Do not use serde's derived `untagged` deserializer here. It replays a
+		// buffered content representation for each variant, which cannot drive
+		// `serde_json::value::RawValue` used by QOS JSON numeric helpers.
+		let raw =
+			<Box<serde_json::value::RawValue>>::deserialize(deserializer)?;
+		let bytes = raw.get().as_bytes();
+
+		if let Ok(envelope) =
+			serde_json::from_slice::<ManifestEnvelopeV2>(bytes)
+		{
+			return Ok(Self::V2(envelope));
+		}
+		if let Ok(envelope) = serde_json::from_slice::<ManifestEnvelope>(bytes)
+		{
+			return Ok(Self::V1(envelope));
+		}
+		if let Ok(envelope) =
+			serde_json::from_slice::<ManifestEnvelopeV0>(bytes)
+		{
+			return Ok(Self::V0(envelope));
+		}
+
+		Err(serde::de::Error::custom(
+			"data did not match any versioned manifest envelope schema",
+		))
+	}
 }
 
 impl From<ManifestEnvelopeV2> for VersionedManifestEnvelope {
@@ -289,7 +359,9 @@ impl BorshSerialize for VersionedManifestEnvelope {
 		writer: &mut W,
 	) -> borsh::io::Result<()> {
 		match self {
-			Self::V2(_) => Err(borsh::io::Error::other("manifest envelope v2 is json-only and cannot be borsh serialized")),
+			Self::V2(_) => Err(borsh::io::Error::other(
+				"manifest envelope v2 is json-only and cannot be borsh serialized",
+			)),
 			Self::V1(envelope) => envelope.serialize(writer),
 			Self::V0(envelope) => envelope.serialize(writer),
 		}
@@ -314,8 +386,8 @@ impl BorshDeserialize for VersionedManifestEnvelope {
 	}
 }
 
-#[allow(missing_docs)]
 impl VersionedManifestEnvelope {
+	/// Consume the envelope and return its embedded manifest.
 	#[must_use]
 	pub fn manifest(self) -> VersionedManifest {
 		match self {
@@ -325,6 +397,7 @@ impl VersionedManifestEnvelope {
 		}
 	}
 
+	/// Return approvals from manifest set members.
 	#[must_use]
 	pub fn manifest_set_approvals(&self) -> &[Approval] {
 		match self {
@@ -334,6 +407,7 @@ impl VersionedManifestEnvelope {
 		}
 	}
 
+	/// Return approvals from share set members.
 	#[must_use]
 	pub fn share_set_approvals(&self) -> &[Approval] {
 		match self {
@@ -343,6 +417,7 @@ impl VersionedManifestEnvelope {
 		}
 	}
 
+	/// Return the embedded manifest hash using its schema-specific encoding.
 	#[must_use]
 	pub fn manifest_hash(&self) -> Hash256 {
 		match self {
@@ -352,6 +427,7 @@ impl VersionedManifestEnvelope {
 		}
 	}
 
+	/// Return the embedded manifest set.
 	#[must_use]
 	pub fn manifest_set(&self) -> &ManifestSet {
 		match self {
@@ -361,6 +437,7 @@ impl VersionedManifestEnvelope {
 		}
 	}
 
+	/// Return the expected pivot binary hash from the embedded manifest.
 	#[must_use]
 	pub fn pivot_hash(&self) -> &Hash256 {
 		match self {

--- a/src/qos_core/src/protocol/services/boot/manifest.rs
+++ b/src/qos_core/src/protocol/services/boot/manifest.rs
@@ -37,7 +37,7 @@ pub fn canonical_json_hash<T: serde::Serialize>(value: &T) -> Hash256 {
 }
 
 /// A manifest decoded with schema version preserved.
-#[derive(PartialEq, Eq, Debug, Clone, serde::Serialize)]
+#[derive(PartialEq, Eq, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(untagged)]
 pub enum VersionedManifest {
 	/// Explicitly versioned JSON manifest schema.
@@ -46,34 +46,6 @@ pub enum VersionedManifest {
 	V1(Manifest),
 	/// Legacy original manifest schema.
 	V0(ManifestV0),
-}
-
-impl<'de> serde::Deserialize<'de> for VersionedManifest {
-	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-	where
-		D: serde::Deserializer<'de>,
-	{
-		// Do not use serde's derived `untagged` deserializer here. It replays a
-		// buffered content representation for each variant, which cannot drive
-		// `serde_json::value::RawValue` used by QOS JSON numeric helpers.
-		let raw =
-			<Box<serde_json::value::RawValue>>::deserialize(deserializer)?;
-		let bytes = raw.get().as_bytes();
-
-		if let Ok(manifest) = serde_json::from_slice::<ManifestV2>(bytes) {
-			return Ok(Self::V2(manifest));
-		}
-		if let Ok(manifest) = serde_json::from_slice::<Manifest>(bytes) {
-			return Ok(Self::V1(manifest));
-		}
-		if let Ok(manifest) = serde_json::from_slice::<ManifestV0>(bytes) {
-			return Ok(Self::V0(manifest));
-		}
-
-		Err(serde::de::Error::custom(
-			"data did not match any versioned manifest schema",
-		))
-	}
 }
 
 impl From<ManifestV2> for VersionedManifest {
@@ -271,7 +243,7 @@ impl VersionedManifest {
 }
 
 /// A manifest envelope decoded with schema version preserved.
-#[derive(PartialEq, Eq, Debug, Clone, serde::Serialize)]
+#[derive(PartialEq, Eq, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(untagged)]
 pub enum VersionedManifestEnvelope {
 	/// Explicitly versioned JSON manifest envelope schema.
@@ -280,39 +252,6 @@ pub enum VersionedManifestEnvelope {
 	V1(ManifestEnvelope),
 	/// Legacy original manifest envelope schema.
 	V0(ManifestEnvelopeV0),
-}
-
-impl<'de> serde::Deserialize<'de> for VersionedManifestEnvelope {
-	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-	where
-		D: serde::Deserializer<'de>,
-	{
-		// Do not use serde's derived `untagged` deserializer here. It replays a
-		// buffered content representation for each variant, which cannot drive
-		// `serde_json::value::RawValue` used by QOS JSON numeric helpers.
-		let raw =
-			<Box<serde_json::value::RawValue>>::deserialize(deserializer)?;
-		let bytes = raw.get().as_bytes();
-
-		if let Ok(envelope) =
-			serde_json::from_slice::<ManifestEnvelopeV2>(bytes)
-		{
-			return Ok(Self::V2(envelope));
-		}
-		if let Ok(envelope) = serde_json::from_slice::<ManifestEnvelope>(bytes)
-		{
-			return Ok(Self::V1(envelope));
-		}
-		if let Ok(envelope) =
-			serde_json::from_slice::<ManifestEnvelopeV0>(bytes)
-		{
-			return Ok(Self::V0(envelope));
-		}
-
-		Err(serde::de::Error::custom(
-			"data did not match any versioned manifest envelope schema",
-		))
-	}
 }
 
 impl From<ManifestEnvelopeV2> for VersionedManifestEnvelope {

--- a/src/qos_core/src/protocol/services/boot/manifest.rs
+++ b/src/qos_core/src/protocol/services/boot/manifest.rs
@@ -473,11 +473,11 @@ mod tests {
 
 	use super::*;
 	use crate::protocol::{
+		QosHash,
 		services::boot::{
 			MemberPubKey, PatchSet, PivotConfig, PivotConfigV0, PivotEnv,
 			QuorumMember,
 		},
-		QosHash,
 	};
 
 	fn sample_member(pair: &P256Pair) -> QuorumMember {

--- a/src/qos_core/src/protocol/services/boot/manifest/v2.rs
+++ b/src/qos_core/src/protocol/services/boot/manifest/v2.rs
@@ -1,11 +1,11 @@
 //! Explicitly versioned JSON manifest schema (v2).
 
 use crate::protocol::{
+	Hash256,
 	services::boot::{
 		Approval, BridgeConfig, ManifestSet, Namespace, NitroConfig, PivotEnv,
 		RestartPolicy, ShareSet,
 	},
-	Hash256,
 };
 
 use super::ManifestVersion;

--- a/src/qos_core/src/protocol/services/boot/manifest/v2.rs
+++ b/src/qos_core/src/protocol/services/boot/manifest/v2.rs
@@ -1,0 +1,62 @@
+//! Explicitly versioned JSON manifest schema (v2).
+
+use crate::protocol::{
+	services::boot::{
+		Approval, BridgeConfig, ManifestSet, Namespace, NitroConfig, PivotEnv,
+		RestartPolicy, ShareSet,
+	},
+	Hash256,
+};
+
+use super::ManifestVersion;
+
+/// JSON-only pivot binary configuration (v2).
+#[derive(PartialEq, Eq, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(any(feature = "mock", test), derive(Default))]
+pub struct PivotConfigV2 {
+	/// Hash of the pivot binary, taken from the binary as a `Vec<u8>`.
+	#[serde(with = "qos_hex::serde")]
+	pub hash: Hash256,
+	/// Restart policy for running the pivot binary.
+	pub restart: RestartPolicy,
+	/// Bridge host configuration for the pivot is a set of per-port rules.
+	pub bridge_config: Vec<BridgeConfig>,
+	/// Whether we're invoking the enclave and pivot in DEBUG mode.
+	pub debug_mode: bool,
+	/// Arguments to invoke the binary with.
+	pub args: Vec<String>,
+	/// Environment variables to inject into the pivot process.
+	#[serde(default, skip_serializing_if = "PivotEnv::is_empty")]
+	pub env: PivotEnv,
+}
+
+/// Explicitly versioned JSON manifest (v2).
+#[derive(PartialEq, Eq, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ManifestV2 {
+	/// Manifest schema version.
+	pub version: ManifestVersion,
+	/// Namespace this manifest belongs too.
+	pub namespace: Namespace,
+	/// Pivot binary configuration and verifiable values.
+	pub pivot: PivotConfigV2,
+	/// Manifest Set members and threshold.
+	pub manifest_set: ManifestSet,
+	/// Share Set members and threshold.
+	pub share_set: ShareSet,
+	/// Configuration and verifiable values for the enclave hardware.
+	pub enclave: NitroConfig,
+}
+
+/// Explicitly versioned JSON manifest envelope (v2).
+#[derive(PartialEq, Eq, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ManifestEnvelopeV2 {
+	/// Encapsulated manifest.
+	pub manifest: ManifestV2,
+	/// Approvals for [`Self::manifest`] from the manifest set.
+	pub manifest_set_approvals: Vec<Approval>,
+	/// Approvals for [`Self::manifest`] from the share set.
+	pub share_set_approvals: Vec<Approval>,
+}

--- a/src/qos_core/src/protocol/services/genesis.rs
+++ b/src/qos_core/src/protocol/services/genesis.rs
@@ -15,13 +15,21 @@ const QOS_TEST_MESSAGE: &[u8] = b"qos-test-message";
 
 /// Configuration for sharding a Quorum Key created in the Genesis flow.
 #[derive(
-	PartialEq, Debug, Eq, Clone, borsh::BorshSerialize, borsh::BorshDeserialize,
+	PartialEq,
+	Debug,
+	Eq,
+	Clone,
+	borsh::BorshSerialize,
+	borsh::BorshDeserialize,
+	serde::Serialize,
+	serde::Deserialize,
 )]
 pub struct GenesisSet {
 	/// Share Set Member's who's production key will be used to encrypt Genesis
 	/// flow outputs.
 	pub members: Vec<QuorumMember>,
 	/// Threshold for successful reconstitution of the Quorum Key shards
+	#[serde(with = "qos_json::string_or_numeric")]
 	pub threshold: u32,
 }
 
@@ -38,6 +46,7 @@ struct MemberShard {
 	member: QuorumMember,
 	/// Shard of the generated Quorum Key, encrypted to the `member`s Setup
 	/// Key.
+	#[serde(with = "qos_hex::serde")]
 	shard: Vec<u8>,
 }
 
@@ -111,6 +120,7 @@ impl fmt::Debug for GenesisMemberOutput {
 )]
 pub struct GenesisOutput {
 	/// Public Quorum Key, DER encoded.
+	#[serde(with = "qos_hex::serde")]
 	pub quorum_key: Vec<u8>,
 	/// Quorum Member specific outputs from the genesis ceremony.
 	pub member_outputs: Vec<GenesisMemberOutput>,
@@ -118,18 +128,27 @@ pub struct GenesisOutput {
 	/// process.
 	pub recovery_permutations: Vec<RecoveredPermutation>,
 	/// The threshold, K, used to generate the shards.
+	#[serde(with = "qos_json::string_or_numeric")]
 	pub threshold: u32,
 	/// The quorum key encrypted to the DR key. None if no DR Key was provided
+	#[serde(
+		default,
+		skip_serializing_if = "Option::is_none",
+		with = "qos_hex::serde::option"
+	)]
 	pub dr_key_wrapped_quorum_key: Option<Vec<u8>>,
 	/// Hash of the quorum key secret
 	#[serde(with = "qos_hex::serde")]
 	pub quorum_key_hash: [u8; 64],
 	/// Test message encrypted to the quorum public key.
+	#[serde(with = "qos_hex::serde")]
 	pub test_message_ciphertext: Vec<u8>,
 	/// Signature over the test message by the quorum key.
+	#[serde(with = "qos_hex::serde")]
 	pub test_message_signature: Vec<u8>,
 	/// The message that was used to generate [`Self::test_message_signature`]
 	/// and [`Self::test_message_ciphertext`]
+	#[serde(with = "qos_hex::serde")]
 	pub test_message: Vec<u8>,
 }
 

--- a/src/qos_core/src/protocol/services/key.rs
+++ b/src/qos_core/src/protocol/services/key.rs
@@ -10,7 +10,7 @@ use qos_p256::{P256Pair, P256Public};
 use serde::{Deserialize, Serialize};
 
 use crate::protocol::{
-	services::boot::{put_manifest_and_pivot, ManifestEnvelope},
+	services::boot::{put_manifest_and_pivot, VersionedManifestEnvelope},
 	ProtocolError, ProtocolState, QosHash,
 };
 
@@ -19,8 +19,10 @@ use crate::protocol::{
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
 pub struct EncryptedQuorumKey {
 	/// The encrypted payload: a quorum key
+	#[serde(with = "qos_hex::serde")]
 	pub encrypted_quorum_key: Vec<u8>,
 	/// Signature over the encrypted quorum key
+	#[serde(with = "qos_hex::serde")]
 	pub signature: Vec<u8>,
 }
 
@@ -29,12 +31,12 @@ pub(in crate::protocol) fn inject_key(
 	EncryptedQuorumKey { encrypted_quorum_key, signature }: EncryptedQuorumKey,
 ) -> Result<(), ProtocolError> {
 	let manifest_envelope = state.handles.get_manifest_envelope()?;
+	let manifest = manifest_envelope.manifest();
 
 	// 1. Verify the signature over the `encrypted_quorum_key` against the
 	// Quorum Key specified in the New Manifest.
-	let quorum_public = P256Public::from_bytes(
-		&manifest_envelope.manifest.namespace.quorum_key,
-	)?;
+	let quorum_public =
+		P256Public::from_bytes(&manifest.namespace().quorum_key)?;
 	quorum_public
 		.verify(&encrypted_quorum_key, &signature)
 		.map_err(|_| ProtocolError::InvalidEncryptedQuorumKeySignature)?;
@@ -73,18 +75,21 @@ pub(in crate::protocol) fn inject_key(
 
 pub(in crate::protocol) fn boot_key_forward(
 	state: &mut ProtocolState,
-	manifest_envelope: &ManifestEnvelope,
+	manifest_envelope: impl Into<VersionedManifestEnvelope>,
 	pivot: &[u8],
 ) -> Result<NsmResponse, ProtocolError> {
-	let nsm_response = put_manifest_and_pivot(state, manifest_envelope, pivot)?;
+	let manifest_envelope = manifest_envelope.into();
+	let nsm_response =
+		put_manifest_and_pivot(state, &manifest_envelope, pivot)?;
 	Ok(nsm_response)
 }
 
 pub(in crate::protocol) fn export_key(
 	state: &mut ProtocolState,
-	new_manifest_envelope: &ManifestEnvelope,
+	new_manifest_envelope: impl Into<VersionedManifestEnvelope>,
 	cose_sign1_attestation_document: &[u8],
 ) -> Result<EncryptedQuorumKey, ProtocolError> {
+	let new_manifest_envelope = new_manifest_envelope.into();
 	// 1. Check the basic validity of the attestation doc (cert chain etc).
 	// Ensures that the attestation document is actually from an AWS controlled
 	// NSM module and the document's timestamp was recent.
@@ -93,19 +98,20 @@ pub(in crate::protocol) fn export_key(
 		&*state.attestor,
 	)?;
 
-	export_key_internal(state, new_manifest_envelope, &attestation_doc)
+	export_key_internal(state, &new_manifest_envelope, &attestation_doc)
 }
 
 // Primary logic of `export_key` pulled out so it can be unit tested.
 fn export_key_internal(
 	state: &mut ProtocolState,
-	new_manifest_envelope: &ManifestEnvelope,
+	new_manifest_envelope: impl Into<VersionedManifestEnvelope>,
 	attestation_doc: &AttestationDoc,
 ) -> Result<EncryptedQuorumKey, ProtocolError> {
+	let new_manifest_envelope = new_manifest_envelope.into();
 	let old_manifest_envelope = state.handles.get_manifest_envelope()?;
 	// steps 2 through 9
 	validate_manifest(
-		new_manifest_envelope,
+		&new_manifest_envelope,
 		&old_manifest_envelope,
 		attestation_doc,
 	)?;
@@ -141,31 +147,32 @@ fn export_key_internal(
 
 /// Manifest validation logic. Extracted to make unit testing easier.
 fn validate_manifest(
-	new_manifest_envelope: &ManifestEnvelope,
-	old_manifest_envelope: &ManifestEnvelope,
+	new_manifest_envelope: impl Into<VersionedManifestEnvelope>,
+	old_manifest_envelope: impl Into<VersionedManifestEnvelope>,
 	#[allow(unused_variables)] attestation_doc: &AttestationDoc,
 ) -> Result<(), ProtocolError> {
+	let new_manifest_envelope = new_manifest_envelope.into();
+	let old_manifest_envelope = old_manifest_envelope.into();
 	// 2. Check the signatures over the New Manifest. Ensures that K Manifest
 	// Set Members approved the New Manifest.
 	new_manifest_envelope.check_approvals()?;
 
-	if !new_manifest_envelope.share_set_approvals.is_empty() {
+	if !new_manifest_envelope.share_set_approvals().is_empty() {
 		return Err(ProtocolError::BadShareSetApprovals);
 	}
+
+	let new_manifest = new_manifest_envelope.manifest();
+	let old_manifest = old_manifest_envelope.manifest();
 
 	// 3. Check that the Quorum Key of the Local Manifest matches the Quorum Key
 	// of the New Manifest. This ensures the request is for the correct Quorum
 	// Key.
-	if old_manifest_envelope.manifest.namespace.quorum_key
-		!= new_manifest_envelope.manifest.namespace.quorum_key
+	if old_manifest.namespace().quorum_key
+		!= new_manifest.namespace().quorum_key
 	{
 		return Err(ProtocolError::DifferentQuorumKey {
-			expected: qos_hex::encode(
-				&old_manifest_envelope.manifest.namespace.quorum_key,
-			),
-			actual: qos_hex::encode(
-				&new_manifest_envelope.manifest.namespace.quorum_key,
-			),
+			expected: qos_hex::encode(&old_manifest.namespace().quorum_key),
+			actual: qos_hex::encode(&new_manifest.namespace().quorum_key),
 		});
 	}
 
@@ -177,16 +184,25 @@ fn validate_manifest(
 	// Node - thus it's important to retire all Original Nodes ASAP that use
 	// compromised Manifest Sets.
 	{
-		let mut new_manifest = new_manifest_envelope.manifest.clone();
-		let mut old_manifest = old_manifest_envelope.manifest.clone();
-		new_manifest.manifest_set.members.sort();
-		old_manifest.manifest_set.members.sort();
-		if old_manifest.manifest_set != new_manifest.manifest_set {
+		let mut old_members = old_manifest.manifest_set().members.clone();
+		let mut new_members = new_manifest.manifest_set().members.clone();
+		old_members.sort();
+		new_members.sort();
+		if old_manifest.manifest_set().threshold
+			!= new_manifest.manifest_set().threshold
+			|| old_members != new_members
+		{
+			let old_set = crate::protocol::services::boot::ManifestSet {
+				threshold: old_manifest.manifest_set().threshold,
+				members: old_members,
+			};
+			let new_set = crate::protocol::services::boot::ManifestSet {
+				threshold: new_manifest.manifest_set().threshold,
+				members: new_members,
+			};
 			return Err(ProtocolError::DifferentManifestSet {
-				expected: qos_hex::encode(
-					&old_manifest.manifest_set.qos_hash(),
-				),
-				actual: qos_hex::encode(&new_manifest.manifest_set.qos_hash()),
+				expected: qos_hex::encode(&old_set.qos_hash()),
+				actual: qos_hex::encode(&new_set.qos_hash()),
 			});
 		}
 	}
@@ -195,12 +211,10 @@ fn validate_manifest(
 	// of the New Manifest. Namespaces are a social construct, but we only want
 	// to allow forwarding a Quorum Key to Nodes in the same Namespace to help
 	// ensure that the nonce is not abused.
-	if old_manifest_envelope.manifest.namespace.name
-		!= new_manifest_envelope.manifest.namespace.name
-	{
+	if old_manifest.namespace().name != new_manifest.namespace().name {
 		return Err(ProtocolError::DifferentNamespaceName {
-			expected: old_manifest_envelope.manifest.namespace.name.clone(),
-			actual: new_manifest_envelope.manifest.namespace.name.clone(),
+			expected: old_manifest.namespace().name.clone(),
+			actual: new_manifest.namespace().name.clone(),
 		});
 	}
 
@@ -213,23 +227,17 @@ fn validate_manifest(
 	// Members approving the manifest. In other words, we rely on the Manifest
 	// Set Members to correctly increment the nonce when any change is made to
 	// the latest manifest for a namespace.
-	if old_manifest_envelope.manifest.namespace.nonce
-		> new_manifest_envelope.manifest.namespace.nonce
-	{
+	if old_manifest.namespace().nonce > new_manifest.namespace().nonce {
 		return Err(ProtocolError::LowNonce {
-			expected: old_manifest_envelope.manifest.namespace.nonce,
-			actual: new_manifest_envelope.manifest.namespace.nonce,
+			expected: old_manifest.namespace().nonce,
+			actual: new_manifest.namespace().nonce,
 		});
-	} else if old_manifest_envelope.manifest.namespace.nonce
-		== new_manifest_envelope.manifest.namespace.nonce
-		&& old_manifest_envelope.manifest.qos_hash()
-			!= new_manifest_envelope.manifest.qos_hash()
+	} else if old_manifest.namespace().nonce == new_manifest.namespace().nonce
+		&& old_manifest.manifest_hash() != new_manifest.manifest_hash()
 	{
 		return Err(ProtocolError::DifferentManifest {
-			expected: qos_hex::encode(
-				&old_manifest_envelope.manifest.qos_hash(),
-			),
-			actual: qos_hex::encode(&new_manifest_envelope.manifest.qos_hash()),
+			expected: qos_hex::encode(&old_manifest.manifest_hash()),
+			actual: qos_hex::encode(&new_manifest.manifest_hash()),
 		});
 	}
 
@@ -246,11 +254,11 @@ fn validate_manifest(
 	{
 		qos_nsm::nitro::verify_attestation_doc_against_user_input(
 			attestation_doc,
-			&new_manifest_envelope.manifest.qos_hash(),
-			&new_manifest_envelope.manifest.enclave.pcr0,
-			&new_manifest_envelope.manifest.enclave.pcr1,
-			&new_manifest_envelope.manifest.enclave.pcr2,
-			&new_manifest_envelope.manifest.enclave.pcr3,
+			&new_manifest.manifest_hash(),
+			&new_manifest.enclave().pcr0,
+			&new_manifest.enclave().pcr1,
+			&new_manifest.enclave().pcr2,
+			&new_manifest.enclave().pcr3,
 		)?;
 	}
 
@@ -261,16 +269,10 @@ fn validate_manifest(
 	// is controlled by the operator, not an enclave that some malicious entity
 	// runs that otherwise configured identically to one of the operator's
 	// enclaves.
-	if old_manifest_envelope.manifest.enclave.pcr3
-		!= new_manifest_envelope.manifest.enclave.pcr3
-	{
+	if old_manifest.enclave().pcr3 != new_manifest.enclave().pcr3 {
 		return Err(ProtocolError::DifferentPcr3 {
-			expected: qos_hex::encode(
-				&old_manifest_envelope.manifest.enclave.pcr3,
-			),
-			actual: qos_hex::encode(
-				&new_manifest_envelope.manifest.enclave.pcr3,
-			),
+			expected: qos_hex::encode(&old_manifest.enclave().pcr3),
+			actual: qos_hex::encode(&new_manifest.enclave().pcr3),
 		});
 	}
 
@@ -469,7 +471,9 @@ mod test {
 			assert!(handles.pivot_exists());
 			assert_eq!(
 				handles.get_manifest_envelope().unwrap(),
-				manifest_envelope
+				crate::protocol::services::boot::VersionedManifestEnvelope::V1(
+					manifest_envelope,
+				)
 			);
 
 			handles.get_ephemeral_key().unwrap();

--- a/src/qos_core/src/protocol/services/key.rs
+++ b/src/qos_core/src/protocol/services/key.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use crate::protocol::{
 	ProtocolError, ProtocolState, QosHash,
 	services::boot::{
-		ManifestEnvelope, VersionedManifestEnvelope, put_manifest_and_pivot,
+		VersionedManifestEnvelope, put_manifest_and_pivot,
 	},
 };
 

--- a/src/qos_core/src/protocol/services/key.rs
+++ b/src/qos_core/src/protocol/services/key.rs
@@ -11,9 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::protocol::{
 	ProtocolError, ProtocolState, QosHash,
-	services::boot::{
-		VersionedManifestEnvelope, put_manifest_and_pivot,
-	},
+	services::boot::{VersionedManifestEnvelope, put_manifest_and_pivot},
 };
 
 /// An encrypted quorum key along with a signature over the encrypted payload

--- a/src/qos_core/src/protocol/services/provision.rs
+++ b/src/qos_core/src/protocol/services/provision.rs
@@ -2,7 +2,8 @@
 use qos_p256::P256Pair;
 
 use crate::protocol::{
-	services::boot::Approval, ProtocolError, ProtocolState, QosHash,
+	services::boot::{Approval, VersionedManifestEnvelope},
+	ProtocolError, ProtocolState,
 };
 
 type Secret = Vec<u8>;
@@ -61,20 +62,31 @@ pub(in crate::protocol) fn provision(
 	state: &mut ProtocolState,
 ) -> Result<bool, ProtocolError> {
 	let manifest_envelope = state.handles.get_manifest_envelope()?;
+	let manifest = manifest_envelope.manifest();
+	let manifest_hash = manifest.manifest_hash();
 
 	// Check that the approval is valid
 	// 1) the signature is valid. Note that we want to check signature before
 	// interacting with data
-	approval.verify(&manifest_envelope.manifest.qos_hash())?;
+	approval.verify(&manifest_hash)?;
 	// 2) the approver belongs to the share set
-	if !manifest_envelope.manifest.share_set.members.contains(&approval.member)
-	{
+	if !manifest.share_set().members.contains(&approval.member) {
 		return Err(ProtocolError::NotShareSetMember);
 	}
 
 	// Record the share set approval
 	state.handles.mutate_manifest_envelope(|mut envelope| {
-		envelope.share_set_approvals.push(approval);
+		match &mut envelope {
+			VersionedManifestEnvelope::V2(inner) => {
+				inner.share_set_approvals.push(approval);
+			}
+			VersionedManifestEnvelope::V1(inner) => {
+				inner.share_set_approvals.push(approval);
+			}
+			VersionedManifestEnvelope::V0(inner) => {
+				inner.share_set_approvals.push(approval);
+			}
+		}
 		envelope
 	})?;
 
@@ -86,8 +98,7 @@ pub(in crate::protocol) fn provision(
 
 	state.provisioner.add_share(share)?;
 
-	let quorum_threshold =
-		manifest_envelope.manifest.share_set.threshold as usize;
+	let quorum_threshold = manifest.share_set().threshold as usize;
 	if state.provisioner.count() < quorum_threshold {
 		// Nothing else to do if we don't have the threshold to reconstruct
 		return Ok(false);
@@ -103,7 +114,7 @@ pub(in crate::protocol) fn provision(
 	let pair = qos_p256::P256Pair::from_master_seed(&master_seed)?;
 	let public_key_bytes = pair.public_key().to_bytes();
 
-	if public_key_bytes != manifest_envelope.manifest.namespace.quorum_key {
+	if public_key_bytes != manifest.namespace().quorum_key {
 		// We did not construct the intended key
 		return Err(ProtocolError::ReconstructionErrorIncorrectPubKey);
 	}
@@ -300,7 +311,7 @@ mod test {
 				.handles
 				.get_manifest_envelope()
 				.unwrap()
-				.share_set_approvals
+				.share_set_approvals()
 				.len(),
 			threshold
 		);
@@ -467,7 +478,8 @@ mod test {
 				.map(|shard| eph_pair.public_key().encrypt(shard).unwrap())
 				.collect();
 
-		let manifest = state.handles.get_manifest_envelope().unwrap().manifest;
+		let manifest =
+			state.handles.get_manifest_envelope().unwrap().manifest();
 		let mut approval = approvals.remove(0);
 		let pair = P256Pair::generate().unwrap();
 

--- a/src/qos_core/src/protocol/services/provision.rs
+++ b/src/qos_core/src/protocol/services/provision.rs
@@ -2,8 +2,8 @@
 use qos_p256::P256Pair;
 
 use crate::protocol::{
-	services::boot::{Approval, VersionedManifestEnvelope},
 	ProtocolError, ProtocolState,
+	services::boot::{Approval, VersionedManifestEnvelope},
 };
 
 type Secret = Vec<u8>;

--- a/src/qos_core/src/protocol/state.rs
+++ b/src/qos_core/src/protocol/state.rs
@@ -19,17 +19,34 @@ use crate::handles::Handles;
 	serde::Deserialize,
 )]
 pub enum ProtocolPhase {
+	// Keep legacy PascalCase wire values for backward compatibility with
+	// existing clients, while accepting camelCase aliases during decode.
 	/// The state machine cannot recover. The enclave must be rebooted.
+	#[serde(rename = "UnrecoverableError", alias = "unrecoverableError")]
 	UnrecoverableError,
 	/// Waiting to receive a boot instruction.
+	#[serde(
+		rename = "WaitingForBootInstruction",
+		alias = "waitingForBootInstruction"
+	)]
 	WaitingForBootInstruction,
 	/// Genesis service has been booted. No further actions.
+	#[serde(rename = "GenesisBooted", alias = "genesisBooted")]
 	GenesisBooted,
 	/// Waiting to receive K quorum shards
+	#[serde(
+		rename = "WaitingForQuorumShards",
+		alias = "waitingForQuorumShards"
+	)]
 	WaitingForQuorumShards,
 	/// The enclave has successfully provisioned its quorum key.
+	#[serde(rename = "QuorumKeyProvisioned", alias = "quorumKeyProvisioned")]
 	QuorumKeyProvisioned,
 	/// Waiting for a forwarded key to be injected
+	#[serde(
+		rename = "WaitingForForwardedKey",
+		alias = "waitingForForwardedKey"
+	)]
 	WaitingForForwardedKey,
 }
 
@@ -199,23 +216,23 @@ impl ProtocolState {
 		self.phase
 	}
 
-	pub fn handle_msg(&mut self, msg_req: &ProtocolMsg) -> Vec<u8> {
+	pub fn handle_msg_response(
+		&mut self,
+		msg_req: &ProtocolMsg,
+	) -> ProtocolMsg {
 		for route in &self.routes() {
 			match route.try_msg(msg_req, self) {
 				None => (),
 				Some(result) => match result {
 					Ok(msg_resp) | Err(msg_resp) => {
-						return borsh::to_vec(&msg_resp).expect(
-							"ProtocolMsg can always be serialized. qed.",
-						)
+						return msg_resp;
 					}
 				},
 			}
 		}
 
 		let err = ProtocolError::NoMatchingRoute(self.phase);
-		borsh::to_vec(&ProtocolMsg::ProtocolErrorResponse(err))
-			.expect("ProtocolMsg can always be serialized. qed.")
+		ProtocolMsg::ProtocolErrorResponse(err)
 	}
 
 	#[allow(clippy::too_many_lines)]

--- a/src/qos_core/src/protocol/state.rs
+++ b/src/qos_core/src/protocol/state.rs
@@ -424,19 +424,24 @@ mod handlers {
 		req: &ProtocolMsg,
 		state: &mut ProtocolState,
 	) -> ProtocolRouteResponse {
-		if let ProtocolMsg::BootStandardRequest { manifest_envelope, pivot } =
-			req
-		{
-			let result = boot::boot_standard(state, manifest_envelope, pivot)
-				.map(|nsm_response| ProtocolMsg::BootStandardResponse {
-					nsm_response,
-				})
-				.map_err(ProtocolMsg::ProtocolErrorResponse);
+		let (manifest_envelope, pivot) = match req {
+			ProtocolMsg::BootStandardRequest { manifest_envelope, pivot } => {
+				((**manifest_envelope).clone(), pivot)
+			}
+			ProtocolMsg::BootStandardJsonEnvelopeRequest {
+				manifest_envelope,
+				pivot,
+			} => (manifest_envelope.as_ref().clone().into_inner(), pivot),
+			_ => return None,
+		};
 
-			Some(result)
-		} else {
-			None
-		}
+		let result = boot::boot_standard(state, manifest_envelope, pivot)
+			.map(|nsm_response| ProtocolMsg::BootStandardResponse {
+				nsm_response,
+			})
+			.map_err(ProtocolMsg::ProtocolErrorResponse);
+
+		Some(result)
 	}
 
 	pub(super) fn boot_genesis(

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -21,9 +21,9 @@ use crate::{
 	handles::Handles,
 	io::{HostBridge, IOError, SocketAddress, StreamPool},
 	protocol::{
-		services::boot::{BridgeConfig, RestartPolicy},
 		ProtocolPhase, ProtocolState,
 		processor::ProtocolProcessor,
+		services::boot::{BridgeConfig, RestartPolicy},
 	},
 	server::SocketServer,
 };

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -22,7 +22,7 @@ use crate::{
 	io::{HostBridge, IOError, SocketAddress, StreamPool},
 	protocol::{
 		processor::ProtocolProcessor,
-		services::boot::{BridgeConfig, PivotConfig, RestartPolicy},
+		services::boot::{BridgeConfig, RestartPolicy},
 		ProtocolPhase, ProtocolState,
 	},
 	server::SocketServer,
@@ -188,9 +188,10 @@ impl Reaper {
 		let manifest = handles
 			.get_manifest_envelope()
 			.expect("Checked above that the manifest exists.")
-			.manifest;
-		let PivotConfig { args, restart, bridge_config: host_config, .. } =
-			manifest.pivot;
+			.manifest();
+		let args = manifest.args().to_vec();
+		let restart = manifest.restart();
+		let host_config = manifest.bridge_config().to_vec();
 
 		// if the app indicates the need for the VSOCK -> TCP bridge, run it as another task
 		run_vsock_to_tcp_bridge(&core_socket, &host_config)
@@ -200,7 +201,7 @@ impl Reaper {
 		pivot.env_clear();
 		pivot.args(&args[..]);
 		// Only pipe pivot output when it will be drained below.
-		if manifest.pivot.debug_mode {
+		if manifest.debug_mode() {
 			pivot.stdout(Stdio::piped()).stderr(Stdio::piped());
 		} else {
 			pivot.stdout(Stdio::null()).stderr(Stdio::null());
@@ -210,7 +211,7 @@ impl Reaper {
 			let mut child = pivot.spawn().expect("Failed to spawn pivot");
 			// print pivot stderr and stdout if in debug mode
 			// *NOTE*: this requires `DEBUG` and `LOGS` env vars set when booting the enclave itself. If not, nothing will be visible
-			if manifest.pivot.debug_mode {
+			if manifest.debug_mode() {
 				reprint_pivot_output(&mut child);
 			}
 

--- a/src/qos_hex/src/lib.rs
+++ b/src/qos_hex/src/lib.rs
@@ -265,7 +265,7 @@ from_hex_array_impl! {
 pub mod serde {
 	use core::{fmt, marker::PhantomData};
 
-	use serde::{de::Visitor, Deserializer, Serializer};
+	use serde::{de::Visitor, Deserialize, Deserializer, Serializer};
 
 	use super::{encode, FromHex};
 
@@ -327,6 +327,51 @@ pub mod serde {
 		}
 
 		deserializer.deserialize_str(StrVisitor(PhantomData))
+	}
+
+	/// Serde support for `Option<T>` where `T` is hex-encoded bytes.
+	pub mod option {
+		use super::{encode, Deserialize, Deserializer, FromHex, Serializer};
+		use serde::Serialize;
+
+		/// Serialize optional bytes as an optional hex string.
+		///
+		/// # Errors
+		///
+		/// Returns the serializer's error type if serialization fails.
+		pub fn serialize<T, S>(
+			value: &Option<T>,
+			serializer: S,
+		) -> Result<S::Ok, S::Error>
+		where
+			T: AsRef<[u8]>,
+			S: Serializer,
+		{
+			let maybe_hex = value.as_ref().map(|bytes| encode(bytes.as_ref()));
+			maybe_hex.serialize(serializer)
+		}
+
+		/// Deserialize an optional hex string into optional bytes.
+		///
+		/// # Errors
+		///
+		/// Returns the deserializer's error type if the input is not `null`
+		/// or a valid hex string.
+		pub fn deserialize<'de, D, T>(
+			deserializer: D,
+		) -> Result<Option<T>, D::Error>
+		where
+			D: Deserializer<'de>,
+			T: FromHex,
+		{
+			let maybe_hex = Option::<String>::deserialize(deserializer)?;
+			maybe_hex
+				.map(|hex| {
+					FromHex::from_hex(&hex)
+						.map_err(|e| serde::de::Error::custom(format!("{e:?}")))
+				})
+				.transpose()
+		}
 	}
 }
 

--- a/src/qos_hex/src/lib.rs
+++ b/src/qos_hex/src/lib.rs
@@ -347,8 +347,10 @@ pub mod serde {
 			T: AsRef<[u8]>,
 			S: Serializer,
 		{
-			let maybe_hex = value.as_ref().map(|bytes| encode(bytes.as_ref()));
-			maybe_hex.serialize(serializer)
+			value
+				.as_ref()
+				.map(|bytes| encode(bytes.as_ref()))
+				.serialize(serializer)
 		}
 
 		/// Deserialize an optional hex string into optional bytes.
@@ -364,11 +366,11 @@ pub mod serde {
 			D: Deserializer<'de>,
 			T: FromHex,
 		{
-			let maybe_hex = Option::<String>::deserialize(deserializer)?;
-			maybe_hex
-				.map(|hex| {
-					FromHex::from_hex(&hex)
-						.map_err(|e| serde::de::Error::custom(format!("{e:?}")))
+			Option::<String>::deserialize(deserializer)?
+				.as_deref()
+				.map(FromHex::from_hex)
+				.map(|res| {
+					res.map_err(|e| serde::de::Error::custom(format!("{e:?}")))
 				})
 				.transpose()
 		}

--- a/src/qos_hex/src/lib.rs
+++ b/src/qos_hex/src/lib.rs
@@ -333,8 +333,8 @@ pub mod serde {
 
 	/// Serde support for `Option<T>` where `T` is hex-encoded bytes.
 	pub mod option {
-		use super::{encode, Deserialize, Deserializer, FromHex, Serializer};
-		use serde::Serialize;
+		use super::{Deserializer, FromHex, Serializer, encode};
+		use serde::{Deserialize, Serialize};
 
 		/// Serialize optional bytes as an optional hex string.
 		///

--- a/src/qos_host/src/host.rs
+++ b/src/qos_host/src/host.rs
@@ -23,13 +23,12 @@ use axum::{
 	routing::{get, post},
 	Json, Router,
 };
-use borsh::BorshDeserialize;
 use qos_core::{
 	client::{ClientError, SocketClient},
 	io::SocketAddress,
 	protocol::{
-		msg::ProtocolMsg, services::boot::ManifestEnvelope, ProtocolError,
-		ProtocolPhase,
+		msg::ProtocolMsg, services::boot::VersionedManifestEnvelope,
+		ProtocolError, ProtocolPhase,
 	},
 };
 use qos_nsm::types::NsmResponse;
@@ -118,7 +117,8 @@ impl HostServer {
 	) -> impl IntoResponse {
 		println!("Enclave health...");
 
-		let encoded_request = borsh::to_vec(&ProtocolMsg::StatusRequest)
+		let encoded_request = ProtocolMsg::StatusRequest
+			.to_json_wire()
 			.expect("ProtocolMsg can always serialize. qed.");
 		let encoded_response = match state
 			.enclave_client
@@ -133,7 +133,7 @@ impl HostServer {
 			}
 		};
 
-		let response = match ProtocolMsg::try_from_slice(&encoded_response) {
+		let response = match ProtocolMsg::from_wire_any(&encoded_response) {
 			Ok(r) => r,
 			Err(e) => {
 				let msg = format!("Error deserializing response from enclave, make sure qos_host version match qos_core: {e}");
@@ -169,14 +169,15 @@ impl HostServer {
 	) -> Result<Json<EnclaveInfo>, Error> {
 		println!("Enclave info...");
 
-		let enc_status_req = borsh::to_vec(&ProtocolMsg::StatusRequest)
+		let enc_status_req = ProtocolMsg::StatusRequest
+			.to_json_wire()
 			.expect("ProtocolMsg can always serialize. qed.");
 		let enc_status_resp =
 			state.enclave_client.call(&enc_status_req).await.map_err(|e| {
 				Error(format!("error sending status request to enclave: {e:?}"))
 			})?;
 
-		let status_resp = match ProtocolMsg::try_from_slice(&enc_status_resp) {
+		let status_resp = match ProtocolMsg::from_wire_any(&enc_status_resp) {
 			Ok(status_resp) => status_resp,
 			Err(e) => {
 				return Err(Error(format!("error deserializing status response from enclave, make sure qos_host version match qos_core: {e:?}")));
@@ -196,13 +197,14 @@ impl HostServer {
 		let ephemeral_key =
 			get_eph_key_from_attestation_doc(&state.enclave_client).await;
 		let vitals_log = if let Some(m) = manifest_envelope.as_ref() {
+			let manifest = m.clone().manifest();
 			serde_json::to_string(&EnclaveVitalStats {
 				phase,
-				namespace: m.manifest.namespace.name.clone(),
-				nonce: m.manifest.namespace.nonce,
-				pivot_hash: m.manifest.pivot.hash,
-				pcr0: m.manifest.enclave.pcr0.clone(),
-				pivot_args: m.manifest.pivot.args.clone(),
+				namespace: manifest.namespace().name.clone(),
+				nonce: manifest.namespace().nonce,
+				pivot_hash: *manifest.pivot_hash(),
+				pcr0: manifest.enclave().pcr0.clone(),
+				pivot_args: manifest.args().to_vec(),
 				ephemeral_key: ephemeral_key.clone(),
 			})
 			.expect("always valid json. qed.")
@@ -229,10 +231,9 @@ impl HostServer {
 		if encoded_request.len() > MAX_ENCODED_MSG_LEN {
 			return (
 				StatusCode::BAD_REQUEST,
-				borsh::to_vec(&ProtocolMsg::ProtocolErrorResponse(
-					ProtocolError::OversizeMsg,
-				))
-				.expect("ProtocolMsg can always serialize. qed."),
+				ProtocolMsg::ProtocolErrorResponse(ProtocolError::OversizeMsg)
+					.to_json_wire()
+					.expect("ProtocolMsg can always serialize. qed."),
 			);
 		}
 
@@ -244,9 +245,10 @@ impl HostServer {
 
 				(
 					StatusCode::INTERNAL_SERVER_ERROR,
-					borsh::to_vec(&ProtocolMsg::ProtocolErrorResponse(
+					ProtocolMsg::ProtocolErrorResponse(
 						ProtocolError::EnclaveClient,
-					))
+					)
+					.to_json_wire()
 					.expect("ProtocolMsg can always serialize. qed."),
 				)
 			}
@@ -259,9 +261,9 @@ async fn get_eph_key_from_attestation_doc(
 ) -> Option<String> {
 	use ProtocolMsg::LiveAttestationDocResponse;
 
-	let req = borsh::to_vec(&ProtocolMsg::LiveAttestationDocRequest).ok()?;
+	let req = ProtocolMsg::LiveAttestationDocRequest.to_json_wire().ok()?;
 	let resp_bytes = enclave_client.call(&req).await.ok()?;
-	let resp = ProtocolMsg::try_from_slice(&resp_bytes).ok()?;
+	let resp = ProtocolMsg::from_wire_any(&resp_bytes).ok()?;
 
 	let LiveAttestationDocResponse { nsm_response, .. } = resp else {
 		return None;
@@ -279,15 +281,16 @@ async fn get_eph_key_from_attestation_doc(
 // try to get the manifest denvelope from the enclave, used for restart handling of qos_host
 async fn get_manifest_envelope(
 	enclave_client: &SocketClient,
-) -> Result<Option<ManifestEnvelope>, ClientError> {
-	let enc_manifest_envelope_req =
-		borsh::to_vec(&ProtocolMsg::ManifestEnvelopeRequest)
-			.expect("ProtocolMsg can always serialize. qed.");
+) -> Result<Option<VersionedManifestEnvelope>, ClientError> {
+	let enc_manifest_envelope_req = ProtocolMsg::ManifestEnvelopeRequest
+		.to_json_wire()
+		.expect("ProtocolMsg can always serialize. qed.");
 	let enc_manifest_envelope_resp =
 		enclave_client.call(&enc_manifest_envelope_req).await?;
 
 	let manifest_envelope_resp =
-		ProtocolMsg::try_from_slice(&enc_manifest_envelope_resp)?;
+		ProtocolMsg::from_wire_any(&enc_manifest_envelope_resp)
+			.map_err(|_| ClientError::ResponseMismatch)?;
 
 	let manifest_envelope = match manifest_envelope_resp {
 		ProtocolMsg::ManifestEnvelopeResponse { manifest_envelope } => {

--- a/src/qos_host/src/lib.rs
+++ b/src/qos_host/src/lib.rs
@@ -19,7 +19,7 @@ use axum::{
 	Json,
 };
 use qos_core::protocol::{
-	services::boot::ManifestEnvelope, Hash256, ProtocolPhase,
+	services::boot::VersionedManifestEnvelope, Hash256, ProtocolPhase,
 };
 
 pub mod cli;
@@ -59,7 +59,7 @@ pub struct EnclaveInfo {
 	/// Current phase of the enclave.
 	pub phase: ProtocolPhase,
 	/// Manifest envelope in the enclave.
-	pub manifest_envelope: Option<ManifestEnvelope>,
+	pub manifest_envelope: Option<VersionedManifestEnvelope>,
 	/// Ephemeral public key from the live attestation doc.
 	pub ephemeral_key: Option<String>,
 }

--- a/src/qos_json/Cargo.toml
+++ b/src/qos_json/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "qos_json"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Canonical JSON encoding for deterministic JSON"
+repository = "https://github.com/tkhq/qos"
+keywords = ["quorumos", "serde", "encoding"]
+categories = ["encoding"]
+
+[lints]
+workspace = true
+
+[dependencies]
+qos_hex = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+
+[dev-dependencies]
+qos_hex = { workspace = true, features = ["serde"] }

--- a/src/qos_json/Cargo.toml
+++ b/src/qos_json/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 [dependencies]
 qos_hex = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["raw_value"] }
 sha2 = { workspace = true }
 
 [dev-dependencies]

--- a/src/qos_json/Cargo.toml
+++ b/src/qos_json/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 [dependencies]
 qos_hex = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true, features = ["raw_value"] }
+serde_json = { workspace = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]

--- a/src/qos_json/SPEC.md
+++ b/src/qos_json/SPEC.md
@@ -1,0 +1,112 @@
+# QOS Canonical JSON
+
+QOS uses JSON for protocol messages and signing payloads. Any JSON bytes that
+are hashed, signed, or verified MUST be canonicalized using QOS-normalized RFC
+8785-style canonical JSON. QOS intentionally differs from RFC 8785 by
+normalizing integer JSON numbers to decimal strings and rejecting non-integer
+numbers.
+
+## Canonicalization
+
+- Implementations MUST parse JSON into a JSON value and re-encode that value as
+  QOS-normalized RFC 8785-style canonical JSON before hashing or signing.
+- Implementations MUST NOT hash or sign raw inbound JSON bytes. Equivalent JSON
+  documents can differ in whitespace or field order.
+- Implementations that serialize typed values for hashing or signing MUST use
+  the same canonical JSON encoding scheme used for parsed JSON values.
+- QOS normalization treats object members with `null` values as unset fields
+  and MUST omit those object members before canonicalization. This means typed
+  optional fields that serialize as `null` are omitted by the canonical encoder.
+  Other `null` values are preserved. In particular, null array elements are not
+  omitted because that would change array length and indexes.
+- JSON object properties MUST be sorted recursively by raw, unescaped property
+  names encoded as UTF-16 code units, as specified by RFC 8785 section 3.2.3.
+  This matters for non-ASCII names: for example, the RFC 8785 sample order is
+  carriage return, `1`, U+0080, `ö`, `€`, grinning-face emoji, and U+FB33.
+- Integer JSON number tokens MUST canonicalize as decimal JSON strings.
+- Non-integer JSON number tokens (for example `1.0`, `1e3`, `-0.5`) MUST be
+  rejected during canonical serialization.
+
+## Signing Object Schemas
+
+- Each signing object MUST have a specified JSON schema. This specification is
+  not, by itself, a rule for choosing every field representation in every
+  signing object.
+- The schema for each signing object MUST specify object field names, enum
+  representations, binary encodings, numeric encodings, and which fields are
+  optional.
+- Unset optional object fields are omitted by QOS canonicalization when they
+  serialize as `null`. Rust schemas SHOULD use `#[serde(default)]` on optional
+  fields that readers must accept when absent.
+- Optional fields in QOS JSON schemas MUST also use
+  `#[serde(skip_serializing_if = "Option::is_none")]` so absent values encode
+  canonically as omitted object fields rather than explicit `null`.
+- QOS canonicalization preserves empty arrays and empty objects. A signing
+  object schema MAY specify type-specific serialization rules that omit an empty
+  map/object field before canonicalization.
+- New fields SHOULD be optional unless every deployed reader can tolerate the
+  field. Append-friendly schemas rely on canonical null-member omission so older
+  and newer writers produce the same payload until the new field is populated.
+- Binary values SHOULD be lowercase hex strings unless the signing object schema
+  explicitly specifies another representation. Rust schemas SHOULD use
+  `#[serde(with = "qos_hex::serde")]` for byte fields represented this way.
+- Enums SHOULD use serde's externally tagged representation unless the signing
+  object schema explicitly specifies another representation.
+- Numeric values in QOS JSON are specified as decimal strings.
+- Rust integer fields in QOS JSON structs SHOULD use
+  `#[serde(with = "qos_json::string_or_numeric")]` to support decoding both
+  string and numeric inputs.
+- Floating point values MUST NOT be introduced into QOS signing payloads.
+
+## Test Vectors
+
+These vectors show the relevant schema pattern, canonical JSON, and SHA-256
+hash. The Rust unit tests in `src/qos_json/src/lib.rs` exercise these vectors
+and additional edge cases for null omission, array preservation, string
+escaping, UTF-16 property ordering, typed/raw hash equivalence, numeric
+normalization, and rejected non-integer JSON number tokens.
+
+Schema: no fields.
+
+```json
+{}
+```
+
+SHA-256:
+`44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`
+
+Schema:
+
+```rust
+#[derive(serde::Serialize)]
+struct Example {
+    version: String,
+    name: String,
+    #[serde(with = "qos_json::string_or_numeric")]
+    threshold: u32,
+}
+```
+
+```json
+{"name":"test","threshold":"3","version":"1"}
+```
+
+SHA-256:
+`898eaf2263b3ca34a9fb0b59615a16e5819b43c53fabc44396f92128f72ccc7e`
+
+Schema:
+
+```rust
+#[derive(serde::Serialize)]
+struct Example {
+    #[serde(with = "qos_hex::serde")]
+    data: Vec<u8>,
+}
+```
+
+```json
+{"data":"deadbeef"}
+```
+
+SHA-256:
+`03fe564ceddcb54a7a742bd7a4db57318a068cecd22ae44435ce68d35e754e13`

--- a/src/qos_json/SPEC.md
+++ b/src/qos_json/SPEC.md
@@ -1,19 +1,19 @@
 # QOS Canonical JSON
 
-QOS uses JSON for protocol messages and signing payloads. Any JSON bytes that
-are hashed, signed, or verified MUST be canonicalized using QOS-normalized RFC
-8785-style canonical JSON. QOS intentionally differs from RFC 8785 by
-normalizing integer JSON numbers to decimal strings and rejecting non-integer
-numbers.
+QOS uses JSON for protocol messages and signing payloads. QOS JSON is primarily
+a canonicalization format for hashing/signing and verification, not a transport
+format. Any JSON bytes that are hashed, signed, or verified MUST be
+canonicalized using QOS-normalized RFC 8785-style canonical JSON. QOS
+intentionally differs from RFC 8785 by normalizing integer JSON numbers to
+base-10 integer strings and rejecting non-integer numbers.
 
 ## Canonicalization
 
-- Implementations MUST parse JSON into a JSON value and re-encode that value as
-  QOS-normalized RFC 8785-style canonical JSON before hashing or signing.
-- Implementations MUST NOT hash or sign raw inbound JSON bytes. Equivalent JSON
-  documents can differ in whitespace or field order.
-- Implementations that serialize typed values for hashing or signing MUST use
-  the same canonical JSON encoding scheme used for parsed JSON values.
+- Implementations MUST NOT hash or sign inbound JSON bytes directly.
+- Inbound JSON used for hashing/signing MUST be parsed into the target schema
+  type, then serialized with QOS canonical JSON.
+- Semantically equivalent payloads MUST produce identical canonical bytes after
+  deserialize-to-schema then serialize-to-QOS-JSON.
 - QOS normalization treats object members with `null` values as unset fields
   and MUST omit those object members before canonicalization. This means typed
   optional fields that serialize as `null` are omitted by the canonical encoder.
@@ -23,7 +23,7 @@ numbers.
   names encoded as UTF-16 code units, as specified by RFC 8785 section 3.2.3.
   This matters for non-ASCII names: for example, the RFC 8785 sample order is
   carriage return, `1`, U+0080, `ö`, `€`, grinning-face emoji, and U+FB33.
-- Integer JSON number tokens MUST canonicalize as decimal JSON strings.
+- Integer JSON number tokens MUST canonicalize as base-10 integer JSON strings.
 - Non-integer JSON number tokens (for example `1.0`, `1e3`, `-0.5`) MUST be
   rejected during canonical serialization.
 
@@ -35,6 +35,8 @@ numbers.
 - The schema for each signing object MUST specify object field names, enum
   representations, binary encodings, numeric encodings, and which fields are
   optional.
+- Hashing/signing pipelines MUST be schema-first: deserialize inbound JSON to
+  the schema type, then serialize with QOS JSON.
 - Unset optional object fields are omitted by QOS canonicalization when they
   serialize as `null`. Rust schemas SHOULD use `#[serde(default)]` on optional
   fields that readers must accept when absent.
@@ -52,7 +54,7 @@ numbers.
   `#[serde(with = "qos_hex::serde")]` for byte fields represented this way.
 - Enums SHOULD use serde's externally tagged representation unless the signing
   object schema explicitly specifies another representation.
-- Numeric values in QOS JSON are specified as decimal strings.
+- Numeric values in QOS JSON are specified as base-10 integer strings.
 - Rust integer fields in QOS JSON structs SHOULD use
   `#[serde(with = "qos_json::string_or_numeric")]` to support decoding both
   string and numeric inputs.

--- a/src/qos_json/SPEC.md
+++ b/src/qos_json/SPEC.md
@@ -53,9 +53,16 @@ base-10 integer strings and rejecting non-integer numbers.
   map/object field before canonicalization.
 - New fields SHOULD be optional unless every deployed reader can tolerate the
   field.
-- Binary values SHOULD be lowercase hex strings unless the signing object schema
-  explicitly specifies another representation. Rust schemas SHOULD use
-  `#[serde(with = "qos_hex::serde")]` for byte fields represented this way.
+- Public keys SHOULD be encoded as lowercase hex strings. This keeps key
+  material more readable during review/audit and avoids introducing extra
+  alphabet/format dependencies (for example SS58) into all implementations.
+- Other binary values SHOULD be encoded as either lowercase hex strings or
+  base64 strings, as specified by each signing object schema.
+- Each signing object schema MUST explicitly specify the binary encoding used
+  by each byte field and keep it stable for compatibility.
+- Rust schemas SHOULD use `#[serde(with = "qos_hex::serde")]` for byte fields
+  represented as hex. Base64-encoded byte fields SHOULD use an explicit serde
+  adapter chosen by that schema.
 - Enums SHOULD use serde's
   [externally tagged representation](https://serde.rs/enum-representations.html)
   unless the signing object schema explicitly specifies another representation.

--- a/src/qos_json/SPEC.md
+++ b/src/qos_json/SPEC.md
@@ -3,7 +3,8 @@
 QOS uses JSON for protocol messages and signing payloads. QOS JSON is primarily
 a canonicalization format for hashing/signing and verification, not a transport
 format. Any JSON bytes that are hashed, signed, or verified MUST be
-canonicalized using QOS-normalized RFC 8785-style canonical JSON. QOS
+canonicalized using QOS-normalized
+[RFC 8785](https://www.rfc-editor.org/rfc/rfc8785)-style canonical JSON. QOS
 intentionally differs from RFC 8785 by normalizing integer JSON numbers to
 base-10 integer strings and rejecting non-integer numbers.
 
@@ -15,31 +16,35 @@ base-10 integer strings and rejecting non-integer numbers.
 - Semantically equivalent payloads MUST produce identical canonical bytes after
   deserialize-to-schema then serialize-to-QOS-JSON.
 - QOS normalization treats object members with `null` values as unset fields
-  and MUST omit those object members before canonicalization. This means typed
-  optional fields that serialize as `null` are omitted by the canonical encoder.
-  Other `null` values are preserved. In particular, null array elements are not
-  omitted because that would change array length and indexes.
+  and MUST omit those object members before canonicalization. Object field names
+  provide domain separation, so omitting an unset field is safe. Other `null`
+  values are preserved: top-level `null` is a complete JSON value, and null
+  array elements are positional data that cannot be omitted without changing
+  array length and indexes.
 - JSON object properties MUST be sorted recursively by raw, unescaped property
   names encoded as UTF-16 code units, as specified by RFC 8785 section 3.2.3.
   This matters for non-ASCII names: for example, the RFC 8785 sample order is
   carriage return, `1`, U+0080, `ö`, `€`, grinning-face emoji, and U+FB33.
-- Integer JSON number tokens MUST canonicalize as base-10 integer JSON strings.
-- Non-integer JSON number tokens (for example `1.0`, `1e3`, `-0.5`) MUST be
-  rejected during canonical serialization.
+- Integer JSON number tokens MUST canonicalize as base-10 integer JSON strings:
+  for example, `1` canonicalizes as `"1"` and `-42` canonicalizes as `"-42"`.
+- Non-integer JSON number tokens (for example `1.0`, `1e3`, `-0.5`) MUST reject
+  the entire deserialization/canonicalization operation. They are not coerced,
+  rounded, or treated as absent optional values.
 
 ## Signing Object Schemas
 
-- Each signing object MUST have a specified JSON schema. This specification is
-  not, by itself, a rule for choosing every field representation in every
-  signing object.
+- Each signing object MUST have a specified JSON schema. This specification
+  defines canonical encoding rules.
 - The schema for each signing object MUST specify object field names, enum
   representations, binary encodings, numeric encodings, and which fields are
   optional.
 - Hashing/signing pipelines MUST be schema-first: deserialize inbound JSON to
   the schema type, then serialize with QOS JSON.
 - Unset optional object fields are omitted by QOS canonicalization when they
-  serialize as `null`. Rust schemas SHOULD use `#[serde(default)]` on optional
-  fields that readers must accept when absent.
+  serialize as `null`. This supports append-friendly schemas: older and newer
+  writers produce the same payload until the new field is populated. Rust
+  schemas SHOULD use `#[serde(default)]` on optional fields that readers must
+  accept when absent.
 - Optional fields in QOS JSON schemas MUST also use
   `#[serde(skip_serializing_if = "Option::is_none")]` so absent values encode
   canonically as omitted object fields rather than explicit `null`.
@@ -47,14 +52,15 @@ base-10 integer strings and rejecting non-integer numbers.
   object schema MAY specify type-specific serialization rules that omit an empty
   map/object field before canonicalization.
 - New fields SHOULD be optional unless every deployed reader can tolerate the
-  field. Append-friendly schemas rely on canonical null-member omission so older
-  and newer writers produce the same payload until the new field is populated.
+  field.
 - Binary values SHOULD be lowercase hex strings unless the signing object schema
   explicitly specifies another representation. Rust schemas SHOULD use
   `#[serde(with = "qos_hex::serde")]` for byte fields represented this way.
-- Enums SHOULD use serde's externally tagged representation unless the signing
-  object schema explicitly specifies another representation.
-- Numeric values in QOS JSON are specified as base-10 integer strings.
+- Enums SHOULD use serde's
+  [externally tagged representation](https://serde.rs/enum-representations.html)
+  unless the signing object schema explicitly specifies another representation.
+- Numeric values in QOS JSON are specified as base-10 integer strings, such as
+  `"0"`, `"42"`, and `"-7"`.
 - Rust integer fields in QOS JSON structs SHOULD use
   `#[serde(with = "qos_json::string_or_numeric")]` to support decoding both
   string and numeric inputs.

--- a/src/qos_json/src/lib.rs
+++ b/src/qos_json/src/lib.rs
@@ -169,7 +169,7 @@ where
 /// Serde helpers that tolerate numeric input as either string or integer.
 pub mod string_or_numeric {
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
-	use serde_json::value::RawValue;
+	use serde_json::Value;
 	use std::{collections::BTreeSet, fmt::Display, str::FromStr};
 
 	/// Serialize using default serde behavior for the field type.
@@ -258,8 +258,8 @@ pub mod string_or_numeric {
 		where
 			D: Deserializer<'de>,
 		{
-			let opt = Option::<Box<RawValue>>::deserialize(deserializer)?;
-			opt.as_deref().map(parse_string_or_numeric_raw).transpose()
+			let opt = Option::<Value>::deserialize(deserializer)?;
+			opt.as_ref().map(parse_string_or_numeric_raw).transpose()
 		}
 	}
 
@@ -281,7 +281,7 @@ pub mod string_or_numeric {
 		where
 			D: Deserializer<'de>,
 		{
-			let values = Vec::<Box<RawValue>>::deserialize(deserializer)?;
+			let values = Vec::<Value>::deserialize(deserializer)?;
 			values
 				.iter()
 				.map(|value| parse_string_or_numeric_raw(value))
@@ -297,22 +297,21 @@ pub mod string_or_numeric {
 		T: FromStr,
 		T::Err: Display,
 	{
-		let value = <Box<RawValue>>::deserialize(deserializer)?;
+		let value = Value::deserialize(deserializer)?;
 		parse_string_or_numeric_raw(&value)
 	}
 
-	fn parse_string_or_numeric_raw<E, T>(value: &RawValue) -> Result<T, E>
+	fn parse_string_or_numeric_raw<E, T>(value: &Value) -> Result<T, E>
 	where
 		E: serde::de::Error,
 		T: FromStr,
 		T::Err: Display,
 	{
-		let raw = value.get();
-		if let Some(s) = raw.strip_prefix('"').and_then(|s| s.strip_suffix('"'))
-		{
-			return s.parse().map_err(E::custom);
+		match value {
+			Value::String(s) => s.parse().map_err(E::custom),
+			Value::Number(n) => n.to_string().parse().map_err(E::custom),
+			_ => Err(E::custom("expected string or integer")),
 		}
-		raw.parse().map_err(E::custom)
 	}
 }
 

--- a/src/qos_json/src/lib.rs
+++ b/src/qos_json/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../SPEC.md")]
 
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 use sha2::{Digest, Sha256};
 use std::io::{self, Write};
 
@@ -712,10 +712,12 @@ mod tests {
 		.unwrap();
 		assert_eq!(parsed.indexes, BTreeSet::from([1]));
 
-		assert!(from_slice::<Example>(
-			br#"{"count":42.5,"limit":"7","indexes":["1"]}"#
-		)
-		.is_err());
+		assert!(
+			from_slice::<Example>(
+				br#"{"count":42.5,"limit":"7","indexes":["1"]}"#
+			)
+			.is_err()
+		);
 		let parsed = from_slice::<Example>(
 			br#"{"count":"\u0034\u0032","limit":"7","indexes":["1"]}"#,
 		)

--- a/src/qos_json/src/lib.rs
+++ b/src/qos_json/src/lib.rs
@@ -716,10 +716,11 @@ mod tests {
 			br#"{"count":42.5,"limit":"7","indexes":["1"]}"#
 		)
 		.is_err());
-		assert!(from_slice::<Example>(
-			br#"{"count":"\u0034\u0032","limit":"7","indexes":["1"]}"#
+		let parsed = from_slice::<Example>(
+			br#"{"count":"\u0034\u0032","limit":"7","indexes":["1"]}"#,
 		)
-		.is_err());
+		.unwrap();
+		assert_eq!(parsed.count, 42);
 	}
 
 	fn assert_qos_number_error<T>(result: serde_json::Result<T>) {

--- a/src/qos_json/src/lib.rs
+++ b/src/qos_json/src/lib.rs
@@ -1,0 +1,748 @@
+#![doc = include_str!("../SPEC.md")]
+
+use serde::{de::DeserializeOwned, Serialize};
+use sha2::{Digest, Sha256};
+use std::io::{self, Write};
+
+/// A SHA-256 digest.
+pub type Hash256 = [u8; 32];
+
+/// Serialize a value as QOS canonical JSON bytes.
+///
+/// Typed values are first converted into `serde_json::Value` and then
+/// canonicalized. This matches the inbound JSON hashing path, where bytes are
+/// parsed and re-encoded before hashing.
+///
+/// # Errors
+///
+/// Returns an error if serde serialization or canonical JSON serialization
+/// fails, including if the value contains a non-integer JSON number. QOS
+/// canonical JSON normalizes integer numbers to decimal strings.
+pub fn to_vec<T: Serialize>(value: &T) -> serde_json::Result<Vec<u8>> {
+	let value = serde_json::to_value(value)?;
+	to_vec_value(&value)
+}
+
+/// Serialize a value as a QOS canonical JSON string.
+///
+/// # Errors
+///
+/// Returns an error if serde serialization or canonical JSON serialization
+/// fails, including if the value contains a non-integer JSON number. QOS
+/// canonical JSON normalizes integer numbers to decimal strings.
+pub fn to_string<T: Serialize>(value: &T) -> serde_json::Result<String> {
+	let value = serde_json::to_value(value)?;
+	to_string_value(&value)
+}
+
+/// Parse JSON bytes and re-encode them as QOS canonical JSON bytes.
+///
+/// # Errors
+///
+/// Returns an error if parsing or canonicalization fails, including if the
+/// parsed value contains a non-integer JSON number. QOS canonical JSON
+/// normalizes integer numbers to decimal strings.
+pub fn canonicalize_slice(bytes: &[u8]) -> serde_json::Result<Vec<u8>> {
+	let value: serde_json::Value = serde_json::from_slice(bytes)?;
+	to_vec_value(&value)
+}
+
+/// Parse a JSON string and re-encode it as a QOS canonical JSON string.
+///
+/// # Errors
+///
+/// Returns an error if parsing or canonicalization fails, including if the
+/// parsed value contains a non-integer JSON number. QOS canonical JSON
+/// normalizes integer numbers to decimal strings.
+pub fn canonicalize_str(json: &str) -> serde_json::Result<String> {
+	let value: serde_json::Value = serde_json::from_str(json)?;
+	to_string_value(&value)
+}
+
+/// Deserialize JSON bytes as `T`.
+///
+/// # Errors
+///
+/// Returns an error if the bytes are not valid JSON for `T`.
+pub fn from_slice<T: DeserializeOwned>(bytes: &[u8]) -> serde_json::Result<T> {
+	serde_json::from_slice(bytes)
+}
+
+/// Hash a typed value after QOS canonical JSON serialization.
+///
+/// # Errors
+///
+/// Returns an error if serialization or canonicalization fails, including if the
+/// value contains a non-integer JSON number. QOS canonical JSON normalizes
+/// integer numbers to decimal strings.
+pub fn hash<T: Serialize>(value: &T) -> serde_json::Result<Hash256> {
+	let canonical = to_vec(value)?;
+	Ok(sha_256(&canonical))
+}
+
+/// Hash inbound JSON after parsing and QOS re-canonicalization.
+///
+/// # Errors
+///
+/// Returns an error if parsing or canonicalization fails, including if the
+/// parsed value contains a non-integer JSON number. QOS canonical JSON
+/// normalizes integer numbers to decimal strings.
+pub fn hash_json_slice(bytes: &[u8]) -> serde_json::Result<Hash256> {
+	let canonical = canonicalize_slice(bytes)?;
+	Ok(sha_256(&canonical))
+}
+
+/// Hash a typed value and return the lowercase hex digest.
+///
+/// # Errors
+///
+/// Returns an error if serialization or canonicalization fails, including if the
+/// value contains a non-integer JSON number. QOS canonical JSON normalizes
+/// integer numbers to decimal strings.
+pub fn hash_hex<T: Serialize>(value: &T) -> serde_json::Result<String> {
+	hash(value).map(|hash| qos_hex::encode(&hash))
+}
+
+fn sha_256(bytes: &[u8]) -> Hash256 {
+	let mut hasher = Sha256::new();
+	hasher.update(bytes);
+	hasher.finalize().into()
+}
+
+fn to_vec_value(value: &serde_json::Value) -> serde_json::Result<Vec<u8>> {
+	let mut bytes = Vec::new();
+	to_writer_value(&mut bytes, value)?;
+	Ok(bytes)
+}
+
+fn to_string_value(value: &serde_json::Value) -> serde_json::Result<String> {
+	let bytes = to_vec_value(value)?;
+	String::from_utf8(bytes).map_err(|err| {
+		serde_json::Error::io(io::Error::new(io::ErrorKind::InvalidData, err))
+	})
+}
+
+fn to_writer_value<W>(
+	writer: &mut W,
+	value: &serde_json::Value,
+) -> serde_json::Result<()>
+where
+	W: ?Sized + Write,
+{
+	write_value(writer, value).map_err(serde_json::Error::io)
+}
+
+fn write_value<W>(writer: &mut W, value: &serde_json::Value) -> io::Result<()>
+where
+	W: ?Sized + Write,
+{
+	match value {
+		// Preserve null values outside object fields. A top-level `null` is a
+		// complete JSON value, and array nulls are positional data: `[null,"1"]`
+		// must not canonicalize to `["1"]`. Dynamic array positions do not provide
+		// the same domain separation as object field names. We do drop null object
+		// fields in `write_object`, where field-name domain separation makes it safe.
+		serde_json::Value::Null => writer.write_all(b"null"),
+		serde_json::Value::Bool(true) => writer.write_all(b"true"),
+		serde_json::Value::Bool(false) => writer.write_all(b"false"),
+		serde_json::Value::Number(number)
+			if number.is_u64() || number.is_i64() =>
+		{
+			write_string(writer, &number.to_string())
+		}
+		serde_json::Value::Number(_) => Err(io::Error::new(
+			io::ErrorKind::InvalidData,
+			"QOS canonical JSON forbids non-integer JSON numbers",
+		)),
+		serde_json::Value::String(value) => write_string(writer, value),
+		serde_json::Value::Array(values) => write_array(writer, values),
+		serde_json::Value::Object(map) => write_object(writer, map),
+	}
+}
+
+fn write_array<W>(
+	writer: &mut W,
+	values: &[serde_json::Value],
+) -> io::Result<()>
+where
+	W: ?Sized + Write,
+{
+	writer.write_all(b"[")?;
+	for (index, value) in values.iter().enumerate() {
+		if index > 0 {
+			writer.write_all(b",")?;
+		}
+		write_value(writer, value)?;
+	}
+	writer.write_all(b"]")
+}
+
+fn write_object<W>(
+	writer: &mut W,
+	map: &serde_json::Map<String, serde_json::Value>,
+) -> io::Result<()>
+where
+	W: ?Sized + Write,
+{
+	// Drop null object fields before writing the object. This is safe because
+	// the field name provides domain separation for each value:
+	// `{"a":null,"b":"1"}` canonicalizes to `{"b":"1"}`. Arrays are not
+	// filtered this way because array indexes are dynamic positions.
+	let mut entries =
+		map.iter().filter(|(_, value)| !value.is_null()).collect::<Vec<_>>();
+	entries.sort_by(|(left, _), (right, _)| {
+		left.encode_utf16().cmp(right.encode_utf16())
+	});
+
+	writer.write_all(b"{")?;
+	for (index, (key, value)) in entries.into_iter().enumerate() {
+		if index > 0 {
+			writer.write_all(b",")?;
+		}
+		write_string(writer, key)?;
+		writer.write_all(b":")?;
+		write_value(writer, value)?;
+	}
+	writer.write_all(b"}")
+}
+
+fn write_string<W>(writer: &mut W, value: &str) -> io::Result<()>
+where
+	W: ?Sized + Write,
+{
+	serde_json::to_writer(writer, value).map_err(io::Error::other)
+}
+
+fn decimal_string_from_json_value<E>(
+	value: serde_json::Value,
+) -> Result<String, E>
+where
+	E: serde::de::Error,
+{
+	match value {
+		serde_json::Value::String(s) => Ok(s),
+		serde_json::Value::Number(n) if n.is_u64() || n.is_i64() => {
+			Ok(n.to_string())
+		}
+		other => Err(E::custom(format!(
+			"expected decimal string or integer, got {other}"
+		))),
+	}
+}
+
+/// Serde helpers that tolerate numeric input as either string or integer.
+pub mod string_or_numeric {
+	use serde::{Deserialize, Deserializer, Serialize, Serializer};
+	use std::{collections::BTreeSet, fmt::Display, str::FromStr};
+
+	/// Serialize using default serde behavior for the field type.
+	///
+	/// # Errors
+	///
+	/// Returns the serializer's error type if serialization fails.
+	pub fn serialize<S, T>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+		T: Serialize,
+	{
+		value.serialize(serializer)
+	}
+
+	/// Deserialize from either decimal string or integer JSON number.
+	///
+	/// # Errors
+	///
+	/// Returns the deserializer's error type if the input is not a valid decimal
+	/// string/integer for the target type.
+	pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+	where
+		D: Deserializer<'de>,
+		T: StringOrNumericDeserialize<'de>,
+	{
+		T::deserialize_string_or_numeric(deserializer)
+	}
+
+	/// A type that can be deserialized from one or more decimal string/integer
+	/// JSON values.
+	pub trait StringOrNumericDeserialize<'de>: Sized {
+		/// Deserialize from decimal string/integer JSON.
+		///
+		/// # Errors
+		///
+		/// Returns the deserializer's error type if the input is not valid for
+		/// the target type.
+		fn deserialize_string_or_numeric<D>(
+			deserializer: D,
+		) -> Result<Self, D::Error>
+		where
+			D: Deserializer<'de>;
+	}
+
+	macro_rules! impl_string_or_numeric_deserialize {
+		($($ty:ty),+ $(,)?) => {$(
+			impl<'de> StringOrNumericDeserialize<'de> for $ty {
+				fn deserialize_string_or_numeric<D>(
+					deserializer: D,
+				) -> Result<Self, D::Error>
+				where
+					D: Deserializer<'de>,
+				{
+					deserialize_string_or_numeric_value(deserializer)
+				}
+			}
+		)+};
+	}
+
+	impl_string_or_numeric_deserialize!(
+		u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize
+	);
+
+	impl<'de, T> StringOrNumericDeserialize<'de> for Option<T>
+	where
+		T: FromStr,
+		T::Err: Display,
+	{
+		fn deserialize_string_or_numeric<D>(
+			deserializer: D,
+		) -> Result<Self, D::Error>
+		where
+			D: Deserializer<'de>,
+		{
+			let opt = Option::<serde_json::Value>::deserialize(deserializer)?;
+			opt.map(parse_string_or_numeric_value).transpose()
+		}
+	}
+
+	impl<'de, T> StringOrNumericDeserialize<'de> for BTreeSet<T>
+	where
+		T: FromStr + Ord,
+		T::Err: Display,
+	{
+		fn deserialize_string_or_numeric<D>(
+			deserializer: D,
+		) -> Result<Self, D::Error>
+		where
+			D: Deserializer<'de>,
+		{
+			let values = Vec::<serde_json::Value>::deserialize(deserializer)?;
+			values.into_iter().map(parse_string_or_numeric_value).collect()
+		}
+	}
+
+	fn deserialize_string_or_numeric_value<'de, D, T>(
+		deserializer: D,
+	) -> Result<T, D::Error>
+	where
+		D: Deserializer<'de>,
+		T: FromStr,
+		T::Err: Display,
+	{
+		let value = serde_json::Value::deserialize(deserializer)?;
+		parse_string_or_numeric_value(value)
+	}
+
+	fn parse_string_or_numeric_value<E, T>(
+		value: serde_json::Value,
+	) -> Result<T, E>
+	where
+		E: serde::de::Error,
+		T: FromStr,
+		T::Err: Display,
+	{
+		let s = super::decimal_string_from_json_value::<E>(value)?;
+		s.parse().map_err(serde::de::Error::custom)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use serde::{Deserialize, Serialize};
+	use std::collections::BTreeSet;
+
+	#[test]
+	fn canonicalizes_key_order_before_hashing() {
+		let a = br#"{"version":"1","name":"test","threshold":"3"}"#;
+		let b = br#"{
+			"threshold": "3",
+			"name": "test",
+			"version": "1"
+		}"#;
+
+		assert_eq!(
+			canonicalize_slice(a).unwrap(),
+			canonicalize_slice(b).unwrap()
+		);
+		assert_eq!(hash_json_slice(a).unwrap(), hash_json_slice(b).unwrap());
+		assert_eq!(
+			qos_hex::encode(&hash_json_slice(a).unwrap()),
+			"898eaf2263b3ca34a9fb0b59615a16e5819b43c53fabc44396f92128f72ccc7e"
+		);
+	}
+
+	#[test]
+	fn typed_values_use_same_canonical_path() {
+		#[derive(Serialize)]
+		struct Example {
+			version: &'static str,
+			name: &'static str,
+			threshold: &'static str,
+		}
+
+		let example = Example { version: "1", name: "test", threshold: "3" };
+		assert_eq!(
+			to_string(&example).unwrap(),
+			r#"{"name":"test","threshold":"3","version":"1"}"#
+		);
+		assert_eq!(
+			hash_hex(&example).unwrap(),
+			"898eaf2263b3ca34a9fb0b59615a16e5819b43c53fabc44396f92128f72ccc7e"
+		);
+	}
+
+	#[test]
+	fn binary_hex_vector_matches_spec() {
+		#[derive(Serialize)]
+		struct Example {
+			#[serde(with = "qos_hex::serde")]
+			data: Vec<u8>,
+		}
+
+		let example = Example { data: vec![0xde, 0xad, 0xbe, 0xef] };
+		assert_eq!(to_string(&example).unwrap(), r#"{"data":"deadbeef"}"#);
+		assert_eq!(
+			hash_hex(&example).unwrap(),
+			"03fe564ceddcb54a7a742bd7a4db57318a068cecd22ae44435ce68d35e754e13"
+		);
+	}
+
+	#[test]
+	fn skip_serializing_if_none_is_not_needed_for_qos_json_output() {
+		#[derive(Serialize)]
+		struct WithSkip {
+			name: &'static str,
+			#[serde(default, skip_serializing_if = "Option::is_none")]
+			maybe: Option<&'static str>,
+		}
+
+		#[derive(Serialize)]
+		struct WithoutSkip {
+			name: &'static str,
+			#[serde(default)]
+			maybe: Option<&'static str>,
+		}
+
+		let with_skip =
+			to_string(&WithSkip { name: "test", maybe: None }).unwrap();
+		let without_skip =
+			to_string(&WithoutSkip { name: "test", maybe: None }).unwrap();
+
+		assert_eq!(
+			serde_json::to_string(&WithSkip { name: "test", maybe: None })
+				.unwrap(),
+			r#"{"name":"test"}"#
+		);
+		assert_eq!(
+			serde_json::to_string(&WithoutSkip { name: "test", maybe: None })
+				.unwrap(),
+			r#"{"name":"test","maybe":null}"#
+		);
+		assert_eq!(with_skip, r#"{"name":"test"}"#);
+		assert_eq!(with_skip, without_skip);
+		assert_eq!(
+			to_string(&WithSkip { name: "test", maybe: Some("value") })
+				.unwrap(),
+			to_string(&WithoutSkip { name: "test", maybe: Some("value") })
+				.unwrap()
+		);
+	}
+
+	#[test]
+	fn object_null_members_are_omitted() {
+		assert_eq!(
+			canonicalize_str(r#"{"b":null,"a":"1","nested":{"z":null,"y":"2"},"items":[null,{"x":null,"y":true}]}"#).unwrap(),
+			r#"{"a":"1","items":[null,{"y":true}],"nested":{"y":"2"}}"#
+		);
+		assert_eq!(
+			hash_json_slice(br#"{"a":"1","b":null}"#).unwrap(),
+			hash_json_slice(br#"{"a":"1"}"#).unwrap()
+		);
+	}
+
+	#[test]
+	fn object_null_members_are_omitted_but_array_nulls_remain() {
+		assert_eq!(
+			canonicalize_str(
+				r#"{"empty":null,"items":[null,{"drop":null,"keep":"yes"},null]}"#
+			)
+			.unwrap(),
+			r#"{"items":[null,{"keep":"yes"},null]}"#
+		);
+	}
+
+	#[test]
+	fn typed_optional_none_serializes_like_absent_field() {
+		#[derive(Serialize)]
+		struct Example {
+			name: &'static str,
+			#[serde(default)]
+			comment: Option<&'static str>,
+		}
+
+		assert_eq!(
+			to_string(&Example { name: "alice", comment: None }).unwrap(),
+			canonicalize_str(r#"{"name":"alice"}"#).unwrap()
+		);
+		assert_eq!(
+			to_string(&Example { name: "alice", comment: Some("ready") })
+				.unwrap(),
+			r#"{"comment":"ready","name":"alice"}"#
+		);
+	}
+
+	#[test]
+	fn normalizes_integer_json_numbers_to_decimal_strings() {
+		assert_eq!(canonicalize_str(r#"{"n":1}"#).unwrap(), r#"{"n":"1"}"#);
+		assert_eq!(
+			canonicalize_str(r#"{"n":-9007199254740991}"#).unwrap(),
+			r#"{"n":"-9007199254740991"}"#
+		);
+	}
+
+	#[test]
+	fn errors_on_floating_point_json_numbers() {
+		assert_qos_number_error(canonicalize_str(r#"{"n":1.0}"#));
+		assert_qos_number_error(canonicalize_str(r#"{"n":1e0}"#));
+		assert_qos_number_error(canonicalize_str(r#"{"n":-1.25}"#));
+	}
+
+	#[test]
+	fn normalizes_typed_numeric_fields_to_decimal_strings() {
+		#[derive(Serialize)]
+		struct Example {
+			count: u32,
+		}
+
+		assert_eq!(
+			to_string(&Example { count: 42 }).unwrap(),
+			r#"{"count":"42"}"#
+		);
+	}
+
+	#[test]
+	fn sorts_object_keys_by_utf16_code_units() {
+		let canonical = canonicalize_str(
+			r#"{
+				"\u20ac": "Euro Sign",
+				"\r": "Carriage Return",
+				"\ufb33": "Hebrew Letter Dalet With Dagesh",
+				"1": "One",
+				"\ud83d\ude00": "Emoji: Grinning Face",
+				"\u0080": "Control",
+				"\u00f6": "Latin Small Letter O With Diaeresis"
+			}"#,
+		)
+		.unwrap();
+
+		let expected_values = [
+			"Carriage Return",
+			"One",
+			"Control",
+			"Latin Small Letter O With Diaeresis",
+			"Euro Sign",
+			"Emoji: Grinning Face",
+			"Hebrew Letter Dalet With Dagesh",
+		];
+		let mut last_position = 0;
+		for value in expected_values {
+			let position = canonical[last_position..].find(value).unwrap();
+			last_position += position + value.len();
+		}
+		assert_eq!(
+			canonical,
+			"{\"\\r\":\"Carriage Return\",\"1\":\"One\",\"\u{80}\":\"Control\",\"ö\":\"Latin Small Letter O With Diaeresis\",\"€\":\"Euro Sign\",\"😀\":\"Emoji: Grinning Face\",\"\u{fb33}\":\"Hebrew Letter Dalet With Dagesh\"}"
+		);
+	}
+
+	#[test]
+	fn recursively_sorts_objects_without_reordering_arrays() {
+		assert_eq!(
+			canonicalize_str(
+				r#"{"z":{"b":"2","a":"1"},"a":[{"d":"4","c":"3"},"second",{"b":"2","a":"1"}]}"#
+			)
+			.unwrap(),
+			r#"{"a":[{"c":"3","d":"4"},"second",{"a":"1","b":"2"}],"z":{"a":"1","b":"2"}}"#
+		);
+	}
+
+	#[test]
+	fn escaped_object_keys_sort_by_raw_key_and_remain_escaped() {
+		assert_eq!(
+			canonicalize_str(
+				"{\"b\":\"plain\",\"\\n\":\"line feed\",\"\\r\":\"carriage return\",\"\\u0001\":\"control\"}"
+			)
+			.unwrap(),
+			"{\"\\u0001\":\"control\",\"\\n\":\"line feed\",\"\\r\":\"carriage return\",\"b\":\"plain\"}"
+		);
+	}
+
+	#[test]
+	fn escapes_string_values_canonically() {
+		assert_eq!(
+			canonicalize_str(
+				"{\"quote\":\"\\\"\",\"slash\":\"/\",\"control\":\"\\u0001\",\"line\":\"a\\nb\",\"unicode\":\"€\"}"
+			)
+			.unwrap(),
+			"{\"control\":\"\\u0001\",\"line\":\"a\\nb\",\"quote\":\"\\\"\",\"slash\":\"/\",\"unicode\":\"€\"}"
+		);
+	}
+
+	#[test]
+	fn canonicalizes_raw_json_whitespace_and_order() {
+		assert_eq!(
+			canonicalize_str(
+				"{\n  \"z\": [ true, false, null ],\n  \"a\": { \"b\": \"2\", \"a\": \"1\" }\n}"
+			)
+			.unwrap(),
+			r#"{"a":{"a":"1","b":"2"},"z":[true,false,null]}"#
+		);
+	}
+
+	#[test]
+	fn supports_external_enums_and_decimal_number_strings() {
+		#[derive(Serialize)]
+		#[serde(rename_all = "camelCase")]
+		enum Example {
+			Request {
+				#[serde(with = "string_or_numeric")]
+				count: u32,
+			},
+		}
+
+		assert_eq!(
+			to_string(&Example::Request { count: 42 }).unwrap(),
+			r#"{"request":{"count":"42"}}"#
+		);
+	}
+
+	#[test]
+	fn string_or_numeric_supports_signed_and_collection_values() {
+		#[derive(Serialize)]
+		struct Example {
+			#[serde(with = "string_or_numeric")]
+			offset: i32,
+			#[serde(with = "string_or_numeric")]
+			indexes: BTreeSet<u8>,
+		}
+
+		assert_eq!(
+			to_string(&Example {
+				offset: -7,
+				indexes: BTreeSet::from([2, 10]),
+			})
+			.unwrap(),
+			r#"{"indexes":["2","10"],"offset":"-7"}"#
+		);
+	}
+
+	#[test]
+	fn typed_and_raw_inputs_produce_same_hash() {
+		#[derive(Serialize)]
+		struct Example {
+			#[serde(with = "string_or_numeric")]
+			threshold: u32,
+			name: &'static str,
+		}
+
+		let typed = Example { threshold: 3, name: "test" };
+		let raw = br#"{"threshold":"3","name":"test","unused":null}"#;
+		assert_eq!(
+			to_string(&typed).unwrap(),
+			canonicalize_slice(raw)
+				.map(|bytes| String::from_utf8(bytes).unwrap())
+				.unwrap()
+		);
+		assert_eq!(hash(&typed).unwrap(), hash_json_slice(raw).unwrap());
+	}
+
+	#[test]
+	fn empty_arrays_and_objects_are_preserved() {
+		assert_eq!(
+			canonicalize_str(
+				r#"{"empty_object":{},"empty_array":[],"null_member":null}"#
+			)
+			.unwrap(),
+			r#"{"empty_array":[],"empty_object":{}}"#
+		);
+	}
+
+	#[test]
+	fn string_or_numeric_round_trips() {
+		#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+		struct Example {
+			#[serde(with = "string_or_numeric")]
+			count: u32,
+			#[serde(default, with = "string_or_numeric")]
+			limit: Option<u64>,
+		}
+
+		let example = Example { count: 42, limit: None };
+		let json = to_string(&example).unwrap();
+		assert_eq!(json, r#"{"count":"42"}"#);
+		assert_eq!(from_slice::<Example>(json.as_bytes()).unwrap(), example);
+	}
+
+	#[test]
+	fn string_or_numeric_helpers_accept_json_numbers_and_strings() {
+		#[derive(Debug, PartialEq, Eq, Deserialize)]
+		struct Example {
+			#[serde(with = "string_or_numeric")]
+			count: u32,
+			#[serde(default, with = "string_or_numeric")]
+			limit: Option<u64>,
+			#[serde(with = "string_or_numeric")]
+			indexes: BTreeSet<u8>,
+		}
+
+		let parsed = from_slice::<Example>(
+			br#"{"count":"42","limit":"7","indexes":["1","2"]}"#,
+		)
+		.unwrap();
+		assert_eq!(parsed.count, 42);
+		assert_eq!(parsed.limit, Some(7));
+		assert_eq!(parsed.indexes, BTreeSet::from([1, 2]));
+
+		let parsed = from_slice::<Example>(
+			br#"{"count":42,"limit":"7","indexes":["1"]}"#,
+		)
+		.unwrap();
+		assert_eq!(parsed.count, 42);
+
+		let parsed = from_slice::<Example>(
+			br#"{"count":"42","limit":7,"indexes":["1"]}"#,
+		)
+		.unwrap();
+		assert_eq!(parsed.limit, Some(7));
+
+		let parsed = from_slice::<Example>(
+			br#"{"count":"42","limit":"7","indexes":[1]}"#,
+		)
+		.unwrap();
+		assert_eq!(parsed.indexes, BTreeSet::from([1]));
+
+		assert!(from_slice::<Example>(
+			br#"{"count":42.5,"limit":"7","indexes":["1"]}"#
+		)
+		.is_err());
+	}
+
+	fn assert_qos_number_error<T>(result: serde_json::Result<T>) {
+		let Err(err) = result else {
+			panic!("expected QOS number error");
+		};
+		assert_eq!(
+			err.to_string(),
+			"QOS canonical JSON forbids non-integer JSON numbers"
+		);
+	}
+}

--- a/src/qos_json/src/lib.rs
+++ b/src/qos_json/src/lib.rs
@@ -17,7 +17,7 @@ pub type Hash256 = [u8; 32];
 ///
 /// Returns an error if serde serialization or canonical JSON serialization
 /// fails, including if the value contains a non-integer JSON number. QOS
-/// canonical JSON normalizes integer numbers to decimal strings.
+/// canonical JSON normalizes integer numbers to base-10 integer strings.
 pub fn to_vec<T: Serialize>(value: &T) -> serde_json::Result<Vec<u8>> {
 	let value = serde_json::to_value(value)?;
 	to_vec_value(&value)
@@ -29,33 +29,9 @@ pub fn to_vec<T: Serialize>(value: &T) -> serde_json::Result<Vec<u8>> {
 ///
 /// Returns an error if serde serialization or canonical JSON serialization
 /// fails, including if the value contains a non-integer JSON number. QOS
-/// canonical JSON normalizes integer numbers to decimal strings.
+/// canonical JSON normalizes integer numbers to base-10 integer strings.
 pub fn to_string<T: Serialize>(value: &T) -> serde_json::Result<String> {
 	let value = serde_json::to_value(value)?;
-	to_string_value(&value)
-}
-
-/// Parse JSON bytes and re-encode them as QOS canonical JSON bytes.
-///
-/// # Errors
-///
-/// Returns an error if parsing or canonicalization fails, including if the
-/// parsed value contains a non-integer JSON number. QOS canonical JSON
-/// normalizes integer numbers to decimal strings.
-pub fn canonicalize_slice(bytes: &[u8]) -> serde_json::Result<Vec<u8>> {
-	let value: serde_json::Value = serde_json::from_slice(bytes)?;
-	to_vec_value(&value)
-}
-
-/// Parse a JSON string and re-encode it as a QOS canonical JSON string.
-///
-/// # Errors
-///
-/// Returns an error if parsing or canonicalization fails, including if the
-/// parsed value contains a non-integer JSON number. QOS canonical JSON
-/// normalizes integer numbers to decimal strings.
-pub fn canonicalize_str(json: &str) -> serde_json::Result<String> {
-	let value: serde_json::Value = serde_json::from_str(json)?;
 	to_string_value(&value)
 }
 
@@ -74,21 +50,9 @@ pub fn from_slice<T: DeserializeOwned>(bytes: &[u8]) -> serde_json::Result<T> {
 ///
 /// Returns an error if serialization or canonicalization fails, including if the
 /// value contains a non-integer JSON number. QOS canonical JSON normalizes
-/// integer numbers to decimal strings.
+/// integer numbers to base-10 integer strings.
 pub fn hash<T: Serialize>(value: &T) -> serde_json::Result<Hash256> {
 	let canonical = to_vec(value)?;
-	Ok(sha_256(&canonical))
-}
-
-/// Hash inbound JSON after parsing and QOS re-canonicalization.
-///
-/// # Errors
-///
-/// Returns an error if parsing or canonicalization fails, including if the
-/// parsed value contains a non-integer JSON number. QOS canonical JSON
-/// normalizes integer numbers to decimal strings.
-pub fn hash_json_slice(bytes: &[u8]) -> serde_json::Result<Hash256> {
-	let canonical = canonicalize_slice(bytes)?;
 	Ok(sha_256(&canonical))
 }
 
@@ -98,7 +62,7 @@ pub fn hash_json_slice(bytes: &[u8]) -> serde_json::Result<Hash256> {
 ///
 /// Returns an error if serialization or canonicalization fails, including if the
 /// value contains a non-integer JSON number. QOS canonical JSON normalizes
-/// integer numbers to decimal strings.
+/// integer numbers to base-10 integer strings.
 pub fn hash_hex<T: Serialize>(value: &T) -> serde_json::Result<String> {
 	hash(value).map(|hash| qos_hex::encode(&hash))
 }
@@ -360,6 +324,24 @@ mod tests {
 	use serde::{Deserialize, Serialize};
 	use std::collections::BTreeSet;
 
+	// Spec note: schema-less canonicalization is not allowed in production.
+	// These helpers exist only in tests to validate low-level normalization
+	// behavior and typed-vs-raw equivalence for known-good fixtures.
+	fn canonicalize_raw_slice(bytes: &[u8]) -> serde_json::Result<Vec<u8>> {
+		let value: serde_json::Value = serde_json::from_slice(bytes)?;
+		to_vec_value(&value)
+	}
+
+	fn canonicalize_raw_str(json: &str) -> serde_json::Result<String> {
+		let value: serde_json::Value = serde_json::from_str(json)?;
+		to_string_value(&value)
+	}
+
+	fn hash_raw_json_slice(bytes: &[u8]) -> serde_json::Result<Hash256> {
+		let canonical = canonicalize_raw_slice(bytes)?;
+		Ok(sha_256(&canonical))
+	}
+
 	#[test]
 	fn canonicalizes_key_order_before_hashing() {
 		let a = br#"{"version":"1","name":"test","threshold":"3"}"#;
@@ -370,12 +352,15 @@ mod tests {
 		}"#;
 
 		assert_eq!(
-			canonicalize_slice(a).unwrap(),
-			canonicalize_slice(b).unwrap()
+			canonicalize_raw_slice(a).unwrap(),
+			canonicalize_raw_slice(b).unwrap()
 		);
-		assert_eq!(hash_json_slice(a).unwrap(), hash_json_slice(b).unwrap());
 		assert_eq!(
-			qos_hex::encode(&hash_json_slice(a).unwrap()),
+			hash_raw_json_slice(a).unwrap(),
+			hash_raw_json_slice(b).unwrap()
+		);
+		assert_eq!(
+			qos_hex::encode(&hash_raw_json_slice(a).unwrap()),
 			"898eaf2263b3ca34a9fb0b59615a16e5819b43c53fabc44396f92128f72ccc7e"
 		);
 	}
@@ -460,19 +445,19 @@ mod tests {
 	#[test]
 	fn object_null_members_are_omitted() {
 		assert_eq!(
-			canonicalize_str(r#"{"b":null,"a":"1","nested":{"z":null,"y":"2"},"items":[null,{"x":null,"y":true}]}"#).unwrap(),
+			canonicalize_raw_str(r#"{"b":null,"a":"1","nested":{"z":null,"y":"2"},"items":[null,{"x":null,"y":true}]}"#).unwrap(),
 			r#"{"a":"1","items":[null,{"y":true}],"nested":{"y":"2"}}"#
 		);
 		assert_eq!(
-			hash_json_slice(br#"{"a":"1","b":null}"#).unwrap(),
-			hash_json_slice(br#"{"a":"1"}"#).unwrap()
+			hash_raw_json_slice(br#"{"a":"1","b":null}"#).unwrap(),
+			hash_raw_json_slice(br#"{"a":"1"}"#).unwrap()
 		);
 	}
 
 	#[test]
 	fn object_null_members_are_omitted_but_array_nulls_remain() {
 		assert_eq!(
-			canonicalize_str(
+			canonicalize_raw_str(
 				r#"{"empty":null,"items":[null,{"drop":null,"keep":"yes"},null]}"#
 			)
 			.unwrap(),
@@ -491,7 +476,7 @@ mod tests {
 
 		assert_eq!(
 			to_string(&Example { name: "alice", comment: None }).unwrap(),
-			canonicalize_str(r#"{"name":"alice"}"#).unwrap()
+			canonicalize_raw_str(r#"{"name":"alice"}"#).unwrap()
 		);
 		assert_eq!(
 			to_string(&Example { name: "alice", comment: Some("ready") })
@@ -502,18 +487,18 @@ mod tests {
 
 	#[test]
 	fn normalizes_integer_json_numbers_to_decimal_strings() {
-		assert_eq!(canonicalize_str(r#"{"n":1}"#).unwrap(), r#"{"n":"1"}"#);
+		assert_eq!(canonicalize_raw_str(r#"{"n":1}"#).unwrap(), r#"{"n":"1"}"#);
 		assert_eq!(
-			canonicalize_str(r#"{"n":-9007199254740991}"#).unwrap(),
+			canonicalize_raw_str(r#"{"n":-9007199254740991}"#).unwrap(),
 			r#"{"n":"-9007199254740991"}"#
 		);
 	}
 
 	#[test]
 	fn errors_on_floating_point_json_numbers() {
-		assert_qos_number_error(canonicalize_str(r#"{"n":1.0}"#));
-		assert_qos_number_error(canonicalize_str(r#"{"n":1e0}"#));
-		assert_qos_number_error(canonicalize_str(r#"{"n":-1.25}"#));
+		assert_qos_number_error(canonicalize_raw_str(r#"{"n":1.0}"#));
+		assert_qos_number_error(canonicalize_raw_str(r#"{"n":1e0}"#));
+		assert_qos_number_error(canonicalize_raw_str(r#"{"n":-1.25}"#));
 	}
 
 	#[test]
@@ -531,7 +516,7 @@ mod tests {
 
 	#[test]
 	fn sorts_object_keys_by_utf16_code_units() {
-		let canonical = canonicalize_str(
+		let canonical = canonicalize_raw_str(
 			r#"{
 				"\u20ac": "Euro Sign",
 				"\r": "Carriage Return",
@@ -567,7 +552,7 @@ mod tests {
 	#[test]
 	fn recursively_sorts_objects_without_reordering_arrays() {
 		assert_eq!(
-			canonicalize_str(
+			canonicalize_raw_str(
 				r#"{"z":{"b":"2","a":"1"},"a":[{"d":"4","c":"3"},"second",{"b":"2","a":"1"}]}"#
 			)
 			.unwrap(),
@@ -578,7 +563,7 @@ mod tests {
 	#[test]
 	fn escaped_object_keys_sort_by_raw_key_and_remain_escaped() {
 		assert_eq!(
-			canonicalize_str(
+			canonicalize_raw_str(
 				"{\"b\":\"plain\",\"\\n\":\"line feed\",\"\\r\":\"carriage return\",\"\\u0001\":\"control\"}"
 			)
 			.unwrap(),
@@ -589,18 +574,18 @@ mod tests {
 	#[test]
 	fn escapes_string_values_canonically() {
 		assert_eq!(
-			canonicalize_str(
-				"{\"quote\":\"\\\"\",\"slash\":\"/\",\"control\":\"\\u0001\",\"line\":\"a\\nb\",\"unicode\":\"€\"}"
+			canonicalize_raw_str(
+				"{\"quote\":\"\\\"\",\"slash\":\"/\",\"control\":\"\\u0001\",\"line\":\"a\\nb\",\"unicode\":\"€\",\"poop\":\"💩\"}"
 			)
 			.unwrap(),
-			"{\"control\":\"\\u0001\",\"line\":\"a\\nb\",\"quote\":\"\\\"\",\"slash\":\"/\",\"unicode\":\"€\"}"
+			"{\"control\":\"\\u0001\",\"line\":\"a\\nb\",\"poop\":\"💩\",\"quote\":\"\\\"\",\"slash\":\"/\",\"unicode\":\"€\"}"
 		);
 	}
 
 	#[test]
 	fn canonicalizes_raw_json_whitespace_and_order() {
 		assert_eq!(
-			canonicalize_str(
+			canonicalize_raw_str(
 				"{\n  \"z\": [ true, false, null ],\n  \"a\": { \"b\": \"2\", \"a\": \"1\" }\n}"
 			)
 			.unwrap(),
@@ -658,17 +643,17 @@ mod tests {
 		let raw = br#"{"threshold":"3","name":"test","unused":null}"#;
 		assert_eq!(
 			to_string(&typed).unwrap(),
-			canonicalize_slice(raw)
+			canonicalize_raw_slice(raw)
 				.map(|bytes| String::from_utf8(bytes).unwrap())
 				.unwrap()
 		);
-		assert_eq!(hash(&typed).unwrap(), hash_json_slice(raw).unwrap());
+		assert_eq!(hash(&typed).unwrap(), hash_raw_json_slice(raw).unwrap());
 	}
 
 	#[test]
 	fn empty_arrays_and_objects_are_preserved() {
 		assert_eq!(
-			canonicalize_str(
+			canonicalize_raw_str(
 				r#"{"empty_object":{},"empty_array":[],"null_member":null}"#
 			)
 			.unwrap(),

--- a/src/qos_json/src/lib.rs
+++ b/src/qos_json/src/lib.rs
@@ -20,7 +20,7 @@ pub type Hash256 = [u8; 32];
 /// canonical JSON normalizes integer numbers to base-10 integer strings.
 pub fn to_vec<T: Serialize>(value: &T) -> serde_json::Result<Vec<u8>> {
 	let value = serde_json::to_value(value)?;
-	to_vec_value(&value)
+	value_to_vec(&value)
 }
 
 /// Serialize a value as a QOS canonical JSON string.
@@ -32,7 +32,7 @@ pub fn to_vec<T: Serialize>(value: &T) -> serde_json::Result<Vec<u8>> {
 /// canonical JSON normalizes integer numbers to base-10 integer strings.
 pub fn to_string<T: Serialize>(value: &T) -> serde_json::Result<String> {
 	let value = serde_json::to_value(value)?;
-	to_string_value(&value)
+	value_to_string(&value)
 }
 
 /// Deserialize JSON bytes as `T`.
@@ -56,37 +56,26 @@ pub fn hash<T: Serialize>(value: &T) -> serde_json::Result<Hash256> {
 	Ok(sha_256(&canonical))
 }
 
-/// Hash a typed value and return the lowercase hex digest.
-///
-/// # Errors
-///
-/// Returns an error if serialization or canonicalization fails, including if the
-/// value contains a non-integer JSON number. QOS canonical JSON normalizes
-/// integer numbers to base-10 integer strings.
-pub fn hash_hex<T: Serialize>(value: &T) -> serde_json::Result<String> {
-	hash(value).map(|hash| qos_hex::encode(&hash))
-}
-
 fn sha_256(bytes: &[u8]) -> Hash256 {
 	let mut hasher = Sha256::new();
 	hasher.update(bytes);
 	hasher.finalize().into()
 }
 
-fn to_vec_value(value: &serde_json::Value) -> serde_json::Result<Vec<u8>> {
+fn value_to_vec(value: &serde_json::Value) -> serde_json::Result<Vec<u8>> {
 	let mut bytes = Vec::new();
-	to_writer_value(&mut bytes, value)?;
+	value_to_writer(&mut bytes, value)?;
 	Ok(bytes)
 }
 
-fn to_string_value(value: &serde_json::Value) -> serde_json::Result<String> {
-	let bytes = to_vec_value(value)?;
+fn value_to_string(value: &serde_json::Value) -> serde_json::Result<String> {
+	let bytes = value_to_vec(value)?;
 	String::from_utf8(bytes).map_err(|err| {
 		serde_json::Error::io(io::Error::new(io::ErrorKind::InvalidData, err))
 	})
 }
 
-fn to_writer_value<W>(
+fn value_to_writer<W>(
 	writer: &mut W,
 	value: &serde_json::Value,
 ) -> serde_json::Result<()>
@@ -177,26 +166,10 @@ where
 	serde_json::to_writer(writer, value).map_err(io::Error::other)
 }
 
-fn decimal_string_from_json_value<E>(
-	value: serde_json::Value,
-) -> Result<String, E>
-where
-	E: serde::de::Error,
-{
-	match value {
-		serde_json::Value::String(s) => Ok(s),
-		serde_json::Value::Number(n) if n.is_u64() || n.is_i64() => {
-			Ok(n.to_string())
-		}
-		other => Err(E::custom(format!(
-			"expected decimal string or integer, got {other}"
-		))),
-	}
-}
-
 /// Serde helpers that tolerate numeric input as either string or integer.
 pub mod string_or_numeric {
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
+	use serde_json::value::RawValue;
 	use std::{collections::BTreeSet, fmt::Display, str::FromStr};
 
 	/// Serialize using default serde behavior for the field type.
@@ -228,7 +201,7 @@ pub mod string_or_numeric {
 
 	/// A type that can be deserialized from one or more decimal string/integer
 	/// JSON values.
-	pub trait StringOrNumericDeserialize<'de>: Sized {
+	pub trait StringOrNumericDeserialize<'de>: sealed::Sealed + Sized {
 		/// Deserialize from decimal string/integer JSON.
 		///
 		/// # Errors
@@ -242,8 +215,14 @@ pub mod string_or_numeric {
 			D: Deserializer<'de>;
 	}
 
+	mod sealed {
+		pub trait Sealed {}
+	}
+
 	macro_rules! impl_string_or_numeric_deserialize {
 		($($ty:ty),+ $(,)?) => {$(
+			impl sealed::Sealed for $ty {}
+
 			impl<'de> StringOrNumericDeserialize<'de> for $ty {
 				fn deserialize_string_or_numeric<D>(
 					deserializer: D,
@@ -261,6 +240,13 @@ pub mod string_or_numeric {
 		u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize
 	);
 
+	impl<T> sealed::Sealed for Option<T>
+	where
+		T: FromStr,
+		T::Err: Display,
+	{
+	}
+
 	impl<'de, T> StringOrNumericDeserialize<'de> for Option<T>
 	where
 		T: FromStr,
@@ -272,9 +258,16 @@ pub mod string_or_numeric {
 		where
 			D: Deserializer<'de>,
 		{
-			let opt = Option::<serde_json::Value>::deserialize(deserializer)?;
-			opt.map(parse_string_or_numeric_value).transpose()
+			let opt = Option::<Box<RawValue>>::deserialize(deserializer)?;
+			opt.as_deref().map(parse_string_or_numeric_raw).transpose()
 		}
+	}
+
+	impl<T> sealed::Sealed for BTreeSet<T>
+	where
+		T: FromStr + Ord,
+		T::Err: Display,
+	{
 	}
 
 	impl<'de, T> StringOrNumericDeserialize<'de> for BTreeSet<T>
@@ -288,8 +281,11 @@ pub mod string_or_numeric {
 		where
 			D: Deserializer<'de>,
 		{
-			let values = Vec::<serde_json::Value>::deserialize(deserializer)?;
-			values.into_iter().map(parse_string_or_numeric_value).collect()
+			let values = Vec::<Box<RawValue>>::deserialize(deserializer)?;
+			values
+				.iter()
+				.map(|value| parse_string_or_numeric_raw(value))
+				.collect()
 		}
 	}
 
@@ -301,20 +297,22 @@ pub mod string_or_numeric {
 		T: FromStr,
 		T::Err: Display,
 	{
-		let value = serde_json::Value::deserialize(deserializer)?;
-		parse_string_or_numeric_value(value)
+		let value = <Box<RawValue>>::deserialize(deserializer)?;
+		parse_string_or_numeric_raw(&value)
 	}
 
-	fn parse_string_or_numeric_value<E, T>(
-		value: serde_json::Value,
-	) -> Result<T, E>
+	fn parse_string_or_numeric_raw<E, T>(value: &RawValue) -> Result<T, E>
 	where
 		E: serde::de::Error,
 		T: FromStr,
 		T::Err: Display,
 	{
-		let s = super::decimal_string_from_json_value::<E>(value)?;
-		s.parse().map_err(serde::de::Error::custom)
+		let raw = value.get();
+		if let Some(s) = raw.strip_prefix('"').and_then(|s| s.strip_suffix('"'))
+		{
+			return s.parse().map_err(E::custom);
+		}
+		raw.parse().map_err(E::custom)
 	}
 }
 
@@ -329,12 +327,12 @@ mod tests {
 	// behavior and typed-vs-raw equivalence for known-good fixtures.
 	fn canonicalize_raw_slice(bytes: &[u8]) -> serde_json::Result<Vec<u8>> {
 		let value: serde_json::Value = serde_json::from_slice(bytes)?;
-		to_vec_value(&value)
+		value_to_vec(&value)
 	}
 
 	fn canonicalize_raw_str(json: &str) -> serde_json::Result<String> {
 		let value: serde_json::Value = serde_json::from_str(json)?;
-		to_string_value(&value)
+		value_to_string(&value)
 	}
 
 	fn hash_raw_json_slice(bytes: &[u8]) -> serde_json::Result<Hash256> {
@@ -380,7 +378,7 @@ mod tests {
 			r#"{"name":"test","threshold":"3","version":"1"}"#
 		);
 		assert_eq!(
-			hash_hex(&example).unwrap(),
+			hash(&example).as_ref().map(|hash| qos_hex::encode(hash)).unwrap(),
 			"898eaf2263b3ca34a9fb0b59615a16e5819b43c53fabc44396f92128f72ccc7e"
 		);
 	}
@@ -396,7 +394,7 @@ mod tests {
 		let example = Example { data: vec![0xde, 0xad, 0xbe, 0xef] };
 		assert_eq!(to_string(&example).unwrap(), r#"{"data":"deadbeef"}"#);
 		assert_eq!(
-			hash_hex(&example).unwrap(),
+			hash(&example).as_ref().map(|hash| qos_hex::encode(hash)).unwrap(),
 			"03fe564ceddcb54a7a742bd7a4db57318a068cecd22ae44435ce68d35e754e13"
 		);
 	}
@@ -717,6 +715,10 @@ mod tests {
 
 		assert!(from_slice::<Example>(
 			br#"{"count":42.5,"limit":"7","indexes":["1"]}"#
+		)
+		.is_err());
+		assert!(from_slice::<Example>(
+			br#"{"count":"\u0034\u0032","limit":"7","indexes":["1"]}"#
 		)
 		.is_err());
 	}

--- a/src/qos_nsm/Cargo.toml
+++ b/src/qos_nsm/Cargo.toml
@@ -14,7 +14,9 @@ workspace = true
 
 [dependencies]
 qos_hex = { workspace = true }
+qos_json = { workspace = true }
 borsh = { workspace = true }
+serde = { workspace = true }
 aws-nitro-enclaves-nsm-api = { workspace = true, features = ["nix"] }
 aws-nitro-enclaves-cose = { workspace = true }
 sha2 = { workspace = true }

--- a/src/qos_nsm/src/types.rs
+++ b/src/qos_nsm/src/types.rs
@@ -9,7 +9,14 @@ use nsm::api::{Digest, ErrorCode, Request, Response};
 
 /// Possible error codes from the Nitro Secure Module API.
 #[derive(
-	Debug, borsh::BorshSerialize, borsh::BorshDeserialize, PartialEq, Eq, Clone,
+	Debug,
+	borsh::BorshSerialize,
+	borsh::BorshDeserialize,
+	serde::Serialize,
+	serde::Deserialize,
+	PartialEq,
+	Eq,
+	Clone,
 )]
 pub enum NsmErrorCode {
 	/// No errors
@@ -72,6 +79,8 @@ impl From<NsmErrorCode> for ErrorCode {
 	Debug,
 	borsh::BorshSerialize,
 	borsh::BorshDeserialize,
+	serde::Serialize,
+	serde::Deserialize,
 	Copy,
 	Clone,
 	PartialEq,
@@ -110,7 +119,14 @@ impl From<NsmDigest> for Digest {
 
 /// Request type for the Nitro Secure Module API.
 #[derive(
-	Debug, borsh::BorshSerialize, borsh::BorshDeserialize, PartialEq, Eq, Clone,
+	Debug,
+	borsh::BorshSerialize,
+	borsh::BorshDeserialize,
+	serde::Serialize,
+	serde::Deserialize,
+	PartialEq,
+	Eq,
+	Clone,
 )]
 pub enum NsmRequest {
 	/// Read data from `PlatformConfigurationRegister` at `index`
@@ -123,6 +139,7 @@ pub enum NsmRequest {
 		/// index the PCR to extend
 		index: u16,
 		/// data to extend it with
+		#[serde(with = "qos_hex::serde")]
 		data: Vec<u8>,
 	},
 	/// Lock `PlatformConfigurationRegister` at `index` from further
@@ -146,10 +163,25 @@ pub enum NsmRequest {
 	/// private key to ensure authenticity.
 	Attestation {
 		/// Includes additional user data in the `AttestationDoc`.
+		#[serde(
+			default,
+			skip_serializing_if = "Option::is_none",
+			with = "qos_hex::serde::option"
+		)]
 		user_data: Option<Vec<u8>>,
 		/// Includes an additional nonce in the `AttestationDoc`.
+		#[serde(
+			default,
+			skip_serializing_if = "Option::is_none",
+			with = "qos_hex::serde::option"
+		)]
 		nonce: Option<Vec<u8>>,
 		/// Includes a user provided public key in the `AttestationDoc`.
+		#[serde(
+			default,
+			skip_serializing_if = "Option::is_none",
+			with = "qos_hex::serde::option"
+		)]
 		public_key: Option<Vec<u8>>,
 	},
 	/// Requests entropy from the NSM side.
@@ -202,43 +234,62 @@ impl From<NsmRequest> for Request {
 
 /// Response type for the Nitro Secure Module API.
 #[derive(
-	Debug, borsh::BorshSerialize, borsh::BorshDeserialize, PartialEq, Eq, Clone,
+	Debug,
+	borsh::BorshSerialize,
+	borsh::BorshDeserialize,
+	serde::Serialize,
+	serde::Deserialize,
+	PartialEq,
+	Eq,
+	Clone,
 )]
 pub enum NsmResponse {
 	/// returns the current `PlatformConfigurationRegister` state
+	#[serde(alias = "describePCR", alias = "describepcr")]
 	DescribePCR {
 		/// true if the PCR is read-only, false otherwise
 		lock: bool,
 		/// the current value of the PCR
+		#[serde(with = "qos_hex::serde")]
 		data: Vec<u8>,
 	},
 	/// returned if `PlatformConfigurationRegister` has been successfully
 	/// extended
+	#[serde(alias = "extendPCR", alias = "extendpcr")]
 	ExtendPCR {
 		/// The new value of the PCR after extending the data into the
 		/// register.
+		#[serde(with = "qos_hex::serde")]
 		data: Vec<u8>,
 	},
 	/// returned if `PlatformConfigurationRegister` has been successfully locked
+	#[serde(alias = "lockPCR", alias = "lockpcr")]
 	LockPCR,
 	/// returned if `PlatformConfigurationRegisters` have been successfully
 	/// locked
+	#[serde(alias = "lockPCRs", alias = "lockpcrs")]
 	LockPCRs,
 	/// returns the runtime configuration of the `NitroSecureModule`
+	#[serde(alias = "describeNSM", alias = "describensm")]
 	DescribeNSM {
 		/// Breaking API changes are denoted by `major_version`
+		#[serde(with = "qos_json::string_or_numeric")]
 		version_major: u16,
 		/// Minor API changes are denoted by `minor_version`. Minor versions
 		/// should be backwards compatible.
+		#[serde(with = "qos_json::string_or_numeric")]
 		version_minor: u16,
 		/// Patch version. These are security and stability updates and do not
 		/// affect API.
+		#[serde(with = "qos_json::string_or_numeric")]
 		version_patch: u16,
 		/// `module_id` is an identifier for a singular `NitroSecureModule`
 		module_id: String,
 		/// The maximum number of PCRs exposed by the `NitroSecureModule`.
+		#[serde(with = "qos_json::string_or_numeric")]
 		max_pcrs: u16,
 		/// The PCRs that are read-only.
+		#[serde(with = "qos_json::string_or_numeric")]
 		locked_pcrs: BTreeSet<u16>,
 		/// The digest of the PCR Bank
 		digest: NsmDigest,
@@ -246,18 +297,23 @@ pub enum NsmResponse {
 	/// A response to an Attestation Request containing the CBOR-encoded
 	/// `AttestationDoc` and the signature generated from the doc by the
 	/// `NitroSecureModule`
+	#[serde(alias = "attestation")]
 	Attestation {
 		/// A signed COSE structure containing a CBOR-encoded
 		/// `AttestationDocument` as the payload.
+		#[serde(with = "qos_hex::serde")]
 		document: Vec<u8>,
 	},
 	/// A response containing a number of bytes of entropy.
+	#[serde(alias = "getRandom", alias = "getrandom")]
 	GetRandom {
 		/// The random bytes.
+		#[serde(with = "qos_hex::serde")]
 		random: Vec<u8>,
 	},
 	/// An error has occured, and the `NitroSecureModule` could not successfully
 	/// complete the operation
+	#[serde(alias = "error")]
 	Error(NsmErrorCode),
 }
 

--- a/src/qos_nsm/src/types.rs
+++ b/src/qos_nsm/src/types.rs
@@ -243,9 +243,9 @@ impl From<NsmRequest> for Request {
 	Eq,
 	Clone,
 )]
+#[serde(rename_all = "camelCase")]
 pub enum NsmResponse {
 	/// returns the current `PlatformConfigurationRegister` state
-	#[serde(alias = "describePCR", alias = "describepcr")]
 	DescribePCR {
 		/// true if the PCR is read-only, false otherwise
 		lock: bool,
@@ -255,7 +255,6 @@ pub enum NsmResponse {
 	},
 	/// returned if `PlatformConfigurationRegister` has been successfully
 	/// extended
-	#[serde(alias = "extendPCR", alias = "extendpcr")]
 	ExtendPCR {
 		/// The new value of the PCR after extending the data into the
 		/// register.
@@ -263,14 +262,11 @@ pub enum NsmResponse {
 		data: Vec<u8>,
 	},
 	/// returned if `PlatformConfigurationRegister` has been successfully locked
-	#[serde(alias = "lockPCR", alias = "lockpcr")]
 	LockPCR,
 	/// returned if `PlatformConfigurationRegisters` have been successfully
 	/// locked
-	#[serde(alias = "lockPCRs", alias = "lockpcrs")]
 	LockPCRs,
 	/// returns the runtime configuration of the `NitroSecureModule`
-	#[serde(alias = "describeNSM", alias = "describensm")]
 	DescribeNSM {
 		/// Breaking API changes are denoted by `major_version`
 		#[serde(with = "qos_json::string_or_numeric")]
@@ -297,7 +293,6 @@ pub enum NsmResponse {
 	/// A response to an Attestation Request containing the CBOR-encoded
 	/// `AttestationDoc` and the signature generated from the doc by the
 	/// `NitroSecureModule`
-	#[serde(alias = "attestation")]
 	Attestation {
 		/// A signed COSE structure containing a CBOR-encoded
 		/// `AttestationDocument` as the payload.
@@ -305,7 +300,6 @@ pub enum NsmResponse {
 		document: Vec<u8>,
 	},
 	/// A response containing a number of bytes of entropy.
-	#[serde(alias = "getRandom", alias = "getrandom")]
 	GetRandom {
 		/// The random bytes.
 		#[serde(with = "qos_hex::serde")]
@@ -313,7 +307,6 @@ pub enum NsmResponse {
 	},
 	/// An error has occured, and the `NitroSecureModule` could not successfully
 	/// complete the operation
-	#[serde(alias = "error")]
 	Error(NsmErrorCode),
 }
 

--- a/src/qos_p256/Cargo.toml
+++ b/src/qos_p256/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 qos_hex = { workspace = true }
 
 borsh = { workspace = true }
+serde = { workspace = true }
 
 sha2 = { workspace = true }
 # as of 0.13.0, the p256 crate "ecdsa" feature enables "sha384", some "ecdsa-core", and others

--- a/src/qos_p256/src/lib.rs
+++ b/src/qos_p256/src/lib.rs
@@ -31,7 +31,14 @@ pub mod sign;
 
 /// Errors for qos P256.
 #[derive(
-	Debug, Clone, PartialEq, Eq, borsh::BorshSerialize, borsh::BorshDeserialize,
+	Debug,
+	Clone,
+	PartialEq,
+	Eq,
+	borsh::BorshSerialize,
+	borsh::BorshDeserialize,
+	serde::Serialize,
+	serde::Deserialize,
 )]
 pub enum P256Error {
 	/// Hex encoding error.


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

### Prior PR desc:

Implements https://linear.app/turnkey/issue/SYS-58/qos-json-for-wire-and-signing-payloads

TLDR: borsh is great if you don't need to change your schema, but not so great if you do.
This change uses human-readable JSON for signing. Because JSON is not great for hashing, even if you follow https://www.rfc-editor.org/rfc/rfc8785, we added some extra restrictions. See the spec md. Credit to Zeke for writing most of the spec and a first draft of the json code.

Also, note you MUST never hash JSON off the wire; you must always deserialize and then serialize to our QoS JSON because JSON is not bijective.

### changes:

This PR is intended to be fully backwards compatible. Please pay close attention to this while reviewing it.

My last PR draft (#683) worked but was a pain to review and bit off switching to clap.
I did not have very much confidence in the switch to clap and while the code organization refactors in that PR were better it made reviewing the PR too difficult.

This PR is mostly the same logic, but unlike that PR I minimized the number of changed lines as much as possible.

It is my hope that at some point we can be confident there are no more v0 or v1 manifests in prod at which point after some deprecation period we can remove this code.


## How I Tested These Changes

I added a few json tests, but it could use more in followup.

## Pre merge check list

- [x] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
