### PR TITLE
chore: upgrade all crates to Rust edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.94"
 version = "0.7.0"
-edition = "2021"
+edition = "2024"
 license = "AGPL-3.0-only"
 
 [workspace.lints.rust]

--- a/src/init/Cargo.toml
+++ b/src/init/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "init"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 rust-version = "1.88"
 publish = false
 

--- a/src/init/init.rs
+++ b/src/init/init.rs
@@ -1,8 +1,8 @@
 use qos_core::{
+	EPHEMERAL_KEY_FILE, MANIFEST_FILE, PIVOT_FILE, QUORUM_FILE,
 	handles::Handles,
 	io::{SocketAddress, VMADDR_NO_FLAGS},
 	reaper::Reaper,
-	EPHEMERAL_KEY_FILE, MANIFEST_FILE, PIVOT_FILE, QUORUM_FILE,
 };
 use qos_nsm::Nsm;
 use qos_system::{dmesg, freopen, get_local_cid, mount, reboot};

--- a/src/init/setip.rs
+++ b/src/init/setip.rs
@@ -1,8 +1,8 @@
 use std::ffi::c_void;
 
 use nix::libc::{
-	close, htonl, ifreq, memcpy, sockaddr, sockaddr_in, socket, AF_INET,
-	IFF_UP, SIOCGIFFLAGS, SIOCSIFADDR, SIOCSIFFLAGS, SOCK_DGRAM,
+	AF_INET, IFF_UP, SIOCGIFFLAGS, SIOCSIFADDR, SIOCSIFFLAGS, SOCK_DGRAM,
+	close, htonl, ifreq, memcpy, sockaddr, sockaddr_in, socket,
 };
 use nix::{errno::Errno, ioctl_read_bad, ioctl_write_ptr_bad};
 

--- a/src/integration/examples/boot_enclave.rs
+++ b/src/integration/examples/boot_enclave.rs
@@ -11,11 +11,11 @@ use std::{
 use borsh::BorshDeserialize;
 use integration::{LOCAL_HOST, PCR3_PRE_IMAGE_PATH, QOS_DIST_DIR};
 use qos_core::protocol::{
+	ProtocolPhase, QosHash,
 	services::{
 		boot::{Approval, Manifest, ManifestSet, Namespace, ShareSet},
 		genesis::{GenesisMemberOutput, GenesisOutput},
 	},
-	ProtocolPhase, QosHash,
 };
 use qos_crypto::sha_256;
 use qos_host::EnclaveInfo;
@@ -293,62 +293,68 @@ async fn main() {
 	qos_test_primitives::wait_until_port_is_bound(host_port);
 
 	// -- CLIENT generate the manifest envelope
-	assert!(Command::new(integration::QOS_CLIENT_PATH)
-		.args([
-			"generate-manifest-envelope",
-			"--manifest-approvals-dir",
-			boot_dir.to_str().unwrap(),
-			"--manifest-path",
-			cli_manifest_path.to_str().unwrap(),
-		])
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
-
-	// -- CLIENT broadcast boot standard instruction
-	let manifest_envelope_path = boot_dir.join("manifest_envelope");
-	assert!(Command::new(integration::QOS_CLIENT_PATH)
-		.args([
-			"boot-standard",
-			"--manifest-envelope-path",
-			manifest_envelope_path.to_str().unwrap(),
-			"--pivot-path",
-			&pivot_file_path,
-			"--host-port",
-			&host_port.to_string(),
-			"--host-ip",
-			LOCAL_HOST,
-			"--pcr3-preimage-path",
-			"./mock/pcr3-preimage.txt",
-			"--unsafe-skip-attestation",
-		])
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
-
-	for user in [&user1, &user2] {
-		// Get attestation doc and manifest
-		assert!(Command::new(integration::QOS_CLIENT_PATH)
+	assert!(
+		Command::new(integration::QOS_CLIENT_PATH)
 			.args([
-				"get-attestation-doc",
-				"--host-port",
-				&host_port.to_string(),
-				"--host-ip",
-				LOCAL_HOST,
-				"--attestation-doc-path",
-				attestation_doc_path.to_str().unwrap(),
-				"--manifest-envelope-path",
-				"/tmp/dont_care"
+				"generate-manifest-envelope",
+				"--manifest-approvals-dir",
+				boot_dir.to_str().unwrap(),
+				"--manifest-path",
+				cli_manifest_path.to_str().unwrap(),
 			])
 			.spawn()
 			.unwrap()
 			.wait()
 			.unwrap()
-			.success());
+			.success()
+	);
+
+	// -- CLIENT broadcast boot standard instruction
+	let manifest_envelope_path = boot_dir.join("manifest_envelope");
+	assert!(
+		Command::new(integration::QOS_CLIENT_PATH)
+			.args([
+				"boot-standard",
+				"--manifest-envelope-path",
+				manifest_envelope_path.to_str().unwrap(),
+				"--pivot-path",
+				&pivot_file_path,
+				"--host-port",
+				&host_port.to_string(),
+				"--host-ip",
+				LOCAL_HOST,
+				"--pcr3-preimage-path",
+				"./mock/pcr3-preimage.txt",
+				"--unsafe-skip-attestation",
+			])
+			.spawn()
+			.unwrap()
+			.wait()
+			.unwrap()
+			.success()
+	);
+
+	for user in [&user1, &user2] {
+		// Get attestation doc and manifest
+		assert!(
+			Command::new(integration::QOS_CLIENT_PATH)
+				.args([
+					"get-attestation-doc",
+					"--host-port",
+					&host_port.to_string(),
+					"--host-ip",
+					LOCAL_HOST,
+					"--attestation-doc-path",
+					attestation_doc_path.to_str().unwrap(),
+					"--manifest-envelope-path",
+					"/tmp/dont_care"
+				])
+				.spawn()
+				.unwrap()
+				.wait()
+				.unwrap()
+				.success()
+		);
 
 		let share_path = personal_dir(user).join(format!("{user}.share"));
 		let secret_path = personal_dir(user).join(format!("{user}.secret"));
@@ -412,9 +418,9 @@ async fn main() {
 		stdin.write_all("yes\n".as_bytes()).expect("Failed to write to stdin");
 
 		assert_eq!(
-				&stdout.next().unwrap().unwrap(),
-				"Does this AWS IAM role belong to the intended organization: arn:aws:iam::123456789012:role/Webserver? (y/n)"
-			);
+			&stdout.next().unwrap().unwrap(),
+			"Does this AWS IAM role belong to the intended organization: arn:aws:iam::123456789012:role/Webserver? (y/n)"
+		);
 		stdin.write_all("yes\n".as_bytes()).expect("Failed to write to stdin");
 
 		assert_eq!(
@@ -427,23 +433,25 @@ async fn main() {
 		assert!(child.wait().unwrap().success());
 
 		// Post the encrypted share
-		assert!(Command::new(integration::QOS_CLIENT_PATH)
-			.args([
-				"post-share",
-				"--host-port",
-				&host_port.to_string(),
-				"--host-ip",
-				LOCAL_HOST,
-				"--eph-wrapped-share-path",
-				eph_wrapped_share_path.to_str().unwrap(),
-				"--approval-path",
-				approval_path.to_str().unwrap(),
-			])
-			.spawn()
-			.unwrap()
-			.wait()
-			.unwrap()
-			.success());
+		assert!(
+			Command::new(integration::QOS_CLIENT_PATH)
+				.args([
+					"post-share",
+					"--host-port",
+					&host_port.to_string(),
+					"--host-ip",
+					LOCAL_HOST,
+					"--eph-wrapped-share-path",
+					eph_wrapped_share_path.to_str().unwrap(),
+					"--approval-path",
+					approval_path.to_str().unwrap(),
+				])
+				.spawn()
+				.unwrap()
+				.wait()
+				.unwrap()
+				.success()
+		);
 	}
 
 	// Give the enclave time to start the pivot

--- a/src/integration/src/bin/pivot_remote_tls.rs
+++ b/src/integration/src/bin/pivot_remote_tls.rs
@@ -56,8 +56,9 @@ impl RequestProcessor for Processor {
 					.await
 					.expect("tls unable to establish connection");
 
-				let http_request =
-					format!("GET {path} HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n\r\n");
+				let http_request = format!(
+					"GET {path} HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n\r\n"
+				);
 
 				tls.write_all(http_request.as_bytes()).await.unwrap();
 

--- a/src/integration/tests/boot.rs
+++ b/src/integration/tests/boot.rs
@@ -11,6 +11,7 @@ use integration::{
 	QOS_DIST_DIR,
 };
 use qos_core::protocol::{
+	ProtocolPhase, QosHash,
 	services::{
 		boot::{
 			Approval, Manifest, ManifestSet, Namespace, PivotConfig,
@@ -18,7 +19,6 @@ use qos_core::protocol::{
 		},
 		genesis::{GenesisMemberOutput, GenesisOutput},
 	},
-	ProtocolPhase, QosHash,
 };
 use qos_crypto::sha_256;
 use qos_host::EnclaveInfo;
@@ -69,39 +69,41 @@ async fn standard_boot_e2e() {
 	let pivot_args = format!("[--msg,{msg}]");
 	let cli_manifest_path = boot_dir.join("manifest");
 
-	assert!(Command::new(integration::QOS_CLIENT_PATH)
-		.args([
-			"generate-manifest",
-			"--nonce",
-			"2",
-			"--namespace",
-			namespace,
-			"--restart-policy",
-			"never",
-			"--pivot-hash-path",
-			PIVOT_HASH_PATH,
-			"--qos-release-dir",
-			QOS_DIST_DIR,
-			"--pcr3-preimage-path",
-			PCR3_PRE_IMAGE_PATH,
-			"--manifest-path",
-			cli_manifest_path.to_str().unwrap(),
-			"--pivot-args",
-			&pivot_args,
-			"--manifest-set-dir",
-			"./mock/keys/manifest-set",
-			"--share-set-dir",
-			"./mock/keys/share-set",
-			"--patch-set-dir",
-			"./mock/keys/manifest-set",
-			"--quorum-key-path",
-			"./mock/namespaces/quit-coding-to-vape/quorum_key.pub"
-		])
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
+	assert!(
+		Command::new(integration::QOS_CLIENT_PATH)
+			.args([
+				"generate-manifest",
+				"--nonce",
+				"2",
+				"--namespace",
+				namespace,
+				"--restart-policy",
+				"never",
+				"--pivot-hash-path",
+				PIVOT_HASH_PATH,
+				"--qos-release-dir",
+				QOS_DIST_DIR,
+				"--pcr3-preimage-path",
+				PCR3_PRE_IMAGE_PATH,
+				"--manifest-path",
+				cli_manifest_path.to_str().unwrap(),
+				"--pivot-args",
+				&pivot_args,
+				"--manifest-set-dir",
+				"./mock/keys/manifest-set",
+				"--share-set-dir",
+				"./mock/keys/share-set",
+				"--patch-set-dir",
+				"./mock/keys/manifest-set",
+				"--quorum-key-path",
+				"./mock/namespaces/quit-coding-to-vape/quorum_key.pub"
+			])
+			.spawn()
+			.unwrap()
+			.wait()
+			.unwrap()
+			.success()
+	);
 
 	// Check the manifest written to file
 	let manifest: Manifest =
@@ -287,65 +289,71 @@ async fn standard_boot_e2e() {
 	qos_test_primitives::wait_until_port_is_bound(host_port);
 
 	// -- CLIENT generate the manifest envelope
-	assert!(Command::new(integration::QOS_CLIENT_PATH)
-		.args([
-			"generate-manifest-envelope",
-			"--manifest-approvals-dir",
-			boot_dir.to_str().unwrap(),
-			"--manifest-path",
-			cli_manifest_path.to_str().unwrap(),
-		])
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
+	assert!(
+		Command::new(integration::QOS_CLIENT_PATH)
+			.args([
+				"generate-manifest-envelope",
+				"--manifest-approvals-dir",
+				boot_dir.to_str().unwrap(),
+				"--manifest-path",
+				cli_manifest_path.to_str().unwrap(),
+			])
+			.spawn()
+			.unwrap()
+			.wait()
+			.unwrap()
+			.success()
+	);
 
 	// -- CLIENT broadcast boot standard instruction
 	let manifest_envelope_path = boot_dir.join("manifest_envelope");
-	assert!(Command::new(integration::QOS_CLIENT_PATH)
-		.args([
-			"boot-standard",
-			"--manifest-envelope-path",
-			manifest_envelope_path.to_str().unwrap(),
-			"--pivot-path",
-			PIVOT_OK2_PATH,
-			"--host-port",
-			&host_port.to_string(),
-			"--host-ip",
-			LOCAL_HOST,
-			"--pcr3-preimage-path",
-			"./mock/pcr3-preimage.txt",
-			"--unsafe-skip-attestation",
-		])
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
+	assert!(
+		Command::new(integration::QOS_CLIENT_PATH)
+			.args([
+				"boot-standard",
+				"--manifest-envelope-path",
+				manifest_envelope_path.to_str().unwrap(),
+				"--pivot-path",
+				PIVOT_OK2_PATH,
+				"--host-port",
+				&host_port.to_string(),
+				"--host-ip",
+				LOCAL_HOST,
+				"--pcr3-preimage-path",
+				"./mock/pcr3-preimage.txt",
+				"--unsafe-skip-attestation",
+			])
+			.spawn()
+			.unwrap()
+			.wait()
+			.unwrap()
+			.success()
+	);
 
 	// For each user, post a share,
 	// and sanity check the pivot has not yet executed.
 	assert!(!Path::new(PIVOT_OK2_SUCCESS_FILE).exists());
 	for user in [&user1, &user2] {
 		// Get attestation doc and manifest
-		assert!(Command::new(integration::QOS_CLIENT_PATH)
-			.args([
-				"get-attestation-doc",
-				"--host-port",
-				&host_port.to_string(),
-				"--host-ip",
-				LOCAL_HOST,
-				"--attestation-doc-path",
-				attestation_doc_path.to_str().unwrap(),
-				"--manifest-envelope-path",
-				"/tmp/dont_care"
-			])
-			.spawn()
-			.unwrap()
-			.wait()
-			.unwrap()
-			.success());
+		assert!(
+			Command::new(integration::QOS_CLIENT_PATH)
+				.args([
+					"get-attestation-doc",
+					"--host-port",
+					&host_port.to_string(),
+					"--host-ip",
+					LOCAL_HOST,
+					"--attestation-doc-path",
+					attestation_doc_path.to_str().unwrap(),
+					"--manifest-envelope-path",
+					"/tmp/dont_care"
+				])
+				.spawn()
+				.unwrap()
+				.wait()
+				.unwrap()
+				.success()
+		);
 
 		let share_path = personal_dir(user).join(format!("{user}.share"));
 		let secret_path = personal_dir(user).join(format!("{user}.secret"));
@@ -409,9 +417,9 @@ async fn standard_boot_e2e() {
 		stdin.write_all("yes\n".as_bytes()).expect("Failed to write to stdin");
 
 		assert_eq!(
-				&stdout.next().unwrap().unwrap(),
-				"Does this AWS IAM role belong to the intended organization: arn:aws:iam::123456789012:role/Webserver? (y/n)"
-			);
+			&stdout.next().unwrap().unwrap(),
+			"Does this AWS IAM role belong to the intended organization: arn:aws:iam::123456789012:role/Webserver? (y/n)"
+		);
 		stdin.write_all("yes\n".as_bytes()).expect("Failed to write to stdin");
 
 		assert_eq!(
@@ -424,23 +432,25 @@ async fn standard_boot_e2e() {
 		assert!(child.wait().unwrap().success());
 
 		// Post the encrypted share
-		assert!(Command::new(integration::QOS_CLIENT_PATH)
-			.args([
-				"post-share",
-				"--host-port",
-				&host_port.to_string(),
-				"--host-ip",
-				LOCAL_HOST,
-				"--eph-wrapped-share-path",
-				eph_wrapped_share_path.to_str().unwrap(),
-				"--approval-path",
-				approval_path.to_str().unwrap(),
-			])
-			.spawn()
-			.unwrap()
-			.wait()
-			.unwrap()
-			.success());
+		assert!(
+			Command::new(integration::QOS_CLIENT_PATH)
+				.args([
+					"post-share",
+					"--host-port",
+					&host_port.to_string(),
+					"--host-ip",
+					LOCAL_HOST,
+					"--eph-wrapped-share-path",
+					eph_wrapped_share_path.to_str().unwrap(),
+					"--approval-path",
+					approval_path.to_str().unwrap(),
+				])
+				.spawn()
+				.unwrap()
+				.wait()
+				.unwrap()
+				.success()
+		);
 	}
 
 	let enclave_info_url =

--- a/src/integration/tests/enclave_app_client_socket_stress.rs
+++ b/src/integration/tests/enclave_app_client_socket_stress.rs
@@ -2,18 +2,18 @@ use std::time::Duration;
 
 use borsh::BorshDeserialize;
 use integration::{
-	wait_for_usock, PivotSocketStressMsg, PIVOT_SOCKET_STRESS_PATH,
+	PIVOT_SOCKET_STRESS_PATH, PivotSocketStressMsg, wait_for_usock,
 };
 use qos_core::{
 	client::{ClientError, SocketClient},
 	handles::Handles,
 	io::{IOError, SocketAddress, StreamPool},
 	protocol::{
+		ProtocolPhase,
 		services::boot::{
 			Manifest, ManifestEnvelope, ManifestSet, Namespace, NitroConfig,
 			PivotConfig, RestartPolicy, ShareSet,
 		},
-		ProtocolPhase,
 	},
 	reaper::Reaper,
 };

--- a/src/integration/tests/genesis.rs
+++ b/src/integration/tests/genesis.rs
@@ -64,19 +64,21 @@ async fn genesis_e2e() {
 		fs::create_dir_all(personal_dir(user)).unwrap();
 		let master_seed_path = personal_dir(user).join(private);
 		let public_path = personal_dir(user).join(public);
-		assert!(Command::new(integration::QOS_CLIENT_PATH)
-			.args([
-				"generate-file-key",
-				"--master-seed-path",
-				master_seed_path.to_str().unwrap(),
-				"--pub-path",
-				public_path.to_str().unwrap(),
-			])
-			.spawn()
-			.unwrap()
-			.wait()
-			.unwrap()
-			.success());
+		assert!(
+			Command::new(integration::QOS_CLIENT_PATH)
+				.args([
+					"generate-file-key",
+					"--master-seed-path",
+					master_seed_path.to_str().unwrap(),
+					"--pub-path",
+					public_path.to_str().unwrap(),
+				])
+				.spawn()
+				.unwrap()
+				.wait()
+				.unwrap()
+				.success()
+		);
 		assert!(Path::new(&*personal_dir(user)).join(public).is_file());
 		assert!(Path::new(&*personal_dir(user)).join(private).is_file());
 	}
@@ -135,30 +137,32 @@ async fn genesis_e2e() {
 
 	// -- CLIENT Run boot genesis, creating a genesis set from the setup keys in
 	// the genesis dir
-	assert!(Command::new(integration::QOS_CLIENT_PATH)
-		.args([
-			"boot-genesis",
-			"--share-set-dir",
-			genesis_dir.to_str().unwrap(),
-			"--namespace-dir",
-			genesis_dir.to_str().unwrap(),
-			"--host-ip",
-			LOCAL_HOST,
-			"--host-port",
-			&*host_port.to_string(),
-			"--qos-release-dir",
-			QOS_DIST_DIR,
-			"--pcr3-preimage-path",
-			PCR3_PRE_IMAGE_PATH,
-			"--dr-key-path",
-			DR_KEY_PUBLIC_PATH,
-			"--unsafe-skip-attestation"
-		])
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
+	assert!(
+		Command::new(integration::QOS_CLIENT_PATH)
+			.args([
+				"boot-genesis",
+				"--share-set-dir",
+				genesis_dir.to_str().unwrap(),
+				"--namespace-dir",
+				genesis_dir.to_str().unwrap(),
+				"--host-ip",
+				LOCAL_HOST,
+				"--host-port",
+				&*host_port.to_string(),
+				"--qos-release-dir",
+				QOS_DIST_DIR,
+				"--pcr3-preimage-path",
+				PCR3_PRE_IMAGE_PATH,
+				"--dr-key-path",
+				DR_KEY_PUBLIC_PATH,
+				"--unsafe-skip-attestation"
+			])
+			.spawn()
+			.unwrap()
+			.wait()
+			.unwrap()
+			.success()
+	);
 
 	// -- Check files generated from the genesis boot
 	drop(unsafe_attestation_doc_from_der(
@@ -210,28 +214,30 @@ async fn genesis_e2e() {
 	for user in [&user1, &user2, &user3] {
 		let share_path = personal_dir(user).join(format!("{user}.share"));
 		let secret_path = personal_dir(user).join(format!("{user}.secret"));
-		assert!(Command::new(integration::QOS_CLIENT_PATH)
-			.args([
-				"after-genesis",
-				"--secret-path",
-				secret_path.to_str().unwrap(),
-				"--share-path",
-				share_path.to_str().unwrap(),
-				"--alias",
-				user,
-				"--namespace-dir",
-				genesis_dir.to_str().unwrap(),
-				"--qos-release-dir",
-				QOS_DIST_DIR,
-				"--pcr3-preimage-path",
-				"./mock/pcr3-preimage.txt",
-				"--unsafe-skip-attestation"
-			])
-			.spawn()
-			.unwrap()
-			.wait()
-			.unwrap()
-			.success());
+		assert!(
+			Command::new(integration::QOS_CLIENT_PATH)
+				.args([
+					"after-genesis",
+					"--secret-path",
+					secret_path.to_str().unwrap(),
+					"--share-path",
+					share_path.to_str().unwrap(),
+					"--alias",
+					user,
+					"--namespace-dir",
+					genesis_dir.to_str().unwrap(),
+					"--qos-release-dir",
+					QOS_DIST_DIR,
+					"--pcr3-preimage-path",
+					"./mock/pcr3-preimage.txt",
+					"--unsafe-skip-attestation"
+				])
+				.spawn()
+				.unwrap()
+				.wait()
+				.unwrap()
+				.success()
+		);
 
 		let share_key_path =
 			Path::new(&personal_dir(user)).join(format!("{user}.secret"));
@@ -266,15 +272,17 @@ async fn genesis_e2e() {
 	let reconstructed_path =
 		tmp_dir.join("reconstructed_quorum_master_seed_hex");
 	reconstructed.to_hex_file(&reconstructed_path).unwrap();
-	assert!(Command::new(integration::QOS_CLIENT_PATH)
-		.arg("verify-genesis")
-		.arg("--namespace-dir")
-		.arg(genesis_dir)
-		.arg("--master-seed-path")
-		.arg(reconstructed_path)
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
+	assert!(
+		Command::new(integration::QOS_CLIENT_PATH)
+			.arg("verify-genesis")
+			.arg("--namespace-dir")
+			.arg(genesis_dir)
+			.arg("--master-seed-path")
+			.arg(reconstructed_path)
+			.spawn()
+			.unwrap()
+			.wait()
+			.unwrap()
+			.success()
+	);
 }

--- a/src/integration/tests/host_bridge.rs
+++ b/src/integration/tests/host_bridge.rs
@@ -3,9 +3,9 @@ use std::{
 	process::Command,
 };
 
-use integration::{wait_for_tcp_sock, wait_for_usock, PIVOT_TCP_PATH};
+use integration::{PIVOT_TCP_PATH, wait_for_tcp_sock, wait_for_usock};
 use qos_core::io::{HostBridge, SocketAddress, Stream, StreamPool};
-use qos_test_primitives::{find_free_port, ChildWrapper};
+use qos_test_primitives::{ChildWrapper, find_free_port};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/integration/tests/interleaving_socket_stress.rs
+++ b/src/integration/tests/interleaving_socket_stress.rs
@@ -2,7 +2,7 @@ use std::process::Command;
 
 use borsh::BorshDeserialize;
 use integration::{
-	wait_for_usock, PivotSocketStressMsg, PIVOT_SOCKET_STRESS_PATH,
+	PIVOT_SOCKET_STRESS_PATH, PivotSocketStressMsg, wait_for_usock,
 };
 use qos_core::{
 	client::{ClientError, SocketClient},

--- a/src/integration/tests/key.rs
+++ b/src/integration/tests/key.rs
@@ -110,63 +110,69 @@ async fn key_fwd_e2e() {
 	qos_test_primitives::wait_until_port_is_bound(new_host_port);
 
 	// -- CLIENT broadcast boot key fwd instruction
-	assert!(Command::new(integration::QOS_CLIENT_PATH)
-		.args([
-			"boot-key-fwd",
-			"--manifest-envelope-path",
-			MANIFEST_ENVELOPE_PATH,
-			"--pivot-path",
-			PIVOT_LOOP_PATH,
-			"--attestation-doc-path",
-			NEW_ATTESTATION_DOC_PATH,
-			"--host-port",
-			&new_host_port.to_string(),
-			"--host-ip",
-			LOCAL_HOST,
-		])
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
+	assert!(
+		Command::new(integration::QOS_CLIENT_PATH)
+			.args([
+				"boot-key-fwd",
+				"--manifest-envelope-path",
+				MANIFEST_ENVELOPE_PATH,
+				"--pivot-path",
+				PIVOT_LOOP_PATH,
+				"--attestation-doc-path",
+				NEW_ATTESTATION_DOC_PATH,
+				"--host-port",
+				&new_host_port.to_string(),
+				"--host-ip",
+				LOCAL_HOST,
+			])
+			.spawn()
+			.unwrap()
+			.wait()
+			.unwrap()
+			.success()
+	);
 
 	// -- CLIENT broadcast key request to the old enclave
-	assert!(Command::new(integration::QOS_CLIENT_PATH)
-		.args([
-			"export-key",
-			"--manifest-envelope-path",
-			MANIFEST_ENVELOPE_PATH,
-			"--attestation-doc-path",
-			NEW_ATTESTATION_DOC_PATH,
-			"--encrypted-quorum-key-path",
-			ENCRYPTED_QUORUM_KEY_PATH,
-			"--host-port",
-			&old_host_port.to_string(),
-			"--host-ip",
-			LOCAL_HOST,
-		])
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
+	assert!(
+		Command::new(integration::QOS_CLIENT_PATH)
+			.args([
+				"export-key",
+				"--manifest-envelope-path",
+				MANIFEST_ENVELOPE_PATH,
+				"--attestation-doc-path",
+				NEW_ATTESTATION_DOC_PATH,
+				"--encrypted-quorum-key-path",
+				ENCRYPTED_QUORUM_KEY_PATH,
+				"--host-port",
+				&old_host_port.to_string(),
+				"--host-ip",
+				LOCAL_HOST,
+			])
+			.spawn()
+			.unwrap()
+			.wait()
+			.unwrap()
+			.success()
+	);
 
 	// -- CLIENT broadcast encrypted quorum to the new enclave
-	assert!(Command::new(integration::QOS_CLIENT_PATH)
-		.args([
-			"inject-key",
-			"--encrypted-quorum-key-path",
-			ENCRYPTED_QUORUM_KEY_PATH,
-			"--host-port",
-			&new_host_port.to_string(),
-			"--host-ip",
-			LOCAL_HOST,
-		])
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
+	assert!(
+		Command::new(integration::QOS_CLIENT_PATH)
+			.args([
+				"inject-key",
+				"--encrypted-quorum-key-path",
+				ENCRYPTED_QUORUM_KEY_PATH,
+				"--host-port",
+				&new_host_port.to_string(),
+				"--host-ip",
+				LOCAL_HOST,
+			])
+			.spawn()
+			.unwrap()
+			.wait()
+			.unwrap()
+			.success()
+	);
 
 	// Check that the quorum key got written
 	let quorum_pair = P256Pair::from_hex_file(new_secret_path).unwrap();
@@ -176,59 +182,26 @@ async fn key_fwd_e2e() {
 
 fn generate_manifest_envelope() {
 	let pivot_args = format!("[--msg,{TEST_MSG}]");
-	assert!(Command::new(integration::QOS_CLIENT_PATH)
-		.args([
-			"generate-manifest",
-			"--nonce",
-			"2",
-			"--namespace",
-			NAMESPACE,
-			"--restart-policy",
-			"always",
-			"--pcr3-preimage-path",
-			PCR3_PRE_IMAGE_PATH,
-			"--pivot-hash-path",
-			PIVOT_HASH_PATH,
-			"--qos-release-dir",
-			QOS_DIST_DIR,
-			"--manifest-path",
-			CLI_MANIFEST_PATH,
-			"--pivot-args",
-			&pivot_args,
-			"--manifest-set-dir",
-			"./mock/keys/manifest-set",
-			"--share-set-dir",
-			"./mock/keys/share-set",
-			"--patch-set-dir",
-			"./mock/keys/manifest-set",
-			"--quorum-key-path",
-			QUORUM_KEY_PUB_PATH
-		])
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
-
-	// -- CLIENT make sure each user can run `approve-manifest`
-	for alias in USERS {
-		let secret_path = format!("{}/{}.secret", &personal_dir(alias), alias);
-
-		assert!(Command::new(integration::QOS_CLIENT_PATH)
+	assert!(
+		Command::new(integration::QOS_CLIENT_PATH)
 			.args([
-				"approve-manifest",
-				"--secret-path",
-				&*secret_path,
-				"--manifest-path",
-				CLI_MANIFEST_PATH,
-				"--manifest-approvals-dir",
-				BOOT_DIR,
+				"generate-manifest",
+				"--nonce",
+				"2",
+				"--namespace",
+				NAMESPACE,
+				"--restart-policy",
+				"always",
 				"--pcr3-preimage-path",
 				PCR3_PRE_IMAGE_PATH,
 				"--pivot-hash-path",
 				PIVOT_HASH_PATH,
 				"--qos-release-dir",
 				QOS_DIST_DIR,
+				"--manifest-path",
+				CLI_MANIFEST_PATH,
+				"--pivot-args",
+				&pivot_args,
 				"--manifest-set-dir",
 				"./mock/keys/manifest-set",
 				"--share-set-dir",
@@ -236,16 +209,53 @@ fn generate_manifest_envelope() {
 				"--patch-set-dir",
 				"./mock/keys/manifest-set",
 				"--quorum-key-path",
-				QUORUM_KEY_PUB_PATH,
-				"--alias",
-				alias,
-				"--unsafe-auto-confirm",
+				QUORUM_KEY_PUB_PATH
 			])
 			.spawn()
 			.unwrap()
 			.wait()
 			.unwrap()
-			.success());
+			.success()
+	);
+
+	// -- CLIENT make sure each user can run `approve-manifest`
+	for alias in USERS {
+		let secret_path = format!("{}/{}.secret", personal_dir(alias), alias);
+
+		assert!(
+			Command::new(integration::QOS_CLIENT_PATH)
+				.args([
+					"approve-manifest",
+					"--secret-path",
+					&*secret_path,
+					"--manifest-path",
+					CLI_MANIFEST_PATH,
+					"--manifest-approvals-dir",
+					BOOT_DIR,
+					"--pcr3-preimage-path",
+					PCR3_PRE_IMAGE_PATH,
+					"--pivot-hash-path",
+					PIVOT_HASH_PATH,
+					"--qos-release-dir",
+					QOS_DIST_DIR,
+					"--manifest-set-dir",
+					"./mock/keys/manifest-set",
+					"--share-set-dir",
+					"./mock/keys/share-set",
+					"--patch-set-dir",
+					"./mock/keys/manifest-set",
+					"--quorum-key-path",
+					QUORUM_KEY_PUB_PATH,
+					"--alias",
+					alias,
+					"--unsafe-auto-confirm",
+				])
+				.spawn()
+				.unwrap()
+				.wait()
+				.unwrap()
+				.success()
+		);
 	}
 }
 
@@ -294,116 +304,126 @@ fn boot_old_enclave(old_host_port: u16) -> (ChildWrapper, ChildWrapper) {
 	qos_test_primitives::wait_until_port_is_bound(old_host_port);
 
 	// -- CLIENT generate the manifest envelope
-	assert!(Command::new(integration::QOS_CLIENT_PATH)
-		.args([
-			"generate-manifest-envelope",
-			"--manifest-approvals-dir",
-			BOOT_DIR,
-			"--manifest-path",
-			CLI_MANIFEST_PATH,
-		])
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
-
-	// -- CLIENT broadcast boot standard instruction
-	assert!(Command::new(integration::QOS_CLIENT_PATH)
-		.args([
-			"boot-standard",
-			"--manifest-envelope-path",
-			MANIFEST_ENVELOPE_PATH,
-			"--pivot-path",
-			PIVOT_LOOP_PATH,
-			"--host-port",
-			&old_host_port.to_string(),
-			"--host-ip",
-			LOCAL_HOST,
-			"--pcr3-preimage-path",
-			PCR3_PRE_IMAGE_PATH,
-			"--unsafe-skip-attestation",
-		])
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
-
-	assert!(Command::new(integration::QOS_CLIENT_PATH)
-		.args([
-			"get-attestation-doc",
-			"--host-port",
-			&old_host_port.to_string(),
-			"--host-ip",
-			LOCAL_HOST,
-			"--attestation-doc-path",
-			ATTESTATION_DOC_PATH,
-			"--manifest-envelope-path",
-			"/tmp/dont_care"
-		])
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
-
-	for user in &USERS[0..2] {
-		let share_path = format!("{}/{}.share", &personal_dir(user), user);
-		let secret_path = format!("{}/{}.secret", &personal_dir(user), user);
-		let eph_wrapped_share_path =
-			PathWrapper::from(format!("{TMP_DIR}/{user}.eph_wrapped.share"));
-		let approval_path =
-			PathWrapper::from(format!("{TMP_DIR}/{user}.attestation.approval"));
-		assert!(Command::new(integration::QOS_CLIENT_PATH)
+	assert!(
+		Command::new(integration::QOS_CLIENT_PATH)
 			.args([
-				"proxy-re-encrypt-share",
-				"--share-path",
-				&share_path,
-				"--secret-path",
-				&secret_path,
-				"--attestation-doc-path",
-				ATTESTATION_DOC_PATH,
-				"--eph-wrapped-share-path",
-				eph_wrapped_share_path.to_str().unwrap(),
-				"--approval-path",
-				approval_path.to_str().unwrap(),
-				"--manifest-envelope-path",
-				MANIFEST_ENVELOPE_PATH,
-				"--pcr3-preimage-path",
-				PCR3_PRE_IMAGE_PATH,
-				"--manifest-set-dir",
-				"./mock/keys/manifest-set",
-				"--alias",
-				user,
-				"--unsafe-skip-attestation",
-				"--unsafe-eph-path-override",
-				SHARED_EPH_PATH,
-				"--unsafe-auto-confirm",
+				"generate-manifest-envelope",
+				"--manifest-approvals-dir",
+				BOOT_DIR,
+				"--manifest-path",
+				CLI_MANIFEST_PATH,
 			])
 			.spawn()
 			.unwrap()
 			.wait()
 			.unwrap()
-			.success());
+			.success()
+	);
 
-		assert!(Command::new(integration::QOS_CLIENT_PATH)
+	// -- CLIENT broadcast boot standard instruction
+	assert!(
+		Command::new(integration::QOS_CLIENT_PATH)
 			.args([
-				"post-share",
+				"boot-standard",
+				"--manifest-envelope-path",
+				MANIFEST_ENVELOPE_PATH,
+				"--pivot-path",
+				PIVOT_LOOP_PATH,
 				"--host-port",
 				&old_host_port.to_string(),
 				"--host-ip",
 				LOCAL_HOST,
-				"--eph-wrapped-share-path",
-				eph_wrapped_share_path.to_str().unwrap(),
-				"--approval-path",
-				approval_path.to_str().unwrap(),
+				"--pcr3-preimage-path",
+				PCR3_PRE_IMAGE_PATH,
+				"--unsafe-skip-attestation",
 			])
 			.spawn()
 			.unwrap()
 			.wait()
 			.unwrap()
-			.success());
+			.success()
+	);
+
+	assert!(
+		Command::new(integration::QOS_CLIENT_PATH)
+			.args([
+				"get-attestation-doc",
+				"--host-port",
+				&old_host_port.to_string(),
+				"--host-ip",
+				LOCAL_HOST,
+				"--attestation-doc-path",
+				ATTESTATION_DOC_PATH,
+				"--manifest-envelope-path",
+				"/tmp/dont_care"
+			])
+			.spawn()
+			.unwrap()
+			.wait()
+			.unwrap()
+			.success()
+	);
+
+	for user in &USERS[0..2] {
+		let share_path = format!("{}/{}.share", personal_dir(user), user);
+		let secret_path = format!("{}/{}.secret", personal_dir(user), user);
+		let eph_wrapped_share_path =
+			PathWrapper::from(format!("{TMP_DIR}/{user}.eph_wrapped.share"));
+		let approval_path =
+			PathWrapper::from(format!("{TMP_DIR}/{user}.attestation.approval"));
+		assert!(
+			Command::new(integration::QOS_CLIENT_PATH)
+				.args([
+					"proxy-re-encrypt-share",
+					"--share-path",
+					&share_path,
+					"--secret-path",
+					&secret_path,
+					"--attestation-doc-path",
+					ATTESTATION_DOC_PATH,
+					"--eph-wrapped-share-path",
+					eph_wrapped_share_path.to_str().unwrap(),
+					"--approval-path",
+					approval_path.to_str().unwrap(),
+					"--manifest-envelope-path",
+					MANIFEST_ENVELOPE_PATH,
+					"--pcr3-preimage-path",
+					PCR3_PRE_IMAGE_PATH,
+					"--manifest-set-dir",
+					"./mock/keys/manifest-set",
+					"--alias",
+					user,
+					"--unsafe-skip-attestation",
+					"--unsafe-eph-path-override",
+					SHARED_EPH_PATH,
+					"--unsafe-auto-confirm",
+				])
+				.spawn()
+				.unwrap()
+				.wait()
+				.unwrap()
+				.success()
+		);
+
+		assert!(
+			Command::new(integration::QOS_CLIENT_PATH)
+				.args([
+					"post-share",
+					"--host-port",
+					&old_host_port.to_string(),
+					"--host-ip",
+					LOCAL_HOST,
+					"--eph-wrapped-share-path",
+					eph_wrapped_share_path.to_str().unwrap(),
+					"--approval-path",
+					approval_path.to_str().unwrap(),
+				])
+				.spawn()
+				.unwrap()
+				.wait()
+				.unwrap()
+				.success()
+		);
 	}
 
 	// Check that the enclave wrote its quorum key

--- a/src/integration/tests/preprod_sharding.rs
+++ b/src/integration/tests/preprod_sharding.rs
@@ -10,7 +10,7 @@ use std::{
 
 use qos_crypto::shamir::shares_generate;
 use qos_p256::{
-	derive_secret, encrypt::P256EncryptPair, P256Pair, P256_ENCRYPT_DERIVE_PATH,
+	P256_ENCRYPT_DERIVE_PATH, P256Pair, derive_secret, encrypt::P256EncryptPair,
 };
 
 // Note: the dev secret can also be found in our keys repo
@@ -58,19 +58,21 @@ fn preprod_reshard_ceremony() {
 
 		let master_seed_path = format!("{}/{}", user_dir(user), private);
 		let public_path = format!("{}/{}", user_dir(user), public);
-		assert!(Command::new(integration::QOS_CLIENT_PATH)
-			.args([
-				"generate-file-key",
-				"--master-seed-path",
-				&master_seed_path,
-				"--pub-path",
-				&public_path,
-			])
-			.spawn()
-			.unwrap()
-			.wait()
-			.unwrap()
-			.success());
+		assert!(
+			Command::new(integration::QOS_CLIENT_PATH)
+				.args([
+					"generate-file-key",
+					"--master-seed-path",
+					&master_seed_path,
+					"--pub-path",
+					&public_path,
+				])
+				.spawn()
+				.unwrap()
+				.wait()
+				.unwrap()
+				.success()
+		);
 
 		// Assert both public and private key paths now exist
 		assert!(Path::new(&*user_dir(user)).join(public).is_file());

--- a/src/integration/tests/proofs.rs
+++ b/src/integration/tests/proofs.rs
@@ -1,7 +1,7 @@
 use std::{process::Command, str};
 
 use borsh::BorshDeserialize;
-use integration::{wait_for_usock, PivotProofMsg, PIVOT_PROOF_PATH};
+use integration::{PIVOT_PROOF_PATH, PivotProofMsg, wait_for_usock};
 use qos_core::{
 	client::SocketClient,
 	io::{SocketAddress, StreamPool},
@@ -39,12 +39,14 @@ async fn fetch_and_verify_app_proof() {
 		PivotProofMsg::AdditionResponse { result, proof } => {
 			let ephemeral_public_key =
 				P256Public::from_bytes(&proof.public_key).unwrap();
-			assert!(ephemeral_public_key
-				.verify(
-					&borsh::to_vec(&proof.payload).unwrap(),
-					&proof.signature
-				)
-				.is_ok());
+			assert!(
+				ephemeral_public_key
+					.verify(
+						&borsh::to_vec(&proof.payload).unwrap(),
+						&proof.signature
+					)
+					.is_ok()
+			);
 
 			assert_eq!(proof.payload.a, 2);
 			assert_eq!(proof.payload.b, 2);

--- a/src/integration/tests/qos_bridge.rs
+++ b/src/integration/tests/qos_bridge.rs
@@ -7,10 +7,11 @@ use std::{
 
 use borsh::de::BorshDeserialize;
 use integration::{
-	wait_for_tcp_sock, PivotSocketStressMsg, LOCAL_HOST, PCR3_PRE_IMAGE_PATH,
-	PIVOT_SOCKET_STRESS_PATH, QOS_DIST_DIR,
+	LOCAL_HOST, PCR3_PRE_IMAGE_PATH, PIVOT_SOCKET_STRESS_PATH,
+	PivotSocketStressMsg, QOS_DIST_DIR, wait_for_tcp_sock,
 };
 use qos_core::protocol::{
+	ProtocolPhase, QosHash,
 	services::{
 		boot::{
 			Approval, BridgeConfig, Manifest, ManifestSet, Namespace,
@@ -18,7 +19,6 @@ use qos_core::protocol::{
 		},
 		genesis::{GenesisMemberOutput, GenesisOutput},
 	},
-	ProtocolPhase, QosHash,
 };
 use qos_crypto::sha_256;
 use qos_host::EnclaveInfo;
@@ -240,7 +240,9 @@ async fn qos_bridge_works() {
 		);
 		assert_eq!(
 			&stdout.next().unwrap().unwrap(),
-			&format!("[\"/tmp/qos_host_bridge/qos_host_bridge.sock.{app_host_port}.appsock\"]?")
+			&format!(
+				"[\"/tmp/qos_host_bridge/qos_host_bridge.sock.{app_host_port}.appsock\"]?"
+			)
 		);
 		assert_eq!(&stdout.next().unwrap().unwrap(), "(y/n)");
 		stdin.write_all("y\n".as_bytes()).expect("Failed to write to stdin");
@@ -321,63 +323,69 @@ async fn qos_bridge_works() {
 			.into();
 
 	// -- CLIENT generate the manifest envelope
-	assert!(Command::new(integration::QOS_CLIENT_PATH)
-		.args([
-			"generate-manifest-envelope",
-			"--manifest-approvals-dir",
-			boot_dir.to_str().unwrap(),
-			"--manifest-path",
-			cli_manifest_path.to_str().unwrap(),
-		])
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
-
-	// -- CLIENT broadcast boot standard instruction
-	let manifest_envelope_path = boot_dir.join("manifest_envelope");
-	assert!(Command::new(integration::QOS_CLIENT_PATH)
-		.args([
-			"boot-standard",
-			"--manifest-envelope-path",
-			manifest_envelope_path.to_str().unwrap(),
-			"--pivot-path",
-			PIVOT_SOCKET_STRESS_PATH,
-			"--host-port",
-			&host_port.to_string(),
-			"--host-ip",
-			LOCAL_HOST,
-			"--pcr3-preimage-path",
-			"./mock/pcr3-preimage.txt",
-			"--unsafe-skip-attestation",
-		])
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
-
-	// For each user, post a share,
-	for user in [&user1, &user2] {
-		// Get attestation doc and manifest
-		assert!(Command::new(integration::QOS_CLIENT_PATH)
+	assert!(
+		Command::new(integration::QOS_CLIENT_PATH)
 			.args([
-				"get-attestation-doc",
-				"--host-port",
-				&host_port.to_string(),
-				"--host-ip",
-				LOCAL_HOST,
-				"--attestation-doc-path",
-				attestation_doc_path.to_str().unwrap(),
-				"--manifest-envelope-path",
-				"/tmp/dont_care"
+				"generate-manifest-envelope",
+				"--manifest-approvals-dir",
+				boot_dir.to_str().unwrap(),
+				"--manifest-path",
+				cli_manifest_path.to_str().unwrap(),
 			])
 			.spawn()
 			.unwrap()
 			.wait()
 			.unwrap()
-			.success());
+			.success()
+	);
+
+	// -- CLIENT broadcast boot standard instruction
+	let manifest_envelope_path = boot_dir.join("manifest_envelope");
+	assert!(
+		Command::new(integration::QOS_CLIENT_PATH)
+			.args([
+				"boot-standard",
+				"--manifest-envelope-path",
+				manifest_envelope_path.to_str().unwrap(),
+				"--pivot-path",
+				PIVOT_SOCKET_STRESS_PATH,
+				"--host-port",
+				&host_port.to_string(),
+				"--host-ip",
+				LOCAL_HOST,
+				"--pcr3-preimage-path",
+				"./mock/pcr3-preimage.txt",
+				"--unsafe-skip-attestation",
+			])
+			.spawn()
+			.unwrap()
+			.wait()
+			.unwrap()
+			.success()
+	);
+
+	// For each user, post a share,
+	for user in [&user1, &user2] {
+		// Get attestation doc and manifest
+		assert!(
+			Command::new(integration::QOS_CLIENT_PATH)
+				.args([
+					"get-attestation-doc",
+					"--host-port",
+					&host_port.to_string(),
+					"--host-ip",
+					LOCAL_HOST,
+					"--attestation-doc-path",
+					attestation_doc_path.to_str().unwrap(),
+					"--manifest-envelope-path",
+					"/tmp/dont_care"
+				])
+				.spawn()
+				.unwrap()
+				.wait()
+				.unwrap()
+				.success()
+		);
 
 		let share_path = personal_dir(user).join(format!("{user}.share"));
 		let secret_path = personal_dir(user).join(format!("{user}.secret"));
@@ -442,9 +450,9 @@ async fn qos_bridge_works() {
 		stdin.write_all("yes\n".as_bytes()).expect("Failed to write to stdin");
 
 		assert_eq!(
-				&stdout.next().unwrap().unwrap(),
-				"Does this AWS IAM role belong to the intended organization: arn:aws:iam::123456789012:role/Webserver? (y/n)"
-			);
+			&stdout.next().unwrap().unwrap(),
+			"Does this AWS IAM role belong to the intended organization: arn:aws:iam::123456789012:role/Webserver? (y/n)"
+		);
 		stdin.write_all("yes\n".as_bytes()).expect("Failed to write to stdin");
 
 		assert_eq!(
@@ -457,23 +465,25 @@ async fn qos_bridge_works() {
 		assert!(child.wait().unwrap().success());
 
 		// Post the encrypted share
-		assert!(Command::new(integration::QOS_CLIENT_PATH)
-			.args([
-				"post-share",
-				"--host-port",
-				&host_port.to_string(),
-				"--host-ip",
-				LOCAL_HOST,
-				"--eph-wrapped-share-path",
-				eph_wrapped_share_path.to_str().unwrap(),
-				"--approval-path",
-				approval_path.to_str().unwrap(),
-			])
-			.spawn()
-			.unwrap()
-			.wait()
-			.unwrap()
-			.success());
+		assert!(
+			Command::new(integration::QOS_CLIENT_PATH)
+				.args([
+					"post-share",
+					"--host-port",
+					&host_port.to_string(),
+					"--host-ip",
+					LOCAL_HOST,
+					"--eph-wrapped-share-path",
+					eph_wrapped_share_path.to_str().unwrap(),
+					"--approval-path",
+					approval_path.to_str().unwrap(),
+				])
+				.spawn()
+				.unwrap()
+				.wait()
+				.unwrap()
+				.success()
+		);
 	}
 
 	let enclave_info_url =

--- a/src/integration/tests/reaper.rs
+++ b/src/integration/tests/reaper.rs
@@ -4,17 +4,17 @@ use std::{
 };
 
 use integration::{
-	wait_for_tcp_sock, wait_for_usock, PIVOT_ABORT_PATH, PIVOT_OK2_PATH,
-	PIVOT_OK2_SUCCESS_FILE, PIVOT_OK_PATH, PIVOT_PANIC_PATH, PIVOT_TCP_PATH,
+	PIVOT_ABORT_PATH, PIVOT_OK_PATH, PIVOT_OK2_PATH, PIVOT_OK2_SUCCESS_FILE,
+	PIVOT_PANIC_PATH, PIVOT_TCP_PATH, wait_for_tcp_sock, wait_for_usock,
 };
 use qos_core::{
 	handles::Handles,
 	io::{HostBridge, SocketAddress, StreamPool},
 	protocol::services::boot::{BridgeConfig, ManifestEnvelope},
-	reaper::{Reaper, REAPER_EXIT_DELAY},
+	reaper::{REAPER_EXIT_DELAY, Reaper},
 };
 use qos_nsm::mock::MockNsm;
-use qos_test_primitives::{find_free_port, PathWrapper};
+use qos_test_primitives::{PathWrapper, find_free_port};
 use tokio::{
 	io::{AsyncReadExt, AsyncWriteExt},
 	net::TcpStream,
@@ -72,6 +72,7 @@ async fn reaper_works() {
 }
 
 #[tokio::test]
+#[allow(unsafe_code)]
 async fn reaper_clears_host_env() {
 	let secret_path = PathWrapper::from("/tmp/reaper_clears_host_env.secret");
 	let usock = PathWrapper::from("/tmp/reaper_clears_host_env.sock");
@@ -81,7 +82,9 @@ async fn reaper_clears_host_env() {
 	let host_only_env_key = "QOS_TEST_REAPER_HOST_ONLY_ENV";
 
 	drop(fs::remove_file(&*secret_path));
-	std::env::set_var(host_only_env_key, "must-not-leak");
+	// SAFETY: This test is not marked multi_thread and no other thread
+	// reads this env var concurrently at this point.
+	unsafe { std::env::set_var(host_only_env_key, "must-not-leak") };
 
 	let handles = Handles::new(
 		"reaper_clears_host_env.eph".to_string(),
@@ -116,7 +119,8 @@ async fn reaper_clears_host_env() {
 	let contents = fs::read(PIVOT_OK2_SUCCESS_FILE).unwrap();
 	assert_eq!(std::str::from_utf8(&contents).unwrap(), msg);
 	assert!(fs::remove_file(PIVOT_OK2_SUCCESS_FILE).is_ok());
-	std::env::remove_var(host_only_env_key);
+	// SAFETY: Matching the set_var above; test is single-threaded.
+	unsafe { std::env::remove_var(host_only_env_key) };
 }
 
 // TODO(json-pr): restore this manifest env test when the JSON manifest PR

--- a/src/integration/tests/remote_tls.rs
+++ b/src/integration/tests/remote_tls.rs
@@ -2,7 +2,7 @@ use std::process::Command;
 
 use borsh::BorshDeserialize;
 use integration::{
-	wait_for_usock, PivotRemoteTlsMsg, PIVOT_REMOTE_TLS_PATH, QOS_NET_PATH,
+	PIVOT_REMOTE_TLS_PATH, PivotRemoteTlsMsg, QOS_NET_PATH, wait_for_usock,
 };
 use qos_core::{
 	client::SocketClient,

--- a/src/integration/tests/simple_socket_stress.rs
+++ b/src/integration/tests/simple_socket_stress.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 use integration::{
-	wait_for_usock, PivotSocketStressMsg, PIVOT_SOCKET_STRESS_PATH,
+	PIVOT_SOCKET_STRESS_PATH, PivotSocketStressMsg, wait_for_usock,
 };
 use qos_core::{
 	client::{ClientError, SocketClient},

--- a/src/integration/tests/version.rs
+++ b/src/integration/tests/version.rs
@@ -1,5 +1,5 @@
 use borsh::BorshDeserialize;
-use integration::{wait_for_tcp_sock, wait_for_usock, PIVOT_OK_PATH};
+use integration::{PIVOT_OK_PATH, wait_for_tcp_sock, wait_for_usock};
 use qos_core::{
 	handles::Handles, io::SocketAddress, protocol::msg::ProtocolMsg,
 	reaper::Reaper,

--- a/src/qos_aws/Cargo.toml
+++ b/src/qos_aws/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "qos_aws"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 rust-version = "1.88"
 publish = false
 

--- a/src/qos_aws/src/lib.rs
+++ b/src/qos_aws/src/lib.rs
@@ -2,7 +2,7 @@ use qos_system::{check_hwrng, dmesg, poweroff};
 
 /// Signal to Nitro hypervisor that booting was successful
 fn nitro_heartbeat() {
-	use libc::{close, read, write, AF_VSOCK};
+	use libc::{AF_VSOCK, close, read, write};
 	use qos_system::socket_connect;
 	let mut buf: [u8; 1] = [0; 1];
 	buf[0] = 0xB7; // AWS Nitro heartbeat value

--- a/src/qos_bridge/src/cli.rs
+++ b/src/qos_bridge/src/cli.rs
@@ -100,7 +100,9 @@ impl HostOpts {
 			.as_ref()
 			.map(|s| s.parse())
 			.map(|r| {
-				r.expect("could not parse `--vsock-to-host`. Valid args are true or false")
+				r.expect(
+					"could not parse `--vsock-to-host`. Valid args are true or false",
+				)
 			})
 			.unwrap_or(true);
 

--- a/src/qos_bridge/src/host.rs
+++ b/src/qos_bridge/src/host.rs
@@ -9,7 +9,7 @@ use qos_core::{
 	io::{HostBridge, SocketAddress, StreamPool},
 	protocol::services::boot::BridgeConfig,
 };
-use qos_host::{EnclaveInfo, ENCLAVE_INFO};
+use qos_host::{ENCLAVE_INFO, EnclaveInfo};
 
 /// Host server implementation using `HostBridge::tcp_to_vsock`
 pub struct BridgeServer {
@@ -82,7 +82,9 @@ impl BridgeServer {
 			{
 				Ok(value) => value,
 				Err(err) => {
-					eprintln!("unable to derive app socket from enclave socket: {err:?}, tcp to vsock bridge will not start");
+					eprintln!(
+						"unable to derive app socket from enclave socket: {err:?}, tcp to vsock bridge will not start"
+					);
 					return;
 				}
 			};
@@ -90,13 +92,17 @@ impl BridgeServer {
 			let app_pool = match StreamPool::single(app_socket) {
 				Ok(value) => value,
 				Err(err) => {
-					eprintln!("unable to create new app socket pool: {err:?}, tcp to vsock bridge will not start");
+					eprintln!(
+						"unable to create new app socket pool: {err:?}, tcp to vsock bridge will not start"
+					);
 					return;
 				}
 			};
 
 			let Ok(host_ip) = host_ip_str.parse::<Ipv4Addr>() else {
-				eprintln!("unable to parse host ip for bridge configuration: {host_ip_str}");
+				eprintln!(
+					"unable to parse host ip for bridge configuration: {host_ip_str}"
+				);
 				return;
 			};
 			let host_addr = SocketAddr::new(host_ip.into(), host_port);

--- a/src/qos_client/src/cli/mod.rs
+++ b/src/qos_client/src/cli/mod.rs
@@ -1277,7 +1277,9 @@ impl ClientRunner {
 		if let Ok((cmd, parsed)) = result {
 			Self { cmd, opts: ClientOpts { parsed } }
 		} else {
-			println!("Invalid input, try using --help with any of the following commands");
+			println!(
+				"Invalid input, try using --help with any of the following commands"
+			);
 			Command::print_all();
 
 			std::process::exit(1);
@@ -1389,8 +1391,8 @@ mod handlers {
 	use super::services::{ApproveManifestArgs, ProxyReEncryptShareArgs};
 	use crate::{
 		cli::{
-			services::{self, GenerateManifestArgs, PairOrYubi},
 			ClientOpts, ProtocolMsg,
+			services::{self, GenerateManifestArgs, PairOrYubi},
 		},
 		request,
 	};
@@ -1398,7 +1400,9 @@ mod handlers {
 	pub(super) fn pivot_hash(opts: &ClientOpts) {
 		let pivot_path = opts.pivot_path();
 		let pivot = std::fs::read(&pivot_path).unwrap_or_else(|e| {
-			panic!("pivot_hash: Could not read pivot file from {pivot_path:?}: {e}")
+			panic!(
+				"pivot_hash: Could not read pivot file from {pivot_path:?}: {e}"
+			)
 		});
 
 		let hash = qos_crypto::sha_256(&pivot);
@@ -1406,7 +1410,9 @@ mod handlers {
 
 		let output_path = opts.output_path();
 		std::fs::write(&output_path, hex_hash.as_bytes()).unwrap_or_else(|e| {
-			panic!("pivot_hash: Could not write pivot hash to {output_path:?}: {e}")
+			panic!(
+				"pivot_hash: Could not write pivot hash to {output_path:?}: {e}"
+			)
 		});
 	}
 

--- a/src/qos_client/src/cli/services.rs
+++ b/src/qos_client/src/cli/services.rs
@@ -8,6 +8,7 @@ use std::{
 use aws_nitro_enclaves_nsm_api::api::AttestationDoc;
 use borsh::BorshDeserialize;
 use qos_core::protocol::{
+	QosHash,
 	msg::ProtocolMsg,
 	services::{
 		boot::{
@@ -18,14 +19,13 @@ use qos_core::protocol::{
 		genesis::{GenesisOutput, GenesisSet},
 		key::EncryptedQuorumKey,
 	},
-	QosHash,
 };
 use qos_crypto::{sha_256, sha_384, sha_512};
 use qos_nsm::{
 	nitro::{
-		attestation_doc_from_der, cert_from_pem,
+		AWS_ROOT_CERT_PEM, attestation_doc_from_der, cert_from_pem,
 		unsafe_attestation_doc_from_der,
-		verify_attestation_doc_against_user_input, AWS_ROOT_CERT_PEM,
+		verify_attestation_doc_against_user_input,
 	},
 	types::NsmResponse,
 };
@@ -50,8 +50,7 @@ const DANGEROUS_DEV_BOOT_NAMESPACE: &str =
 	"DANGEROUS_DEV_BOOT_MEMBER_NAMESPACE";
 
 #[cfg(not(feature = "smartcard"))]
-pub(crate) const SMARTCARD_FEAT_DISABLED_MSG: &str =
-	"The \"smartcard\" feature must be enabled to use YubiKey related functionality.";
+pub(crate) const SMARTCARD_FEAT_DISABLED_MSG: &str = "The \"smartcard\" feature must be enabled to use YubiKey related functionality.";
 
 const ENTER_PIN_PROMPT: &str = "Enter your pin: ";
 const TAP_MSG: &str = "Tap your YubiKey";
@@ -248,11 +247,11 @@ impl PairOrYubi {
 	pub fn sign(&mut self, data: &[u8]) -> Result<Vec<u8>, Error> {
 		match self {
 			#[cfg(feature = "smartcard")]
-			Self::Yubi((ref mut yubi, ref pin)) => {
+			Self::Yubi((yubi, pin)) => {
 				println!("{TAP_MSG}");
 				crate::yubikey::sign_data(yubi, data, pin).map_err(Into::into)
 			}
-			Self::Pair(ref pair) => pair.sign(data).map_err(Into::into),
+			Self::Pair(pair) => pair.sign(data).map_err(Into::into),
 		}
 	}
 
@@ -264,7 +263,7 @@ impl PairOrYubi {
 	pub fn decrypt(&mut self, payload: &[u8]) -> Result<Vec<u8>, Error> {
 		match self {
 			#[cfg(feature = "smartcard")]
-			Self::Yubi((ref mut yubi, ref pin)) => {
+			Self::Yubi((yubi, pin)) => {
 				println!("{TAP_MSG}");
 				let shared_secret =
 					crate::yubikey::shared_secret(yubi, payload, pin)?;
@@ -277,7 +276,7 @@ impl PairOrYubi {
 					.decrypt_from_shared_secret(payload, &shared_secret)
 					.map_err(Into::into)
 			}
-			Self::Pair(ref pair) => pair.decrypt(payload).map_err(Into::into),
+			Self::Pair(pair) => pair.decrypt(payload).map_err(Into::into),
 		}
 	}
 
@@ -289,10 +288,10 @@ impl PairOrYubi {
 	pub fn public_key_bytes(&mut self) -> Result<Vec<u8>, Error> {
 		match self {
 			#[cfg(feature = "smartcard")]
-			Self::Yubi((ref mut yubi, _)) => {
+			Self::Yubi((yubi, _)) => {
 				crate::yubikey::pair_public_key(yubi).map_err(Into::into)
 			}
-			Self::Pair(ref pair) => Ok(pair.public_key().to_bytes()),
+			Self::Pair(pair) => Ok(pair.public_key().to_bytes()),
 		}
 	}
 }
@@ -625,7 +624,9 @@ pub(crate) fn verify_genesis<P: AsRef<Path>>(
 	if expected_signature != genesis_output.test_message_signature {
 		return Err(Error::CouldNotReproduceSignature);
 	}
-	println!("Quorum key signature over test message was deterministically reproduced");
+	println!(
+		"Quorum key signature over test message was deterministically reproduced"
+	);
 
 	// check test_message_ciphertext
 	let plaintext = pair.decrypt(&genesis_output.test_message_ciphertext)?;
@@ -1080,7 +1081,7 @@ pub(crate) fn boot_key_fwd<P: AsRef<Path>>(
 			nsm_response: NsmResponse::Attestation { document },
 		} => document,
 		r => {
-			return Err(Error::UnexpectedProtocolMsgResponse(format!("{r:?}")))
+			return Err(Error::UnexpectedProtocolMsgResponse(format!("{r:?}")));
 		}
 	};
 
@@ -1113,7 +1114,7 @@ pub(crate) fn export_key<P: AsRef<Path>>(
 			EncryptedQuorumKey { encrypted_quorum_key, signature }
 		}
 		r => {
-			return Err(Error::UnexpectedProtocolMsgResponse(format!("{r:?}")))
+			return Err(Error::UnexpectedProtocolMsgResponse(format!("{r:?}")));
 		}
 	};
 
@@ -1145,7 +1146,7 @@ pub(crate) fn inject_key<P: AsRef<Path>>(
 	match request::post(uri, &req).unwrap() {
 		ProtocolMsg::InjectKeyResponse => println!("Successful key injection!"),
 		r => {
-			return Err(Error::UnexpectedProtocolMsgResponse(format!("{r:?}")))
+			return Err(Error::UnexpectedProtocolMsgResponse(format!("{r:?}")));
 		}
 	}
 
@@ -1222,20 +1223,22 @@ pub(crate) fn get_attestation_doc<P: AsRef<Path>>(
 	attestation_doc_path: P,
 	manifest_envelope_path: P,
 ) {
-	let (cose_sign1, manifest_envelope) =
-		match request::post(uri, &ProtocolMsg::LiveAttestationDocRequest) {
-			Ok(ProtocolMsg::LiveAttestationDocResponse {
-				nsm_response: NsmResponse::Attestation { document },
-				manifest_envelope: Some(manifest_envelope),
-			}) => (document, manifest_envelope),
-			Ok(ProtocolMsg::LiveAttestationDocResponse {
-				nsm_response: _,
-				manifest_envelope: None,
-			}) => panic!(
-				"ManifestEnvelope does not exist in enclave - likely waiting for boot instruction"
-			),
-			r => panic!("Unexpected response: {r:?}"),
-		};
+	let (cose_sign1, manifest_envelope) = match request::post(
+		uri,
+		&ProtocolMsg::LiveAttestationDocRequest,
+	) {
+		Ok(ProtocolMsg::LiveAttestationDocResponse {
+			nsm_response: NsmResponse::Attestation { document },
+			manifest_envelope: Some(manifest_envelope),
+		}) => (document, manifest_envelope),
+		Ok(ProtocolMsg::LiveAttestationDocResponse {
+			nsm_response: _,
+			manifest_envelope: None,
+		}) => panic!(
+			"ManifestEnvelope does not exist in enclave - likely waiting for boot instruction"
+		),
+		r => panic!("Unexpected response: {r:?}"),
+	};
 
 	write_with_msg(
 		attestation_doc_path.as_ref(),
@@ -1395,7 +1398,9 @@ fn proxy_re_encrypt_share_programmatic_verifications(
 	}
 
 	if !manifest_envelope.manifest.share_set.members.contains(member) {
-		eprintln!("The provided share set key and alias are not part of the Share Set");
+		eprintln!(
+			"The provided share set key and alias are not part of the Share Set"
+		);
 		return false;
 	}
 
@@ -1779,7 +1784,11 @@ pub(crate) fn dangerous_dev_boot<P: AsRef<Path>>(
 	// Pull out the ephemeral key or use the override
 	let eph_pub: P256Public = if let Some(eph_path) = unsafe_eph_path_override {
 		P256Pair::from_hex_file(eph_path)
-			.unwrap_or_else(|e| panic!("dangerous_dev_boot: Could not read ephemeral key from {eph_path:?}: {e:?}"))
+			.unwrap_or_else(|e| {
+				panic!(
+					"dangerous_dev_boot: Could not read ephemeral key from {eph_path:?}: {e:?}"
+				)
+			})
 			.public_key()
 	} else {
 		P256Public::from_bytes(&attestation_doc.public_key.expect(
@@ -1977,7 +1986,10 @@ fn get_manifest_set<P: AsRef<Path>>(dir: P) -> ManifestSet {
 			}
 
 			let public = P256Public::from_hex_file(path).unwrap_or_else(|e| {
-				panic!("get_manifest_set: Could not read public key from {}: {e:?}", path.display())
+				panic!(
+					"get_manifest_set: Could not read public key from {}: {e:?}",
+					path.display()
+				)
 			});
 			Some(QuorumMember {
 				alias: mem::take(&mut file_name[0]),
@@ -2063,10 +2075,16 @@ fn find_approvals<P: AsRef<Path>>(
 
 			let approval: Approval =
 				serde_json::from_slice(&fs::read(path).unwrap_or_else(|e| {
-					panic!("find_approvals: Could not read approval from {}: {e}", path.display())
+					panic!(
+						"find_approvals: Could not read approval from {}: {e}",
+						path.display()
+					)
 				}))
 				.unwrap_or_else(|e| {
-					panic!("find_approvals: Could not deserialize approval from {}: {e}", path.display())
+					panic!(
+						"find_approvals: Could not deserialize approval from {}: {e}",
+						path.display()
+					)
 				});
 
 			assert!(
@@ -2321,21 +2339,21 @@ mod tests {
 	use std::vec;
 
 	use qos_core::protocol::{
+		QosHash,
 		services::boot::{
 			Approval, Manifest, ManifestEnvelope, ManifestSet, MemberPubKey,
 			Namespace, NitroConfig, PatchSet, PivotConfig, QuorumMember,
 			RestartPolicy, ShareSet,
 		},
-		QosHash,
 	};
-	use qos_nsm::nitro::{cert_from_pem, AWS_ROOT_CERT_PEM};
+	use qos_nsm::nitro::{AWS_ROOT_CERT_PEM, cert_from_pem};
 	use qos_p256::{P256Pair, P256Public};
 
 	use super::{
-		approve_manifest_human_verifications,
+		Prompter, approve_manifest_human_verifications,
 		approve_manifest_programmatic_verifications,
 		proxy_re_encrypt_share_human_verifications,
-		proxy_re_encrypt_share_programmatic_verifications, Prompter,
+		proxy_re_encrypt_share_programmatic_verifications,
 	};
 
 	struct Setup {
@@ -2964,16 +2982,16 @@ mod tests {
 			assert_eq!(
 				output,
 				vec![
-				"Is this the correct namespace name: test-namespace? (y/n)",
-				"Is this the correct namespace nonce: 2? (y/n)",
-				"Does this AWS IAM role belong to the intended organization: pr3? (y/n)",
-				"Please answer with either \"yes\" (y) or \"no\" (n)",
-				"Please answer with either \"yes\" (y) or \"no\" (n)",
-				"The following manifest set members approved:",
-				"\talias: 0",
-				"\talias: 1",
-				"Is this ok? (y/n)",
-			]
+					"Is this the correct namespace name: test-namespace? (y/n)",
+					"Is this the correct namespace nonce: 2? (y/n)",
+					"Does this AWS IAM role belong to the intended organization: pr3? (y/n)",
+					"Please answer with either \"yes\" (y) or \"no\" (n)",
+					"Please answer with either \"yes\" (y) or \"no\" (n)",
+					"The following manifest set members approved:",
+					"\talias: 0",
+					"\talias: 1",
+					"Is this ok? (y/n)",
+				]
 			);
 		}
 

--- a/src/qos_client/src/lib.rs
+++ b/src/qos_client/src/lib.rs
@@ -36,7 +36,9 @@ pub mod request {
 			.map_err(|e| match e {
 				ureq::Error::Status(code, r) => {
 					let body = r.into_string();
-					format!("http_post error: [url: {url}, status: {code}, body: {body:?}]")
+					format!(
+						"http_post error: [url: {url}, status: {code}, body: {body:?}]"
+					)
 				}
 				ureq::Error::Transport(e) => {
 					format!("http_post error: transport error: {e}")

--- a/src/qos_client/src/yubikey.rs
+++ b/src/qos_client/src/yubikey.rs
@@ -3,9 +3,9 @@
 use borsh::BorshDeserialize;
 use der::{asn1::BitStringRef, referenced::OwnedToRef};
 use p256::{
-	ecdsa::{signature::Verifier, Signature, VerifyingKey},
-	pkcs8::SubjectPublicKeyInfo,
 	SecretKey,
+	ecdsa::{Signature, VerifyingKey, signature::Verifier},
+	pkcs8::SubjectPublicKeyInfo,
 };
 use qos_p256::encrypt::Envelope;
 use rand_core::{OsRng, TryRngCore};
@@ -14,9 +14,9 @@ use x509_cert::{
 	name::RdnSequence, serial_number::SerialNumber, time::Validity,
 };
 use yubikey::{
+	MgmKey, PinPolicy, TouchPolicy, YubiKey,
 	certificate::Certificate,
 	piv::{self, AlgorithmId, SlotId},
-	MgmKey, PinPolicy, TouchPolicy, YubiKey,
 };
 use zeroize::Zeroizing;
 

--- a/src/qos_client/tests/p256.rs
+++ b/src/qos_client/tests/p256.rs
@@ -24,36 +24,40 @@ fn p256_sign_verify_roundtrip() {
 	// Sanity check the signature output doesn't already exist
 	assert!(!PathBuf::from(signature_path).exists());
 
-	assert!(Command::new(QOS_CLIENT_PATH)
-		.arg("p256-sign")
-		.arg("--payload-path")
-		.arg(payload_path)
-		.arg("--signature-path")
-		.arg(signature_path)
-		.arg("--master-seed-path")
-		.arg(MOCK_PRIMARY_SEED_PATH)
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
+	assert!(
+		Command::new(QOS_CLIENT_PATH)
+			.arg("p256-sign")
+			.arg("--payload-path")
+			.arg(payload_path)
+			.arg("--signature-path")
+			.arg(signature_path)
+			.arg("--master-seed-path")
+			.arg(MOCK_PRIMARY_SEED_PATH)
+			.spawn()
+			.unwrap()
+			.wait()
+			.unwrap()
+			.success()
+	);
 
 	let signature = std::fs::read_to_string(signature_path).unwrap();
 	assert_eq!(EXPECTED_SIGNATURE, signature);
 
-	assert!(Command::new(QOS_CLIENT_PATH)
-		.arg("p256-verify")
-		.arg("--payload-path")
-		.arg(payload_path)
-		.arg("--signature-path")
-		.arg(signature_path)
-		.arg("--pub-path")
-		.arg(MOCK_PRIMARY_PUB_PATH)
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
+	assert!(
+		Command::new(QOS_CLIENT_PATH)
+			.arg("p256-verify")
+			.arg("--payload-path")
+			.arg(payload_path)
+			.arg("--signature-path")
+			.arg(signature_path)
+			.arg("--pub-path")
+			.arg(MOCK_PRIMARY_PUB_PATH)
+			.spawn()
+			.unwrap()
+			.wait()
+			.unwrap()
+			.success()
+	);
 }
 
 #[test]
@@ -70,57 +74,63 @@ fn p256_asymmetric_encrypt_decrypt_roundtrip() {
 	// Sanity check the ciphertext output doesn't already exist
 	assert!(!PathBuf::from(ciphertext_path).exists());
 
-	assert!(Command::new(QOS_CLIENT_PATH)
-		.arg("p256-asymmetric-encrypt")
-		.arg("--plaintext-path")
-		.arg(plaintext_input_path)
-		.arg("--ciphertext-path")
-		.arg(ciphertext_path)
-		.arg("--pub-path")
-		.arg(MOCK_PRIMARY_PUB_PATH)
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
+	assert!(
+		Command::new(QOS_CLIENT_PATH)
+			.arg("p256-asymmetric-encrypt")
+			.arg("--plaintext-path")
+			.arg(plaintext_input_path)
+			.arg("--ciphertext-path")
+			.arg(ciphertext_path)
+			.arg("--pub-path")
+			.arg(MOCK_PRIMARY_PUB_PATH)
+			.spawn()
+			.unwrap()
+			.wait()
+			.unwrap()
+			.success()
+	);
 
 	let plaintext_output_path =
 		"/tmp/p256_asymmetric_encrypt_decrypt_roundtrip/plaintext_output";
 	assert!(!PathBuf::from(plaintext_output_path).exists());
 
-	assert!(Command::new(QOS_CLIENT_PATH)
-		.arg("p256-asymmetric-decrypt")
-		.arg("--plaintext-path")
-		.arg(plaintext_output_path)
-		.arg("--ciphertext-path")
-		.arg(ciphertext_path)
-		.arg("--master-seed-path")
-		.arg(MOCK_PRIMARY_SEED_PATH)
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
+	assert!(
+		Command::new(QOS_CLIENT_PATH)
+			.arg("p256-asymmetric-decrypt")
+			.arg("--plaintext-path")
+			.arg(plaintext_output_path)
+			.arg("--ciphertext-path")
+			.arg(ciphertext_path)
+			.arg("--master-seed-path")
+			.arg(MOCK_PRIMARY_SEED_PATH)
+			.spawn()
+			.unwrap()
+			.wait()
+			.unwrap()
+			.success()
+	);
 
 	let decrypted_bytes = std::fs::read(plaintext_output_path).unwrap();
 	assert_eq!(decrypted_bytes, DATA.as_bytes());
 
 	let hex_plaintext_output_path =
 		"/tmp/p256_asymmetric_encrypt_decrypt_roundtrip/plaintext_output";
-	assert!(Command::new(QOS_CLIENT_PATH)
-		.arg("p256-asymmetric-decrypt")
-		.arg("--plaintext-path")
-		.arg(hex_plaintext_output_path)
-		.arg("--ciphertext-path")
-		.arg(ciphertext_path)
-		.arg("--master-seed-path")
-		.arg(MOCK_PRIMARY_SEED_PATH)
-		.arg("--output-hex")
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
+	assert!(
+		Command::new(QOS_CLIENT_PATH)
+			.arg("p256-asymmetric-decrypt")
+			.arg("--plaintext-path")
+			.arg(hex_plaintext_output_path)
+			.arg("--ciphertext-path")
+			.arg(ciphertext_path)
+			.arg("--master-seed-path")
+			.arg(MOCK_PRIMARY_SEED_PATH)
+			.arg("--output-hex")
+			.spawn()
+			.unwrap()
+			.wait()
+			.unwrap()
+			.success()
+	);
 
 	let hex_plaintext = std::fs::read_to_string(plaintext_output_path).unwrap();
 

--- a/src/qos_client/tests/shamir.rs
+++ b/src/qos_client/tests/shamir.rs
@@ -19,21 +19,23 @@ fn shamir_commands_work() {
 	std::fs::create_dir_all(shares_dir).unwrap();
 	std::fs::write(secret_path, SECRET).unwrap();
 
-	assert!(Command::new(QOS_CLIENT_PATH)
-		.arg("shamir-split")
-		.arg("--secret-path")
-		.arg(secret_path)
-		.arg("--total-shares")
-		.arg("4")
-		.arg("--threshold")
-		.arg("3")
-		.arg("--output-dir")
-		.arg(shares_dir)
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
+	assert!(
+		Command::new(QOS_CLIENT_PATH)
+			.arg("shamir-split")
+			.arg("--secret-path")
+			.arg(secret_path)
+			.arg("--total-shares")
+			.arg("4")
+			.arg("--threshold")
+			.arg("3")
+			.arg("--output-dir")
+			.arg(shares_dir)
+			.spawn()
+			.unwrap()
+			.wait()
+			.unwrap()
+			.success()
+	);
 
 	// The expected shares
 	let share1 = "/tmp/shamir_commands_works/shares/1.share";
@@ -46,21 +48,23 @@ fn shamir_commands_work() {
 	assert!(!std::fs::read(share3).unwrap().is_empty());
 	assert!(!std::fs::read(share4).unwrap().is_empty());
 
-	assert!(Command::new(QOS_CLIENT_PATH)
-		.arg("shamir-reconstruct")
-		.arg("--share")
-		.arg(share1)
-		.arg("--share")
-		.arg(share3)
-		.arg("--share")
-		.arg(share4)
-		.arg("--output-path")
-		.arg(reconstructed_secret_path)
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
+	assert!(
+		Command::new(QOS_CLIENT_PATH)
+			.arg("shamir-reconstruct")
+			.arg("--share")
+			.arg(share1)
+			.arg("--share")
+			.arg(share3)
+			.arg("--share")
+			.arg(share4)
+			.arg("--output-path")
+			.arg(reconstructed_secret_path)
+			.spawn()
+			.unwrap()
+			.wait()
+			.unwrap()
+			.success()
+	);
 
 	let reconstructed = std::fs::read(reconstructed_secret_path).unwrap();
 	assert_eq!(reconstructed, SECRET);

--- a/src/qos_client/tests/yubikey.rs
+++ b/src/qos_client/tests/yubikey.rs
@@ -8,14 +8,13 @@ use std::{
 
 use borsh::BorshDeserialize;
 use qos_client::yubikey::{
-	generate_signed_certificate, import_key_and_generate_signed_certificate,
-	key_agreement, sign_data, DEFAULT_PIN, KEY_AGREEMENT_SLOT, SIGNING_SLOT,
+	DEFAULT_PIN, KEY_AGREEMENT_SLOT, SIGNING_SLOT, generate_signed_certificate,
+	import_key_and_generate_signed_certificate, key_agreement, sign_data,
 };
 use qos_p256::{
-	bytes_os_rng,
+	P256_SECRET_LEN, P256Pair, P256Public, bytes_os_rng,
 	encrypt::{Envelope, P256EncryptPair, P256EncryptPublic},
 	sign::{P256SignPair, P256SignPublic},
-	P256Pair, P256Public, P256_SECRET_LEN,
 };
 use qos_test_primitives::PathWrapper;
 use yubikey::{MgmKey, TouchPolicy, YubiKey};
@@ -205,15 +204,17 @@ fn provision_yubikey_works() {
 	// Create the temporary directory where we write the yubikey
 	std::fs::create_dir(&*tmp_dir).unwrap();
 
-	assert!(Command::new(QOS_CLIENT_PATH)
-		.arg("provision-yubikey")
-		.arg("--pub-path")
-		.arg(&*pub_path)
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
+	assert!(
+		Command::new(QOS_CLIENT_PATH)
+			.arg("provision-yubikey")
+			.arg("--pub-path")
+			.arg(&*pub_path)
+			.spawn()
+			.unwrap()
+			.wait()
+			.unwrap()
+			.success()
+	);
 
 	// Check that public keys where written
 	{
@@ -235,27 +236,31 @@ fn advanced_provision_yubikey_works() {
 	// Create the temporary directory where we write the yubikey
 	std::fs::create_dir(&*tmp_dir).unwrap();
 
-	assert!(Command::new(QOS_CLIENT_PATH)
-		.arg("generate-file-key")
-		.arg("--master-seed-path")
-		.arg(&*master_seed_path)
-		.arg("--pub-path")
-		.arg(&*pub_path)
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
+	assert!(
+		Command::new(QOS_CLIENT_PATH)
+			.arg("generate-file-key")
+			.arg("--master-seed-path")
+			.arg(&*master_seed_path)
+			.arg("--pub-path")
+			.arg(&*pub_path)
+			.spawn()
+			.unwrap()
+			.wait()
+			.unwrap()
+			.success()
+	);
 
-	assert!(Command::new(QOS_CLIENT_PATH)
-		.arg("advanced-provision-yubikey")
-		.arg("--master-seed-path")
-		.arg(&*master_seed_path)
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
+	assert!(
+		Command::new(QOS_CLIENT_PATH)
+			.arg("advanced-provision-yubikey")
+			.arg("--master-seed-path")
+			.arg(&*master_seed_path)
+			.spawn()
+			.unwrap()
+			.wait()
+			.unwrap()
+			.success()
+	);
 
 	// Check that public keys where written
 	let public = {
@@ -283,15 +288,17 @@ fn provision_sign_and_verify() {
 	let signature_path = "/tmp/provision_sign_and_verify/signature";
 	let payload_path = "/tmp/provision_sign_and_verify/payload";
 
-	assert!(Command::new(QOS_CLIENT_PATH)
-		.arg("provision-yubikey")
-		.arg("--pub-path")
-		.arg(&*pub_path)
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
+	assert!(
+		Command::new(QOS_CLIENT_PATH)
+			.arg("provision-yubikey")
+			.arg("--pub-path")
+			.arg(&*pub_path)
+			.spawn()
+			.unwrap()
+			.wait()
+			.unwrap()
+			.success()
+	);
 
 	let data_hex = qos_hex::encode(DATA);
 	let mut child = Command::new(QOS_CLIENT_PATH)
@@ -315,19 +322,21 @@ fn provision_sign_and_verify() {
 	std::fs::write(payload_path, DATA).unwrap();
 	std::fs::write(signature_path, signature).unwrap();
 
-	assert!(Command::new(QOS_CLIENT_PATH)
-		.arg("p256-verify")
-		.arg("--payload-path")
-		.arg(payload_path)
-		.arg("--signature-path")
-		.arg(signature_path)
-		.arg("--pub-path")
-		.arg(&*pub_path)
-		.spawn()
-		.unwrap()
-		.wait()
-		.unwrap()
-		.success());
+	assert!(
+		Command::new(QOS_CLIENT_PATH)
+			.arg("p256-verify")
+			.arg("--payload-path")
+			.arg(payload_path)
+			.arg("--signature-path")
+			.arg(signature_path)
+			.arg("--pub-path")
+			.arg(&*pub_path)
+			.spawn()
+			.unwrap()
+			.wait()
+			.unwrap()
+			.success()
+	);
 }
 
 /// Similar to [`qos_client::yubikey::yubikey_piv_reset`], but does not open a new connection

--- a/src/qos_core/build.rs
+++ b/src/qos_core/build.rs
@@ -26,9 +26,5 @@ fn git_short_sha() -> Option<String> {
 		return None;
 	}
 	let s = String::from_utf8(out.stdout).ok()?.trim().to_string();
-	if s.is_empty() {
-		None
-	} else {
-		Some(s)
-	}
+	if s.is_empty() { None } else { Some(s) }
 }

--- a/src/qos_core/src/cli.rs
+++ b/src/qos_core/src/cli.rs
@@ -5,11 +5,11 @@ use std::env;
 use qos_nsm::{Nsm, NsmProvider};
 
 use crate::{
+	EPHEMERAL_KEY_FILE, MANIFEST_FILE, PIVOT_FILE, QUORUM_FILE,
 	handles::Handles,
 	io::SocketAddress,
 	parser::{GetParserForOptions, OptionsParser, Parser, Token},
 	reaper::Reaper,
-	EPHEMERAL_KEY_FILE, MANIFEST_FILE, PIVOT_FILE, QUORUM_FILE,
 };
 
 use crate::io::IOError;

--- a/src/qos_core/src/handles.rs
+++ b/src/qos_core/src/handles.rs
@@ -8,7 +8,7 @@ use std::{
 
 use qos_p256::P256Pair;
 
-use crate::protocol::{services::boot::ManifestEnvelope, ProtocolError};
+use crate::protocol::{ProtocolError, services::boot::ManifestEnvelope};
 
 /// Handle for accessing the quorum key.
 #[derive(Debug, Clone)]
@@ -266,11 +266,11 @@ impl Handles {
 			Err(ProtocolError::CannotModifyPostPivotStatic)?;
 		}
 
-		if let Some(parent) = Path::new(&self.pivot).parent() {
-			if !parent.exists() {
-				fs::create_dir_all(parent)
-					.map_err(|_| ProtocolError::FailedToPutPivot)?;
-			}
+		if let Some(parent) = Path::new(&self.pivot).parent()
+			&& !parent.exists()
+		{
+			fs::create_dir_all(parent)
+				.map_err(|_| ProtocolError::FailedToPutPivot)?;
 		}
 
 		fs::write(&self.pivot, pivot)
@@ -299,10 +299,10 @@ impl Handles {
 			Err(ProtocolError::CannotModifyPostPivotStatic)?;
 		}
 
-		if let Some(parent) = path.as_ref().parent() {
-			if !parent.exists() {
-				fs::create_dir_all(parent).map_err(|_| err.clone())?;
-			}
+		if let Some(parent) = path.as_ref().parent()
+			&& !parent.exists()
+		{
+			fs::create_dir_all(parent).map_err(|_| err.clone())?;
 		}
 
 		let tmp_path = PathBuf::from(path.as_ref()).with_extension("tmp");
@@ -477,6 +477,6 @@ mod test {
 		assert!(result.is_ok());
 		assert_eq!(error, ProtocolError::CannotModifyPostPivotStatic);
 		assert!(handles.manifest_envelope_exists());
-		assert!(handles.get_manifest_envelope().unwrap() == manifest_envelope);
+		assert_eq!(handles.get_manifest_envelope().unwrap(), manifest_envelope);
 	}
 }

--- a/src/qos_core/src/io/host_bridge.rs
+++ b/src/qos_core/src/io/host_bridge.rs
@@ -95,12 +95,14 @@ async fn await_all(tasks: Vec<JoinHandle<Result<(), IOError>>>) {
 
 	for result in results {
 		match result {
-				Err(err) => eprintln!("error on task joining: {err:?}"),
-				Ok(result) => match result {
-					Ok(()) => println!("tcp to vsock bridge host exit, no errors. This shouldn't happen"),
-					Err(err) => eprintln!("error in task: {err:?}"),
-				},
-			}
+			Err(err) => eprintln!("error on task joining: {err:?}"),
+			Ok(result) => match result {
+				Ok(()) => println!(
+					"tcp to vsock bridge host exit, no errors. This shouldn't happen"
+				),
+				Err(err) => eprintln!("error in task: {err:?}"),
+			},
+		}
 	}
 }
 

--- a/src/qos_core/src/io/pool.rs
+++ b/src/qos_core/src/io/pool.rs
@@ -335,7 +335,7 @@ mod test {
 		let server_task = tokio::task::spawn(async move {
 			let _stream = server.accept().await.unwrap();
 			// give the call time to connect and hang
-			tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+			tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 		});
 
 		let pool = StreamPool::new(server_addr, 1).unwrap().shared();

--- a/src/qos_core/src/io/stream.rs
+++ b/src/qos_core/src/io/stream.rs
@@ -102,11 +102,11 @@ impl Stream {
 		let addr = self.address()?.clone();
 
 		match &mut self.inner_mut()? {
-			InnerStream::Unix(ref mut s) => {
+			InnerStream::Unix(s) => {
 				*s = unix_connect(&addr).await?;
 			}
 			#[cfg(feature = "vm")]
-			InnerStream::Vsock(ref mut s) => {
+			InnerStream::Vsock(s) => {
 				*s = vsock_connect(&addr).await?;
 			}
 		}
@@ -121,9 +121,9 @@ impl Stream {
 	/// fails.
 	pub async fn send(&mut self, buf: &[u8]) -> Result<(), IOError> {
 		match &mut self.inner_mut()? {
-			InnerStream::Unix(ref mut s) => send(s, buf).await,
+			InnerStream::Unix(s) => send(s, buf).await,
 			#[cfg(feature = "vm")]
-			InnerStream::Vsock(ref mut s) => send(s, buf).await,
+			InnerStream::Vsock(s) => send(s, buf).await,
 		}
 	}
 
@@ -134,9 +134,9 @@ impl Stream {
 	/// Returns [`IOError`] if the stream is disconnected or the read fails.
 	pub async fn recv(&mut self) -> Result<Vec<u8>, IOError> {
 		match &mut self.inner_mut()? {
-			InnerStream::Unix(ref mut s) => recv(s).await,
+			InnerStream::Unix(s) => recv(s).await,
 			#[cfg(feature = "vm")]
-			InnerStream::Vsock(ref mut s) => recv(s).await,
+			InnerStream::Vsock(s) => recv(s).await,
 		}
 	}
 
@@ -268,9 +268,9 @@ impl AsyncRead for Stream {
 		buf: &mut tokio::io::ReadBuf<'_>,
 	) -> std::task::Poll<std::io::Result<()>> {
 		match &mut self.inner_mut()? {
-			InnerStream::Unix(ref mut s) => Pin::new(s).poll_read(cx, buf),
+			InnerStream::Unix(s) => Pin::new(s).poll_read(cx, buf),
 			#[cfg(feature = "vm")]
-			InnerStream::Vsock(ref mut s) => Pin::new(s).poll_read(cx, buf),
+			InnerStream::Vsock(s) => Pin::new(s).poll_read(cx, buf),
 		}
 	}
 }
@@ -282,9 +282,9 @@ impl AsyncWrite for Stream {
 		buf: &[u8],
 	) -> std::task::Poll<Result<usize, std::io::Error>> {
 		match &mut self.inner_mut()? {
-			InnerStream::Unix(ref mut s) => Pin::new(s).poll_write(cx, buf),
+			InnerStream::Unix(s) => Pin::new(s).poll_write(cx, buf),
 			#[cfg(feature = "vm")]
-			InnerStream::Vsock(ref mut s) => Pin::new(s).poll_write(cx, buf),
+			InnerStream::Vsock(s) => Pin::new(s).poll_write(cx, buf),
 		}
 	}
 
@@ -293,9 +293,9 @@ impl AsyncWrite for Stream {
 		cx: &mut std::task::Context<'_>,
 	) -> std::task::Poll<Result<(), std::io::Error>> {
 		match &mut self.inner_mut()? {
-			InnerStream::Unix(ref mut s) => Pin::new(s).poll_flush(cx),
+			InnerStream::Unix(s) => Pin::new(s).poll_flush(cx),
 			#[cfg(feature = "vm")]
-			InnerStream::Vsock(ref mut s) => Pin::new(s).poll_flush(cx),
+			InnerStream::Vsock(s) => Pin::new(s).poll_flush(cx),
 		}
 	}
 
@@ -304,9 +304,9 @@ impl AsyncWrite for Stream {
 		cx: &mut std::task::Context<'_>,
 	) -> std::task::Poll<Result<(), std::io::Error>> {
 		match &mut self.inner_mut()? {
-			InnerStream::Unix(ref mut s) => Pin::new(s).poll_shutdown(cx),
+			InnerStream::Unix(s) => Pin::new(s).poll_shutdown(cx),
 			#[cfg(feature = "vm")]
-			InnerStream::Vsock(ref mut s) => Pin::new(s).poll_shutdown(cx),
+			InnerStream::Vsock(s) => Pin::new(s).poll_shutdown(cx),
 		}
 	}
 }

--- a/src/qos_core/src/parser.rs
+++ b/src/qos_core/src/parser.rs
@@ -26,18 +26,28 @@ pub enum ParserError {
 impl fmt::Display for ParserError {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match self {
-			Self::UnexpectedInput(u) => write!(f, "found {u}, which was not an expected argument"),
+			Self::UnexpectedInput(u) => {
+				write!(f, "found {u}, which was not an expected argument")
+			}
 			Self::DuplicateInput(i) => {
-				write!(f, "found argument {i} more then once, but only one instance was expected")
+				write!(
+					f,
+					"found argument {i} more then once, but only one instance was expected"
+				)
 			}
 			Self::MutuallyExclusiveInput(y, z) => write!(
 				f,
 				"arguments {y} and {z} are mutually exclusive and cannot be used at the same time"
 			),
 			Self::MissingValue(i) => {
-				write!(f, "found argument {i}, which requires a value, but no value was given")
+				write!(
+					f,
+					"found argument {i}, which requires a value, but no value was given"
+				)
 			}
-			Self::MissingInput(i) => write!(f, "argument {i} is required but was not found"),
+			Self::MissingInput(i) => {
+				write!(f, "argument {i} is required but was not found")
+			}
 		}
 	}
 }
@@ -377,7 +387,7 @@ impl TokenType {
 
 	fn push_val(&mut self, val: &str) -> Result<(), ParserError> {
 		match self {
-			TokenType::Multiple(ref mut v) => {
+			TokenType::Multiple(v) => {
 				v.push(val.to_string());
 				Ok(())
 			}
@@ -466,8 +476,8 @@ impl TokenMap {
 				// Find the value
 				let value = if iter
 					.peek()
-					.filter(|i| !i.starts_with(INPUT_PREFIX))
-					.is_some()
+					.as_ref()
+					.is_some_and(|i| !i.starts_with(INPUT_PREFIX))
 				{
 					// Advance the iterator since we only peaked above
 					iter.next().unwrap().clone()
@@ -520,12 +530,10 @@ impl TokenMap {
 
 			if token.user_value.is_some() {
 				// Check if this token requires the presence of another token
-				if let Some(ref other_name) = token.requires {
-					if !inputs.contains(&(format!("--{other_name}"))) {
-						return Err(ParserError::MissingInput(
-							other_name.clone(),
-						));
-					}
+				if let Some(ref other_name) = token.requires
+					&& !inputs.contains(&(format!("--{other_name}")))
+				{
+					return Err(ParserError::MissingInput(other_name.clone()));
 				}
 
 				// Check if there already exists a token that is mutually

--- a/src/qos_core/src/protocol/error.rs
+++ b/src/qos_core/src/protocol/error.rs
@@ -5,7 +5,7 @@ use qos_p256::P256Error;
 use crate::{
 	client::ClientError,
 	io::IOError,
-	protocol::{services::boot, ProtocolPhase},
+	protocol::{ProtocolPhase, services::boot},
 };
 
 /// A error from protocol execution.
@@ -344,7 +344,10 @@ impl std::fmt::Display for ProtocolError {
 				)
 			}
 			Self::LowNonce { expected, actual } => {
-				write!(f, "manifest nonce too low: expected >= {expected}, got {actual}")
+				write!(
+					f,
+					"manifest nonce too low: expected >= {expected}, got {actual}"
+				)
 			}
 			Self::DifferentPcr3 { expected, actual } => {
 				write!(f, "different PCR3: expected {expected}, got {actual}")

--- a/src/qos_core/src/protocol/msg.rs
+++ b/src/qos_core/src/protocol/msg.rs
@@ -3,11 +3,11 @@
 use qos_nsm::types::NsmResponse;
 
 use crate::protocol::{
+	ProtocolError,
 	services::{
 		boot::{Approval, ManifestEnvelope},
 		genesis::{GenesisOutput, GenesisSet},
 	},
-	ProtocolError,
 };
 
 /// Message types for communicating with protocol executor.

--- a/src/qos_core/src/protocol/processor.rs
+++ b/src/qos_core/src/protocol/processor.rs
@@ -3,8 +3,8 @@
 use borsh::BorshDeserialize;
 
 use super::{
-	error::ProtocolError, msg::ProtocolMsg, SharedProtocolState,
-	MAX_ENCODED_MSG_LEN,
+	MAX_ENCODED_MSG_LEN, SharedProtocolState, error::ProtocolError,
+	msg::ProtocolMsg,
 };
 use crate::server::RequestProcessor;
 

--- a/src/qos_core/src/protocol/services/attestation.rs
+++ b/src/qos_core/src/protocol/services/attestation.rs
@@ -1,6 +1,6 @@
 use qos_nsm::{
-	types::{NsmRequest, NsmResponse},
 	NsmProvider,
+	types::{NsmRequest, NsmResponse},
 };
 
 use crate::protocol::{ProtocolError, ProtocolState, QosHash};

--- a/src/qos_core/src/protocol/services/boot.rs
+++ b/src/qos_core/src/protocol/services/boot.rs
@@ -7,13 +7,13 @@ use qos_nsm::types::NsmResponse;
 use qos_p256::{P256Pair, P256Public};
 
 use crate::protocol::{
-	services::attestation, Hash256, ProtocolError, ProtocolState, QosHash,
+	Hash256, ProtocolError, ProtocolState, QosHash, services::attestation,
 };
 
 pub mod env;
 pub use env::{
-	PivotEnv, PivotEnvValue, PivotEnvVarName, MAX_PIVOT_ENV_NAME_LEN,
-	MAX_PIVOT_ENV_VALUE_LEN, MAX_PIVOT_ENV_VARS,
+	MAX_PIVOT_ENV_NAME_LEN, MAX_PIVOT_ENV_VALUE_LEN, MAX_PIVOT_ENV_VARS,
+	PivotEnv, PivotEnvValue, PivotEnvVarName,
 };
 
 /// Enclave configuration specific to AWS Nitro.
@@ -1097,11 +1097,14 @@ mod test {
 		};
 
 		let pivot_file = PathWrapper::from(
-			"boot_standard_rejects_manifest_envelope_with_share_set_approvals.pivot");
+			"boot_standard_rejects_manifest_envelope_with_share_set_approvals.pivot",
+		);
 		let ephemeral_file = PathWrapper::from(
-			"boot_standard_rejects_manifest_envelope_with_share_set_approvals_eph.secret");
+			"boot_standard_rejects_manifest_envelope_with_share_set_approvals_eph.secret",
+		);
 		let manifest_file = PathWrapper::from(
-			"boot_standard_rejects_manifest_envelope_with_share_set_approvals.manifest");
+			"boot_standard_rejects_manifest_envelope_with_share_set_approvals.manifest",
+		);
 
 		let handles = Handles::new(
 			ephemeral_file.display().to_string(),
@@ -1155,9 +1158,11 @@ mod test {
 			"boot_standard_rejects_approval_from_non_manifest_set_member.pivot",
 		);
 		let ephemeral_file = PathWrapper::from(
-			"boot_standard_rejects_approval_from_non_manifest_set_member.secret");
+			"boot_standard_rejects_approval_from_non_manifest_set_member.secret",
+		);
 		let manifest_file = PathWrapper::from(
-			"boot_standard_rejects_approval_from_non_manifest_set_member.manifest");
+			"boot_standard_rejects_approval_from_non_manifest_set_member.manifest",
+		);
 
 		let handles = Handles::new(
 			ephemeral_file.display().to_string(),

--- a/src/qos_core/src/protocol/services/boot/env.rs
+++ b/src/qos_core/src/protocol/services/boot/env.rs
@@ -416,11 +416,15 @@ mod test {
 		assert!(PivotEnvVarName::new("BAD NAME".to_string()).is_err());
 		assert!(PivotEnvVarName::new("BAD/NAME".to_string()).is_err());
 		assert!(PivotEnvVarName::new("BAD+NAME".to_string()).is_err());
-		assert!(PivotEnvVarName::new("A".repeat(MAX_PIVOT_ENV_NAME_LEN + 1))
-			.is_err());
+		assert!(
+			PivotEnvVarName::new("A".repeat(MAX_PIVOT_ENV_NAME_LEN + 1))
+				.is_err()
+		);
 		assert!(PivotEnvValue::plain("bad\0value".to_string()).is_err());
-		assert!(PivotEnvValue::plain("A".repeat(MAX_PIVOT_ENV_VALUE_LEN + 1))
-			.is_err());
+		assert!(
+			PivotEnvValue::plain("A".repeat(MAX_PIVOT_ENV_VALUE_LEN + 1))
+				.is_err()
+		);
 
 		let mut env = BTreeMap::new();
 		for i in 0..=MAX_PIVOT_ENV_VARS {

--- a/src/qos_core/src/protocol/services/genesis.rs
+++ b/src/qos_core/src/protocol/services/genesis.rs
@@ -8,7 +8,7 @@ use qos_p256::{P256Pair, P256Public};
 use serde::{Deserialize, Serialize};
 
 use crate::protocol::{
-	services::boot::QuorumMember, ProtocolError, ProtocolState, QosHash,
+	ProtocolError, ProtocolState, QosHash, services::boot::QuorumMember,
 };
 
 const QOS_TEST_MESSAGE: &[u8] = b"qos-test-message";

--- a/src/qos_core/src/protocol/services/key.rs
+++ b/src/qos_core/src/protocol/services/key.rs
@@ -3,15 +3,15 @@
 use aws_nitro_enclaves_nsm_api::api::AttestationDoc;
 use borsh::{BorshDeserialize, BorshSerialize};
 use qos_nsm::{
-	nitro::{attestation_doc_from_der, cert_from_pem, AWS_ROOT_CERT_PEM},
+	nitro::{AWS_ROOT_CERT_PEM, attestation_doc_from_der, cert_from_pem},
 	types::NsmResponse,
 };
 use qos_p256::{P256Pair, P256Public};
 use serde::{Deserialize, Serialize};
 
 use crate::protocol::{
-	services::boot::{put_manifest_and_pivot, ManifestEnvelope},
 	ProtocolError, ProtocolState, QosHash,
+	services::boot::{ManifestEnvelope, put_manifest_and_pivot},
 };
 
 /// An encrypted quorum key along with a signature over the encrypted payload
@@ -304,15 +304,15 @@ mod test {
 	use crate::{
 		handles::Handles,
 		protocol::{
+			ProtocolError, ProtocolPhase, ProtocolState, QosHash,
 			services::{
 				boot::{
 					Approval, Manifest, ManifestEnvelope, ManifestSet,
 					Namespace, NitroConfig, PivotConfig, QuorumMember,
 					RestartPolicy, ShareSet,
 				},
-				key::{inject_key, EncryptedQuorumKey},
+				key::{EncryptedQuorumKey, inject_key},
 			},
-			ProtocolError, ProtocolPhase, ProtocolState, QosHash,
 		},
 	};
 
@@ -486,7 +486,8 @@ mod test {
 				"/tmp/boot_key_rejects_manifest_if_not_enough_approvals.secret",
 			);
 			let manifest_file = PathWrapper::from(
-				"/tmp/boot_key_rejects_manifest_if_not_enough_approvals.manifest");
+				"/tmp/boot_key_rejects_manifest_if_not_enough_approvals.manifest",
+			);
 
 			let handles = Handles::new(
 				ephemeral_file.display().to_string(),
@@ -559,13 +560,13 @@ mod test {
 			let TestArgs { mut manifest_envelope, pivot, .. } = get_test_args();
 
 			let pivot_file = PathWrapper::from(
-				"/tmp/boot_key_rejects_rejects_manifest_with_bad_approval_signature.pivot"
+				"/tmp/boot_key_rejects_rejects_manifest_with_bad_approval_signature.pivot",
 			);
 			let ephemeral_file = PathWrapper::from(
-				"/tmp/boot_key_rejects_rejects_manifest_with_bad_approval_signature.secret"
+				"/tmp/boot_key_rejects_rejects_manifest_with_bad_approval_signature.secret",
 			);
 			let manifest_file = PathWrapper::from(
-				"/tmp/boot_key_rejects_rejects_manifest_with_bad_approval_signature.manifest"
+				"/tmp/boot_key_rejects_rejects_manifest_with_bad_approval_signature.manifest",
 			);
 
 			let handles = Handles::new(
@@ -615,11 +616,14 @@ mod test {
 			};
 
 			let pivot_file = PathWrapper::from(
-				"/tmp/boot_key_reject_manifest_with_approval_from_non_memberpivot");
+				"/tmp/boot_key_reject_manifest_with_approval_from_non_memberpivot",
+			);
 			let ephemeral_file = PathWrapper::from(
-				"/tmp/boot_key_reject_manifest_with_approval_from_non_membersecret");
+				"/tmp/boot_key_reject_manifest_with_approval_from_non_membersecret",
+			);
 			let manifest_file = PathWrapper::from(
-				"/tmp/boot_key_reject_manifest_with_approval_from_non_membermanifest");
+				"/tmp/boot_key_reject_manifest_with_approval_from_non_membermanifest",
+			);
 
 			let handles = Handles::new(
 				ephemeral_file.display().to_string(),
@@ -652,12 +656,14 @@ mod test {
 		#[test]
 		fn accepts_matching_manifests() {
 			let TestArgs { manifest_envelope, att_doc, .. } = get_test_args();
-			assert!(validate_manifest(
-				&manifest_envelope,
-				&manifest_envelope,
-				&att_doc
-			)
-			.is_ok());
+			assert!(
+				validate_manifest(
+					&manifest_envelope,
+					&manifest_envelope,
+					&att_doc
+				)
+				.is_ok()
+			);
 		}
 
 		#[test]
@@ -666,12 +672,14 @@ mod test {
 			let mut old_manifest_envelope = manifest_envelope.clone();
 			old_manifest_envelope.manifest.namespace.nonce -= 1;
 
-			assert!(validate_manifest(
-				&manifest_envelope,
-				&old_manifest_envelope,
-				&att_doc
-			)
-			.is_ok());
+			assert!(
+				validate_manifest(
+					&manifest_envelope,
+					&old_manifest_envelope,
+					&att_doc
+				)
+				.is_ok()
+			);
 		}
 
 		#[test]
@@ -767,12 +775,14 @@ mod test {
 
 			old_manifest_envelope.manifest.namespace.nonce -= 1;
 
-			assert!(validate_manifest(
-				&manifest_envelope,
-				&old_manifest_envelope,
-				&att_doc
-			)
-			.is_ok(),);
+			assert!(
+				validate_manifest(
+					&manifest_envelope,
+					&old_manifest_envelope,
+					&att_doc
+				)
+				.is_ok(),
+			);
 		}
 
 		#[test]
@@ -1119,10 +1129,12 @@ mod test {
 				.unwrap();
 
 			// quorum key signature over payload is valid
-			assert!(quorum_pair
-				.public_key()
-				.verify(&encrypted_quorum_key, &signature)
-				.is_ok());
+			assert!(
+				quorum_pair
+					.public_key()
+					.verify(&encrypted_quorum_key, &signature)
+					.is_ok()
+			);
 
 			let decrypted_quorum_secret =
 				eph_pair.decrypt(&encrypted_quorum_key).unwrap();

--- a/src/qos_core/src/protocol/services/provision.rs
+++ b/src/qos_core/src/protocol/services/provision.rs
@@ -2,7 +2,7 @@
 use qos_p256::P256Pair;
 
 use crate::protocol::{
-	services::boot::Approval, ProtocolError, ProtocolState, QosHash,
+	ProtocolError, ProtocolState, QosHash, services::boot::Approval,
 };
 
 type Secret = Vec<u8>;
@@ -135,6 +135,7 @@ mod test {
 	use crate::{
 		handles::Handles,
 		protocol::{
+			ProtocolError, ProtocolPhase, ProtocolState, QosHash,
 			services::{
 				boot::{
 					Approval, Manifest, ManifestEnvelope, ManifestSet,
@@ -143,7 +144,6 @@ mod test {
 				},
 				provision::provision,
 			},
-			ProtocolError, ProtocolPhase, ProtocolState, QosHash,
 		},
 	};
 
@@ -445,11 +445,14 @@ mod test {
 	#[test]
 	fn provision_rejects_if_approval_is_not_from_share_set_member() {
 		let eph_file = PathWrapper::from(
-			"./provision_rejects_if_approval_is_not_from_share_set_member.eph.key");
+			"./provision_rejects_if_approval_is_not_from_share_set_member.eph.key",
+		);
 		let quorum_file = PathWrapper::from(
-			"./provision_rejects_if_approval_is_not_from_share_set_member.quorum.key");
+			"./provision_rejects_if_approval_is_not_from_share_set_member.quorum.key",
+		);
 		let manifest_file = PathWrapper::from(
-			"./provision_rejects_if_approval_is_not_from_share_set_member.manifest");
+			"./provision_rejects_if_approval_is_not_from_share_set_member.manifest",
+		);
 
 		let Setup {
 			quorum_pair,
@@ -485,14 +488,17 @@ mod test {
 	}
 
 	#[test]
-	fn provision_rejects_with_signature_error_if_approval_is_not_from_share_set_member_and_bad_signature(
-	) {
+	fn provision_rejects_with_signature_error_if_approval_is_not_from_share_set_member_and_bad_signature()
+	 {
 		let eph_file = PathWrapper::from(
-			"./provision_rejects_with_signature_error_if_approval_is_not_from_share_set_member_and_bad_signature.eph.key");
+			"./provision_rejects_with_signature_error_if_approval_is_not_from_share_set_member_and_bad_signature.eph.key",
+		);
 		let quorum_file = PathWrapper::from(
-			"./provision_rejects_with_signature_error_if_approval_is_not_from_share_set_member_and_bad_signature.quorum.key");
+			"./provision_rejects_with_signature_error_if_approval_is_not_from_share_set_member_and_bad_signature.quorum.key",
+		);
 		let manifest_file = PathWrapper::from(
-			"./provision_rejects_with_signature_error_if_approval_is_not_from_share_set_member_and_bad_signature.manifest");
+			"./provision_rejects_with_signature_error_if_approval_is_not_from_share_set_member_and_bad_signature.manifest",
+		);
 
 		let Setup {
 			quorum_pair,

--- a/src/qos_core/src/protocol/state.rs
+++ b/src/qos_core/src/protocol/state.rs
@@ -54,10 +54,9 @@ impl ProtocolRoute {
 
 		// ignore transitions in special cases
 		if let Some(Ok(ProtocolMsg::ProvisionResponse { reconstructed })) = resp
+			&& !reconstructed
 		{
-			if !reconstructed {
-				return resp;
-			}
+			return resp;
 		}
 
 		// handle state transitions
@@ -69,10 +68,10 @@ impl ProtocolRoute {
 			},
 		};
 
-		if let Some(phase) = transition {
-			if let Err(e) = state.transition(phase) {
-				return Some(Err(ProtocolMsg::ProtocolErrorResponse(e)));
-			}
+		if let Some(phase) = transition
+			&& let Err(e) = state.transition(phase)
+		{
+			return Some(Err(ProtocolMsg::ProtocolErrorResponse(e)));
 		}
 
 		resp
@@ -207,7 +206,7 @@ impl ProtocolState {
 					Ok(msg_resp) | Err(msg_resp) => {
 						return borsh::to_vec(&msg_resp).expect(
 							"ProtocolMsg can always be serialized. qed.",
-						)
+						);
 					}
 				},
 			}
@@ -333,11 +332,11 @@ impl ProtocolState {
 mod handlers {
 	use super::ProtocolRouteResponse;
 	use crate::protocol::{
+		ProtocolState,
 		msg::ProtocolMsg,
 		services::{
 			attestation, boot, genesis, key, key::EncryptedQuorumKey, provision,
 		},
-		ProtocolState,
 	};
 
 	// TODO: Add tests for this in the middle of some integration tests

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -21,9 +21,9 @@ use crate::{
 	handles::Handles,
 	io::{HostBridge, IOError, SocketAddress, StreamPool},
 	protocol::{
+		ProtocolPhase, ProtocolState,
 		processor::ProtocolProcessor,
 		services::boot::{BridgeConfig, PivotConfig, RestartPolicy},
-		ProtocolPhase, ProtocolState,
 	},
 	server::SocketServer,
 };

--- a/src/qos_core/src/server.rs
+++ b/src/qos_core/src/server.rs
@@ -226,14 +226,18 @@ where
 						match stream.send(&response).await {
 							Ok(()) => {}
 							Err(err) => {
-								eprintln!("SocketServer: error sending reply {err:?}, re-accepting");
+								eprintln!(
+									"SocketServer: error sending reply {err:?}, re-accepting"
+								);
 								break;
 							}
 						}
 					}
 					Err(IOError::RecvConnectionClosed) => break,
 					Err(err) => {
-						eprintln!("SocketServer: error receiving request {err:?}, re-accepting");
+						eprintln!(
+							"SocketServer: error receiving request {err:?}, re-accepting"
+						);
 						break;
 					}
 				}

--- a/src/qos_crypto/fuzz/Cargo.toml
+++ b/src/qos_crypto/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "qos_crypto_fuzz"
 version = "0.0.0"
 publish = false
-edition = "2021"
+edition = "2024"
 rust-version = "1.88"
 
 [package.metadata]

--- a/src/qos_crypto/fuzz/fuzz_targets/1_shamir_generate_reconstruct.rs
+++ b/src/qos_crypto/fuzz/fuzz_targets/1_shamir_generate_reconstruct.rs
@@ -61,7 +61,9 @@ fuzz_target!(|fuzzerdata: FuzzShamirStruct| {
 					// if we managed to reconstruct the secret with less than the minimum number of shares
 					// the something is wrong, or we have a random collision
 					if reconstructed == secret.to_vec() {
-						panic!("reconstructed the secret with less than k shares, this should not happen")
+						panic!(
+							"reconstructed the secret with less than k shares, this should not happen"
+						)
 					}
 				}
 			}

--- a/src/qos_crypto/src/n_choose_k.rs
+++ b/src/qos_crypto/src/n_choose_k.rs
@@ -66,11 +66,7 @@ fn expected_combinations_count(n: usize, k: usize) -> usize {
 }
 
 fn factorial(n: usize) -> usize {
-	if n == 0 || n == 1 {
-		1
-	} else {
-		(2..=n).product()
-	}
+	if n == 0 || n == 1 { 1 } else { (2..=n).product() }
 }
 
 #[cfg(test)]

--- a/src/qos_crypto/src/shamir.rs
+++ b/src/qos_crypto/src/shamir.rs
@@ -1,6 +1,6 @@
 //! Shamir Secret Sharing module. We use the [`vsss-rs`](https://crates.io/crates/vsss-rs)
-use vsss_rs::elliptic_curve::rand_core::OsRng;
 use vsss_rs::Gf256;
+use vsss_rs::elliptic_curve::rand_core::OsRng;
 
 use crate::QosCryptoError;
 
@@ -60,8 +60,8 @@ mod test {
 		let shares = &all_shares[..(k - 1)];
 		let reconstructed = shares_reconstruct(shares).unwrap();
 		let old_reconstructed = shares_reconstruct(shares).unwrap();
-		assert!(secret.to_vec() != reconstructed);
-		assert!(secret.to_vec() != old_reconstructed);
+		assert_ne!(secret.to_vec(), reconstructed);
+		assert_ne!(secret.to_vec(), old_reconstructed);
 
 		// Reconstruct with enough shuffled shares
 		let mut shares = all_shares.clone()[..k].to_vec();

--- a/src/qos_enclave/Cargo.toml
+++ b/src/qos_enclave/Cargo.toml
@@ -3,7 +3,7 @@ name = "qos_enclave"
 version = "1.2.0"
 authors = [""]
 rust-version = "1.88"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]

--- a/src/qos_enclave/src/main.rs
+++ b/src/qos_enclave/src/main.rs
@@ -1,7 +1,7 @@
 use std::{
 	fs::create_dir_all,
-	io::stdout,
 	io::Write,
+	io::stdout,
 	mem::MaybeUninit,
 	net::{Shutdown, TcpListener},
 	os::unix::net::UnixStream,
@@ -11,16 +11,17 @@ use std::{
 };
 
 use libc::{
-	c_int, sigaddset, sigemptyset, sigprocmask, sigset_t, sigwaitinfo, SIGINT,
-	SIGTERM, SIG_BLOCK,
+	SIG_BLOCK, SIGINT, SIGTERM, c_int, sigaddset, sigemptyset, sigprocmask,
+	sigset_t, sigwaitinfo,
 };
 use nitro_cli::{
+	CID_TO_CONSOLE_PORT_OFFSET, VMADDR_CID_HYPERVISOR,
 	common::{
+		EnclaveProcessCommandType, ExitGracefully,
 		commands_parser::{DescribeEnclavesArgs, EmptyArgs, RunEnclavesArgs},
 		enclave_proc_command_send_single,
 		json_output::{EnclaveDescribeInfo, EnclaveRunInfo},
 		logger::init_logger,
-		EnclaveProcessCommandType, ExitGracefully,
 	},
 	enclave_proc_comm::{
 		enclave_proc_command_send_all, enclave_proc_connect_to_single,
@@ -28,7 +29,6 @@ use nitro_cli::{
 	},
 	get_id_by_name,
 	utils::Console,
-	CID_TO_CONSOLE_PORT_OFFSET, VMADDR_CID_HYPERVISOR,
 };
 
 const RUN_ENCLAVE_STR: &str = "Run Enclave";

--- a/src/qos_hex/src/lib.rs
+++ b/src/qos_hex/src/lib.rs
@@ -121,7 +121,9 @@ pub fn decode(raw_s: &str) -> Result<Vec<u8>, HexError> {
 					verify_ascii(sanitized_s_bytes[i + 1])?;
 
 					let s = std::str::from_utf8(&sanitized_s_bytes[i..i + 2])
-						.expect("We ensure that input slice represents ASCII above. qed.");
+						.expect(
+							"We ensure that input slice represents ASCII above. qed.",
+						);
 					u8::from_str_radix(s, 16).map_err(Into::into)
 				})
 				.collect()
@@ -265,9 +267,9 @@ from_hex_array_impl! {
 pub mod serde {
 	use core::{fmt, marker::PhantomData};
 
-	use serde::{de::Visitor, Deserializer, Serializer};
+	use serde::{Deserializer, Serializer, de::Visitor};
 
-	use super::{encode, FromHex};
+	use super::{FromHex, encode};
 
 	/// Serialize bytes as a hex string.
 	///

--- a/src/qos_host/src/cli.rs
+++ b/src/qos_host/src/cli.rs
@@ -167,7 +167,9 @@ impl HostOpts {
 			.as_ref()
 			.map(|s| s.parse())
 			.map(|r| {
-				r.expect("could not parse `--vsock-to-host`. Valid args are true or false")
+				r.expect(
+					"could not parse `--vsock-to-host`. Valid args are true or false",
+				)
 			})
 			.unwrap_or(false);
 

--- a/src/qos_host/src/host.rs
+++ b/src/qos_host/src/host.rs
@@ -16,26 +16,26 @@
 use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use axum::{
+	Json, Router,
 	body::Bytes,
 	extract::{DefaultBodyLimit, State},
 	http::StatusCode,
 	response::{Html, IntoResponse},
 	routing::{get, post},
-	Json, Router,
 };
 use borsh::BorshDeserialize;
 use qos_core::{
 	client::{ClientError, SocketClient},
 	io::SocketAddress,
 	protocol::{
-		msg::ProtocolMsg, services::boot::ManifestEnvelope, ProtocolError,
-		ProtocolPhase,
+		ProtocolError, ProtocolPhase, msg::ProtocolMsg,
+		services::boot::ManifestEnvelope,
 	},
 };
 use qos_nsm::types::NsmResponse;
 
 use crate::{
-	EnclaveInfo, EnclaveVitalStats, Error, ENCLAVE_HEALTH, ENCLAVE_INFO,
+	ENCLAVE_HEALTH, ENCLAVE_INFO, EnclaveInfo, EnclaveVitalStats, Error,
 	HOST_HEALTH, MAX_ENCODED_MSG_LEN, MESSAGE,
 };
 
@@ -120,23 +120,24 @@ impl HostServer {
 
 		let encoded_request = borsh::to_vec(&ProtocolMsg::StatusRequest)
 			.expect("ProtocolMsg can always serialize. qed.");
-		let encoded_response = match state
-			.enclave_client
-			.call(&encoded_request)
-			.await
-		{
-			Ok(encoded_response) => encoded_response,
-			Err(e) => {
-				let msg = format!("Error while trying to send socket request to enclave: {e:?}");
-				eprintln!("{msg}");
-				return (StatusCode::INTERNAL_SERVER_ERROR, Html(msg));
-			}
-		};
+		let encoded_response =
+			match state.enclave_client.call(&encoded_request).await {
+				Ok(encoded_response) => encoded_response,
+				Err(e) => {
+					let msg = format!(
+						"Error while trying to send socket request to enclave: {e:?}"
+					);
+					eprintln!("{msg}");
+					return (StatusCode::INTERNAL_SERVER_ERROR, Html(msg));
+				}
+			};
 
 		let response = match ProtocolMsg::try_from_slice(&encoded_response) {
 			Ok(r) => r,
 			Err(e) => {
-				let msg = format!("Error deserializing response from enclave, make sure qos_host version match qos_core: {e}");
+				let msg = format!(
+					"Error deserializing response from enclave, make sure qos_host version match qos_core: {e}"
+				);
 				eprintln!("{msg}");
 				return (StatusCode::INTERNAL_SERVER_ERROR, Html(msg));
 			}
@@ -157,7 +158,9 @@ impl HostServer {
 				(status, Html(inner))
 			}
 			other => {
-				let msg = format!("Unexpected response: Expected a ProtocolMsg::StatusResponse, but got: {other:?}");
+				let msg = format!(
+					"Unexpected response: Expected a ProtocolMsg::StatusResponse, but got: {other:?}"
+				);
 				eprintln!("{msg}");
 				(StatusCode::INTERNAL_SERVER_ERROR, Html(msg))
 			}
@@ -179,13 +182,17 @@ impl HostServer {
 		let status_resp = match ProtocolMsg::try_from_slice(&enc_status_resp) {
 			Ok(status_resp) => status_resp,
 			Err(e) => {
-				return Err(Error(format!("error deserializing status response from enclave, make sure qos_host version match qos_core: {e:?}")));
+				return Err(Error(format!(
+					"error deserializing status response from enclave, make sure qos_host version match qos_core: {e:?}"
+				)));
 			}
 		};
 		let phase = match status_resp {
 			ProtocolMsg::StatusResponse(phase) => phase,
 			other => {
-				return Err(Error(format!("unexpected response: expected a ProtocolMsg::StatusResponse, but got: {other:?}")));
+				return Err(Error(format!(
+					"unexpected response: expected a ProtocolMsg::StatusResponse, but got: {other:?}"
+				)));
 			}
 		};
 
@@ -240,7 +247,9 @@ impl HostServer {
 			Ok(encoded_response) => (StatusCode::OK, encoded_response),
 
 			Err(e) => {
-				eprintln!("Error while trying to send request over socket to enclave: {e:?}");
+				eprintln!(
+					"Error while trying to send request over socket to enclave: {e:?}"
+				);
 
 				(
 					StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/qos_host/src/lib.rs
+++ b/src/qos_host/src/lib.rs
@@ -14,12 +14,12 @@
 //! * Responding with error: <https://github.com/tokio-rs/axum/blob/main/axum/src/docs/error_handling.md/>
 
 use axum::{
+	Json,
 	http::StatusCode,
 	response::{IntoResponse, Response},
-	Json,
 };
 use qos_core::protocol::{
-	services::boot::ManifestEnvelope, Hash256, ProtocolPhase,
+	Hash256, ProtocolPhase, services::boot::ManifestEnvelope,
 };
 
 pub mod cli;

--- a/src/qos_net/fuzz/Cargo.toml
+++ b/src/qos_net/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "qos_net_fuzz"
 version = "0.0.0"
 publish = false
-edition = "2021"
+edition = "2024"
 
 [package.metadata]
 cargo-fuzz = true

--- a/src/qos_net/src/proxy_connection.rs
+++ b/src/qos_net/src/proxy_connection.rs
@@ -6,9 +6,9 @@ use std::{
 };
 
 use hickory_resolver::{
+	TokioResolver,
 	config::{NameServerConfigGroup, ResolverConfig, ResolverOpts},
 	name_server::TokioConnectionProvider,
-	TokioResolver,
 };
 use tokio::{
 	io::{AsyncReadExt, AsyncWriteExt},

--- a/src/qos_nsm/fuzz/Cargo.toml
+++ b/src/qos_nsm/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "qos_nsm_fuzz"
 version = "0.0.0"
 publish = false
-edition = "2021"
+edition = "2024"
 rust-version = "1.88"
 
 [package.metadata]

--- a/src/qos_nsm/src/nitro/mod.rs
+++ b/src/qos_nsm/src/nitro/mod.rs
@@ -2,14 +2,14 @@
 //! Document.
 
 use aws_nitro_enclaves_cose::{
+	CoseSign1,
 	crypto::{Hash, MessageDigest, SignatureAlgorithm, SigningPublicKey},
 	error::CoseError,
-	CoseSign1,
 };
 use aws_nitro_enclaves_nsm_api::api::AttestationDoc;
 use p384::{
-	ecdsa::{signature::hazmat::PrehashVerifier, Signature, VerifyingKey},
 	PublicKey,
+	ecdsa::{Signature, VerifyingKey, signature::hazmat::PrehashVerifier},
 };
 use serde_bytes::ByteBuf;
 
@@ -346,7 +346,7 @@ mod test {
 	use aws_nitro_enclaves_cose::{
 		crypto::SigningPrivateKey, header_map::HeaderMap,
 	};
-	use p384::{ecdsa::SigningKey, SecretKey};
+	use p384::{SecretKey, ecdsa::SigningKey};
 
 	use super::*;
 	use crate::mock::{
@@ -452,24 +452,30 @@ mod test {
 			SecretKey::random(&mut p384::elliptic_curve::rand_core::OsRng);
 		let random_public = random_private.public_key();
 
-		assert!(cose_doc
-			.verify_signature::<Sha2>(&P384PubKey(random_public))
-			.is_err());
+		assert!(
+			cose_doc
+				.verify_signature::<Sha2>(&P384PubKey(random_public))
+				.is_err()
+		);
 
-		assert!(cose_doc
-			.get_payload::<Sha2>(Some(&P384PubKey(random_public)))
-			.is_err());
+		assert!(
+			cose_doc
+				.get_payload::<Sha2>(Some(&P384PubKey(random_public)))
+				.is_err()
+		);
 	}
 
 	#[test]
 	fn attestation_doc_from_der_works_with_valid_payload() {
 		let root_cert = cert_from_pem(AWS_ROOT_CERT_PEM).unwrap();
-		assert!(attestation_doc_from_der(
-			MOCK_NSM_ATTESTATION_DOCUMENT,
-			&root_cert[..],
-			MOCK_SECONDS_SINCE_EPOCH,
-		)
-		.is_ok());
+		assert!(
+			attestation_doc_from_der(
+				MOCK_NSM_ATTESTATION_DOCUMENT,
+				&root_cert[..],
+				MOCK_SECONDS_SINCE_EPOCH,
+			)
+			.is_ok()
+		);
 	}
 
 	#[test]
@@ -669,15 +675,18 @@ mod test {
 			unsafe_attestation_doc_from_der(MOCK_NSM_ATTESTATION_DOCUMENT)
 				.unwrap();
 		// Accepts valid inputs
-		assert!(verify_attestation_doc_against_user_input(
-			&attestation_doc,
-			&qos_hex::decode(MOCK_USER_DATA_NSM_ATTESTATION_DOCUMENT).unwrap(),
-			&qos_hex::decode(MOCK_PCR0).unwrap(),
-			&qos_hex::decode(MOCK_PCR1).unwrap(),
-			&qos_hex::decode(MOCK_PCR2).unwrap(),
-			&qos_hex::decode(MOCK_PCR3).unwrap(),
-		)
-		.is_ok());
+		assert!(
+			verify_attestation_doc_against_user_input(
+				&attestation_doc,
+				&qos_hex::decode(MOCK_USER_DATA_NSM_ATTESTATION_DOCUMENT)
+					.unwrap(),
+				&qos_hex::decode(MOCK_PCR0).unwrap(),
+				&qos_hex::decode(MOCK_PCR1).unwrap(),
+				&qos_hex::decode(MOCK_PCR2).unwrap(),
+				&qos_hex::decode(MOCK_PCR3).unwrap(),
+			)
+			.is_ok()
+		);
 	}
 
 	#[test]

--- a/src/qos_nsm/src/nitro/syntactic_validation.rs
+++ b/src/qos_nsm/src/nitro/syntactic_validation.rs
@@ -47,11 +47,7 @@ pub(super) fn validate_attestation_doc(
 
 /// Mandatory field
 fn validate_module_id(id: &str) -> Result<(), AttestError> {
-	if id.is_empty() {
-		Err(AttestError::InvalidModuleId)
-	} else {
-		Ok(())
-	}
+	if id.is_empty() { Err(AttestError::InvalidModuleId) } else { Ok(()) }
 }
 /// Mandatory field
 fn validate_pcrs(pcrs: &BTreeMap<usize, ByteBuf>) -> Result<(), AttestError> {
@@ -85,19 +81,11 @@ fn validate_cabundle(cabundle: &[ByteBuf]) -> Result<(), AttestError> {
 }
 /// Mandatory field
 fn validate_digest(d: Digest) -> Result<(), AttestError> {
-	if d == Digest::SHA384 {
-		Ok(())
-	} else {
-		Err(AttestError::InvalidDigest)
-	}
+	if d == Digest::SHA384 { Ok(()) } else { Err(AttestError::InvalidDigest) }
 }
 /// Mandatory field
 fn validate_timestamp(t: u64) -> Result<(), AttestError> {
-	if t == 0 {
-		Err(AttestError::InvalidTimeStamp)
-	} else {
-		Ok(())
-	}
+	if t == 0 { Err(AttestError::InvalidTimeStamp) } else { Ok(()) }
 }
 /// Optional field
 fn validate_public_key(pub_key: Option<&ByteBuf>) -> Result<(), AttestError> {
@@ -111,10 +99,10 @@ fn validate_public_key(pub_key: Option<&ByteBuf>) -> Result<(), AttestError> {
 }
 
 fn validate_bytes_512(val: Option<&ByteBuf>) -> Result<(), AttestError> {
-	if let Some(val) = val {
-		if val.len() > 512 {
-			return Err(AttestError::InvalidBytes);
-		}
+	if let Some(val) = val
+		&& val.len() > 512
+	{
+		return Err(AttestError::InvalidBytes);
 	}
 
 	Ok(())
@@ -136,11 +124,13 @@ mod tests {
 	fn bytes_512_works() {
 		assert!(validate_bytes_512(None).is_ok());
 		assert!(validate_bytes_512(Some(ByteBuf::new()).as_ref()).is_ok());
-		assert!(validate_bytes_512(
-			Some(ByteBuf::from((0..513).map(|_| 42u8).collect::<Vec<_>>()))
-				.as_ref()
-		)
-		.is_err());
+		assert!(
+			validate_bytes_512(
+				Some(ByteBuf::from((0..513).map(|_| 42u8).collect::<Vec<_>>()))
+					.as_ref()
+			)
+			.is_err()
+		);
 	}
 
 	#[test]

--- a/src/qos_nsm/src/types.rs
+++ b/src/qos_nsm/src/types.rs
@@ -180,8 +180,8 @@ impl From<Request> for NsmRequest {
 
 impl From<NsmRequest> for Request {
 	fn from(req: NsmRequest) -> Self {
-		use serde_bytes::ByteBuf;
 		use NsmRequest as R;
+		use serde_bytes::ByteBuf;
 		match req {
 			R::DescribePCR { index } => Self::DescribePCR { index },
 			R::ExtendPCR { index, data } => Self::ExtendPCR { index, data },

--- a/src/qos_p256/fuzz/Cargo.toml
+++ b/src/qos_p256/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "qos_p256_fuzz"
 version = "0.0.0"
 publish = false
-edition = "2021"
+edition = "2024"
 rust-version = "1.88"
 
 [package.metadata]

--- a/src/qos_p256/src/encrypt.rs
+++ b/src/qos_p256/src/encrypt.rs
@@ -1,20 +1,20 @@
 //! Abstractions for encryption.
 
 use aes_gcm::{
-	aead::{Aead, KeyInit, Payload},
 	Aes256Gcm, Nonce,
+	aead::{Aead, KeyInit, Payload},
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 use hmac::{Hmac, Mac};
 use p256::elliptic_curve::rand_core::OsRng;
 use p256::{
-	ecdh::diffie_hellman, elliptic_curve::sec1::ToEncodedPoint, PublicKey,
-	SecretKey,
+	PublicKey, SecretKey, ecdh::diffie_hellman,
+	elliptic_curve::sec1::ToEncodedPoint,
 };
 use sha2::Sha512;
 use zeroize::ZeroizeOnDrop;
 
-use crate::{bytes_os_rng, P256Error, PUB_KEY_LEN_UNCOMPRESSED};
+use crate::{P256Error, PUB_KEY_LEN_UNCOMPRESSED, bytes_os_rng};
 
 const AES256_KEY_LEN: usize = 32;
 const BITS_96_AS_BYTES: u8 = 12;

--- a/src/qos_p256/src/sign.rs
+++ b/src/qos_p256/src/sign.rs
@@ -1,8 +1,8 @@
 //! Abstractions for sign and signature verification
 
 use p256::ecdsa::{
-	signature::{Signer, Verifier},
 	Signature, SigningKey, VerifyingKey,
+	signature::{Signer, Verifier},
 };
 use p256::elliptic_curve::rand_core::OsRng;
 use zeroize::ZeroizeOnDrop;

--- a/src/qos_system/Cargo.toml
+++ b/src/qos_system/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "qos_system"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 rust-version = "1.88"
 publish = false
 

--- a/src/qos_system/src/lib.rs
+++ b/src/qos_system/src/lib.rs
@@ -25,7 +25,7 @@ pub fn dmesg(message: String) {
 
 /// Dmesg formatted seconds since boot
 pub fn boot_time() -> String {
-	use libc::{clock_gettime, timespec, CLOCK_BOOTTIME};
+	use libc::{CLOCK_BOOTTIME, clock_gettime, timespec};
 	let mut t = timespec { tv_sec: 0, tv_nsec: 0 };
 	unsafe {
 		clock_gettime(CLOCK_BOOTTIME, &mut t as *mut timespec);
@@ -35,7 +35,7 @@ pub fn boot_time() -> String {
 
 /// Unconditionally reboot the system now
 pub fn reboot() {
-	use libc::{reboot, RB_AUTOBOOT};
+	use libc::{RB_AUTOBOOT, reboot};
 	unsafe {
 		reboot(RB_AUTOBOOT);
 	}
@@ -43,7 +43,7 @@ pub fn reboot() {
 
 /// Unconditionally halt the system now
 pub fn poweroff() {
-	use libc::{reboot, RB_POWER_OFF};
+	use libc::{RB_POWER_OFF, reboot};
 	unsafe {
 		reboot(RB_POWER_OFF);
 	}
@@ -106,7 +106,7 @@ pub fn freopen(
 
 /// Insert kernel module into memory
 pub fn insmod(path: &str) -> Result<(), SystemError> {
-	use libc::{syscall, SYS_finit_module};
+	use libc::{SYS_finit_module, syscall};
 	let file = File::open(path).unwrap();
 	let fd = file.as_raw_fd();
 	let finit_module_result =
@@ -126,7 +126,7 @@ pub fn socket_connect(
 	port: u32,
 	cid: u32,
 ) -> Result<c_int, SystemError> {
-	use libc::{connect, sockaddr, sockaddr_vm, socket, SOCK_STREAM};
+	use libc::{SOCK_STREAM, connect, sockaddr, sockaddr_vm, socket};
 	let fd = unsafe { socket(family, SOCK_STREAM, 0) };
 	let connect_result = unsafe {
 		let mut sa: sockaddr_vm = zeroed();
@@ -182,7 +182,7 @@ pub fn get_local_cid() -> Result<u32, SystemError> {
 		Err(_e) => {
 			return Err(SystemError {
 				message: "Failed to open /dev/vsock".to_string(),
-			})
+			});
 		}
 	};
 

--- a/src/qos_test_primitives/src/lib.rs
+++ b/src/qos_test_primitives/src/lib.rs
@@ -101,7 +101,7 @@ pub fn find_free_port() -> Option<u16> {
 	for _ in 0..MAX_FIND_FREE_PORT_ATTEMPTS {
 		match TcpListener::bind(("127.0.0.1", 0)) {
 			Ok(listener) => {
-				return listener.local_addr().ok().map(|addr| addr.port())
+				return listener.local_addr().ok().map(|addr| addr.port());
 			}
 			Err(err) => {
 				last_err = Some(err);


### PR DESCRIPTION
## Summary

Upgrades all crates in the workspace (and standalone crates outside the workspace) from Rust edition 2021 to edition 2024.

## Changes

### Cargo.toml updates (9 files)
- Workspace root `[workspace.package]` edition → 2024
- Standalone crates: `init`, `qos_aws`, `qos_system`, `qos_enclave`
- Fuzz crates: `qos_crypto/fuzz`, `qos_net/fuzz`, `qos_nsm/fuzz`, `qos_p256/fuzz`

### Edition 2024 code fixes
- **Match ergonomics**: Removed explicit `ref`/`ref mut` bindings in patterns that implicitly borrow (new in edition 2024). Affected: `qos_core::io::stream`, `qos_core::parser`, `qos_client::cli::services`
- **Unsafe env operations**: Wrapped `std::env::set_var`/`remove_var` in `unsafe` blocks with `#[allow(unsafe_code)]` (these functions are now unsafe in edition 2024). Affected: `integration::tests::reaper`
- **Clippy pedantic lints** (newly enforced):
  - `manual_assert_eq` → replaced `assert!(a == b)` with `assert_eq!(a, b)`
  - `manual_is_variant_and` → replaced `.filter().is_some()` with `.is_some_and()`
  - `collapsible_if` → merged nested `if let` chains using `&&` syntax
  - `duration_suboptimal_units` → `from_millis(1000)` → `from_secs(1)`
  - `useless_borrows_in_formatting` → removed redundant `&` in `format!` args

### Formatting
- Applied `cargo fmt` with edition 2024 formatting rules across all 71 modified files

## Verification
- `cargo build` — passes
- `cargo clippy --all-targets` — passes (no errors)
- `cargo fmt --check` — passes