### PR TITLE
docs: fix duplicate 'the' in code comments

### DIFF
--- a/src/qos_host/src/host.rs
+++ b/src/qos_host/src/host.rs
@@ -5,7 +5,7 @@
 //! # IMPLEMENTERS NOTE
 //!
 //! The host HTTP server is currently implemented using the `axum` framework.
-//! This may be swapped out in the the future in favor of a lighter package in
+//! This may be swapped out in the future in favor of a lighter package in
 //! order to slim the dependency tree. In the mean time, these resources can
 //! help familiarize you with the abstractions:
 //!

--- a/src/qos_nsm/src/nitro/mod.rs
+++ b/src/qos_nsm/src/nitro/mod.rs
@@ -185,7 +185,7 @@ pub fn unsafe_attestation_doc_from_der(
 }
 
 /// Extract the DER encoded `AttestationDoc` from the nitro secure module
-/// (nsm) provided COSE Sign1 structure. This function will verify the the
+/// (nsm) provided COSE Sign1 structure. This function will verify the
 /// root certificate authority via the CA bundle and verify that the end
 /// entity certificate signed the COSE Sign1 structure.
 ///

--- a/src/qos_test_primitives/src/lib.rs
+++ b/src/qos_test_primitives/src/lib.rs
@@ -122,7 +122,7 @@ pub fn find_free_port() -> Option<u16> {
 ///
 /// # Panics
 ///
-/// Panics if the the port is not bound to within `MAX_PORT_BIND_WAIT_TIME`.
+/// Panics if the port is not bound to within `MAX_PORT_BIND_WAIT_TIME`.
 pub fn wait_until_port_is_bound(port: u16) {
 	let mut wait_time = PORT_BIND_WAIT_TIME_INCREMENT;
 


### PR DESCRIPTION
## Summary
Fixed 3 instances of duplicate "the" in code comments.

## Changes
- Changed "verify the the" → "verify the"
- Changed "if the the port" → "if the port"
- Changed "in the the future" → "in the future"

## Files
- `src/qos_nsm/src/nitro/mod.rs` (line 188)
- `src/qos_test_primitives/src/lib.rs` (line 125)
- `src/qos_host/src/host.rs` (line 8)