### PR TITLE
refactor(qos_p256): ensure all sensitivie accessors return zeroize types

### DIFF
--- a/src/integration/tests/genesis.rs
+++ b/src/integration/tests/genesis.rs
@@ -192,7 +192,7 @@ async fn genesis_e2e() {
 
 			assert_eq!(sha_512(&plain_text_share), member.share_hash);
 
-			plain_text_share
+			plain_text_share.to_vec()
 		})
 		.collect();
 
@@ -250,7 +250,11 @@ async fn genesis_e2e() {
 			share_key_pair.decrypt(&fs::read(share_path).unwrap()).unwrap();
 		// Cross check that the share belongs `decrypted_shares`, which we
 		// created out of band in this test.
-		assert!(decrypted_shares.contains(&share));
+		assert!(
+			decrypted_shares
+				.iter()
+				.any(|decrypted_share| decrypted_share.as_slice() == &share[..])
+		);
 	}
 
 	// Check that we can use the DR key to decrypt the quorum key
@@ -260,6 +264,7 @@ async fn genesis_e2e() {
 	let master_seed: [u8; 32] = dr_key_pair
 		.decrypt(&dr_wrapped_quorum_key)
 		.unwrap()
+		.to_vec()
 		.try_into()
 		.unwrap();
 	let pair = P256Pair::from_master_seed(&master_seed).unwrap();

--- a/src/integration/tests/preprod_sharding.rs
+++ b/src/integration/tests/preprod_sharding.rs
@@ -112,7 +112,7 @@ fn preprod_reshard_ceremony() {
 		assert_eq!(removed_byte, 1);
 
 		let pk = P256Pair::from_master_seed(
-			&decrypted_dev_share.clone().try_into().unwrap(),
+			&decrypted_dev_share[..].try_into().unwrap(),
 		)
 		.unwrap()
 		.public_key();
@@ -169,6 +169,7 @@ fn assert_can_decrypt(user_secret_path: String, sharepath: String) {
 		P256_ENCRYPT_DERIVE_PATH,
 	)
 	.unwrap();
-	let pair = P256EncryptPair::from_bytes(&encryption_pair_secret).unwrap();
+	let pair =
+		P256EncryptPair::from_bytes(&encryption_pair_secret[..]).unwrap();
 	assert!(pair.decrypt(&share).is_ok());
 }

--- a/src/qos_client/src/cli/services.rs
+++ b/src/qos_client/src/cli/services.rs
@@ -274,7 +274,10 @@ impl PairOrYubi {
 	/// # Errors
 	///
 	/// Returns [`Error`] if decryption fails.
-	pub fn decrypt(&mut self, payload: &[u8]) -> Result<Vec<u8>, Error> {
+	pub fn decrypt(
+		&mut self,
+		payload: &[u8],
+	) -> Result<Zeroizing<Vec<u8>>, Error> {
 		match self {
 			#[cfg(feature = "smartcard")]
 			Self::Yubi((yubi, pin)) => {
@@ -288,6 +291,7 @@ impl PairOrYubi {
 
 				public
 					.decrypt_from_shared_secret(payload, &shared_secret)
+					.map(Zeroizing::new)
 					.map_err(Into::into)
 			}
 			Self::Pair(pair) => pair.decrypt(payload).map_err(Into::into),
@@ -426,7 +430,7 @@ pub fn advanced_provision_yubikey<P: AsRef<Path>>(
 
 	crate::yubikey::import_key_and_generate_signed_certificate(
 		&mut yubikey,
-		&sign_secret,
+		&sign_secret[..],
 		crate::yubikey::SIGNING_SLOT,
 		&pin,
 		yubikey::MgmKey::default(),
@@ -436,7 +440,7 @@ pub fn advanced_provision_yubikey<P: AsRef<Path>>(
 
 	crate::yubikey::import_key_and_generate_signed_certificate(
 		&mut yubikey,
-		&encrypt_secret,
+		&encrypt_secret[..],
 		crate::yubikey::KEY_AGREEMENT_SLOT,
 		&pin,
 		yubikey::MgmKey::default(),
@@ -616,7 +620,7 @@ pub(crate) fn verify_genesis<P: AsRef<Path>>(
 	});
 
 	// sanity check our logic to read in master seed
-	if pair.to_master_seed_hex() != master_seed_hex.as_bytes() {
+	if pair.to_master_seed_hex().as_slice() != master_seed_hex.as_bytes() {
 		return Err(Error::ErrorReadingSeed);
 	}
 
@@ -644,7 +648,7 @@ pub(crate) fn verify_genesis<P: AsRef<Path>>(
 
 	// check test_message_ciphertext
 	let plaintext = pair.decrypt(&genesis_output.test_message_ciphertext)?;
-	if plaintext != genesis_output.test_message {
+	if plaintext[..] != genesis_output.test_message {
 		return Err(Error::BadDecryption);
 	}
 	println!("Successfully decrypted test message ciphertext");
@@ -1748,8 +1752,11 @@ pub(crate) fn p256_asymmetric_decrypt<P: AsRef<Path>>(
 	let ciphertext = std::fs::read(ciphertext_path.as_ref())?;
 
 	let plaintext = pair.decrypt(&ciphertext)?;
-	let file_contents =
-		if output_hex { qos_hex::encode_to_vec(&plaintext) } else { plaintext };
+	let file_contents = if output_hex {
+		qos_hex::encode_to_vec(&plaintext)
+	} else {
+		plaintext.to_vec()
+	};
 
 	write_with_msg(plaintext_path.as_ref(), &file_contents, "Plaintext");
 
@@ -1863,9 +1870,12 @@ pub(crate) fn dangerous_dev_boot<P: AsRef<Path>>(
 	};
 
 	// Shard it with N=2, K=2
-	let shares =
-		qos_crypto::shamir::shares_generate(quorum_pair.to_master_seed(), 2, 2)
-			.unwrap();
+	let shares = qos_crypto::shamir::shares_generate(
+		&quorum_pair.to_master_seed()[..],
+		2,
+		2,
+	)
+	.unwrap();
 	assert_eq!(
 		shares.len(),
 		2,

--- a/src/qos_client/tests/yubikey.rs
+++ b/src/qos_client/tests/yubikey.rs
@@ -141,12 +141,12 @@ fn signing_works(yubikey: &mut YubiKey) {
 
 fn import_signing_works(yubikey: &mut YubiKey) {
 	let secret = bytes_os_rng::<P256_SECRET_LEN>();
-	let pair = P256SignPair::from_bytes(&secret).unwrap();
+	let pair = P256SignPair::from_bytes(&secret[..]).unwrap();
 	let public = pair.public_key();
 
 	import_key_and_generate_signed_certificate(
 		yubikey,
-		&secret,
+		&secret[..],
 		SIGNING_SLOT,
 		DEFAULT_PIN,
 		MgmKey::default(),
@@ -161,12 +161,12 @@ fn import_signing_works(yubikey: &mut YubiKey) {
 
 fn import_key_agreement_works(yubikey: &mut YubiKey) {
 	let secret = bytes_os_rng::<32>();
-	let pair = P256EncryptPair::from_bytes(&secret).unwrap();
+	let pair = P256EncryptPair::from_bytes(&secret[..]).unwrap();
 	let public = pair.public_key();
 
 	import_key_and_generate_signed_certificate(
 		yubikey,
-		&secret,
+		&secret[..],
 		KEY_AGREEMENT_SLOT,
 		DEFAULT_PIN,
 		MgmKey::default(),

--- a/src/qos_core/src/protocol/services/genesis.rs
+++ b/src/qos_core/src/protocol/services/genesis.rs
@@ -282,7 +282,7 @@ mod test {
 
 				assert_eq!(sha_512(decrypted_share), output.share_hash);
 
-				decrypted_share.clone()
+				decrypted_share.to_vec()
 			})
 			.collect();
 
@@ -311,7 +311,7 @@ mod test {
 		let test_message_plaintext = reconstructed_quorum_key
 			.decrypt(&output.test_message_ciphertext)
 			.unwrap();
-		assert_eq!(test_message_plaintext, QOS_TEST_MESSAGE);
+		assert_eq!(&test_message_plaintext[..], QOS_TEST_MESSAGE);
 		quorum_public_key
 			.verify(QOS_TEST_MESSAGE, &output.test_message_signature)
 			.unwrap();

--- a/src/qos_core/src/protocol/services/key.rs
+++ b/src/qos_core/src/protocol/services/key.rs
@@ -46,7 +46,7 @@ pub(in crate::protocol) fn inject_key(
 	let quorum_master_seed = {
 		let ephemeral_pair = state.handles.get_ephemeral_key()?;
 		let bytes = ephemeral_pair.decrypt(&encrypted_quorum_key)?;
-		bytes
+		bytes[..]
 			.try_into()
 			.map_err(|_| ProtocolError::EncryptedQuorumKeyInvalidLen)?
 	};
@@ -139,7 +139,8 @@ fn export_key_internal(
 	// extracted from the attestation document and a signature over the
 	// encrypted payload. The Original Node uses its Quorum Key to create the
 	// signature.
-	let encrypted_quorum_key = eph_key.encrypt(quorum_key.to_master_seed())?;
+	let encrypted_quorum_key =
+		eph_key.encrypt(&quorum_key.to_master_seed()[..])?;
 	let signature = quorum_key.sign(&encrypted_quorum_key)?;
 
 	Ok(EncryptedQuorumKey { encrypted_quorum_key, signature })
@@ -1143,7 +1144,7 @@ mod test {
 			let decrypted_quorum_secret =
 				eph_pair.decrypt(&encrypted_quorum_key).unwrap();
 			let reconstructed_quorum_pair = P256Pair::from_master_seed(
-				&decrypted_quorum_secret.try_into().unwrap(),
+				&decrypted_quorum_secret[..].try_into().unwrap(),
 			)
 			.unwrap();
 			assert!(quorum_pair == reconstructed_quorum_pair);
@@ -1175,7 +1176,7 @@ mod test {
 
 			let encrypted_quorum_key = eph_pair
 				.public_key()
-				.encrypt(quorum_pair.to_master_seed())
+				.encrypt(&quorum_pair.to_master_seed()[..])
 				.unwrap();
 			let signature = quorum_pair.sign(&encrypted_quorum_key).unwrap();
 
@@ -1233,7 +1234,7 @@ mod test {
 			let wrong_key = P256Pair::generate().unwrap();
 			let encrypted_quorum_key = eph_pair
 				.public_key()
-				.encrypt(wrong_key.to_master_seed())
+				.encrypt(&wrong_key.to_master_seed()[..])
 				.unwrap();
 			let signature = quorum_pair.sign(&encrypted_quorum_key).unwrap();
 
@@ -1287,7 +1288,7 @@ mod test {
 			let wrong_key = P256Pair::generate().unwrap();
 			let encrypted_quorum_key = eph_pair
 				.public_key()
-				.encrypt(quorum_pair.to_master_seed())
+				.encrypt(&quorum_pair.to_master_seed()[..])
 				.unwrap();
 			let signature = wrong_key.sign(&encrypted_quorum_key).unwrap();
 

--- a/src/qos_core/src/protocol/services/provision.rs
+++ b/src/qos_core/src/protocol/services/provision.rs
@@ -96,7 +96,7 @@ pub(in crate::protocol) fn provision(
 		.decrypt(encrypted_share)
 		.map_err(|_| ProtocolError::DecryptionFailed)?;
 
-	state.provisioner.add_share(share)?;
+	state.provisioner.add_share(share.to_vec())?;
 
 	let quorum_threshold = manifest.share_set().threshold as usize;
 	if state.provisioner.count() < quorum_threshold {
@@ -269,7 +269,7 @@ mod test {
 		// 4) Create shards and encrypt them to eph key
 		let quorum_key = quorum_pair.to_master_seed();
 		let encrypted_shares: Vec<_> =
-			shares_generate(quorum_key, 4, threshold)
+			shares_generate(&quorum_key[..], 4, threshold)
 				.unwrap()
 				.iter()
 				.map(|shard| eph_pair.public_key().encrypt(shard).unwrap())
@@ -296,7 +296,7 @@ mod test {
 		assert_eq!(provision(share, approval, &mut state), Ok(true));
 		let quorum_key = std::fs::read(&*quorum_file).unwrap();
 
-		assert_eq!(quorum_key, quorum_pair.to_master_seed_hex());
+		assert_eq!(quorum_key, quorum_pair.to_master_seed_hex().as_slice());
 
 		// Make sure the EK is persisted
 		assert!(Path::new(&*eph_file).exists());
@@ -381,7 +381,7 @@ mod test {
 		let quorum_key = quorum_pair.to_master_seed();
 
 		let encrypted_shares: Vec<_> =
-			shares_generate(quorum_key, 4, threshold)
+			shares_generate(&quorum_key[..], 4, threshold)
 				.unwrap()
 				.iter()
 				.map(|shard| eph_pair.public_key().encrypt(shard).unwrap())
@@ -435,7 +435,7 @@ mod test {
 
 		let quorum_key = quorum_pair.to_master_seed();
 		let mut encrypted_shares: Vec<_> =
-			shares_generate(quorum_key, 4, threshold)
+			shares_generate(&quorum_key[..], 4, threshold)
 				.unwrap()
 				.iter()
 				.map(|shard| eph_pair.public_key().encrypt(shard).unwrap())
@@ -475,7 +475,7 @@ mod test {
 
 		let quorum_key = quorum_pair.to_master_seed();
 		let mut encrypted_shares: Vec<_> =
-			shares_generate(quorum_key, 4, threshold)
+			shares_generate(&quorum_key[..], 4, threshold)
 				.unwrap()
 				.iter()
 				.map(|shard| eph_pair.public_key().encrypt(shard).unwrap())
@@ -522,7 +522,7 @@ mod test {
 
 		let quorum_key = quorum_pair.to_master_seed();
 		let mut encrypted_shares: Vec<_> =
-			shares_generate(quorum_key, 4, threshold)
+			shares_generate(&quorum_key[..], 4, threshold)
 				.unwrap()
 				.iter()
 				.map(|shard| eph_pair.public_key().encrypt(shard).unwrap())

--- a/src/qos_p256/Cargo.toml
+++ b/src/qos_p256/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 qos_hex = { workspace = true }
 
 borsh = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, features = ["alloc"] }
 
 sha2 = { workspace = true }
 # as of 0.13.0, the p256 crate "ecdsa" feature enables "sha384", some "ecdsa-core", and others
@@ -24,7 +24,7 @@ p256 = { workspace = true, features = ["ecdh", "ecdsa", "std"] }
 aes-gcm = { workspace = true }
 hmac = { workspace = true }
 hkdf = { workspace = true }
-zeroize = { workspace = true, features = ["derive"] }
+zeroize = { workspace = true, features = ["alloc", "derive"] }
 
 [dev-dependencies]
 qos_test_primitives = { path = "../qos_test_primitives" }

--- a/src/qos_p256/fuzz/fuzz_targets/5_basic_encrypt_decrypt.rs
+++ b/src/qos_p256/fuzz/fuzz_targets/5_basic_encrypt_decrypt.rs
@@ -34,5 +34,5 @@ fuzz_target!(|input: FuzzKeyDataStruct| {
 	let decrypted_data = key_pair.decrypt(&serialized_envelope).unwrap();
 
 	// check roundtrip data consistency, assert should always hold
-	assert_eq!(decrypted_data, data);
+	assert_eq!(&decrypted_data[..], data);
 });

--- a/src/qos_p256/fuzz/fuzz_targets/6_basic_encrypt_decrypt_aesgcm.rs
+++ b/src/qos_p256/fuzz/fuzz_targets/6_basic_encrypt_decrypt_aesgcm.rs
@@ -33,7 +33,7 @@ fuzz_target!(|input: FuzzKeyDataStruct| {
 	// expected to always succeed
 	let decrypted_data = random_key.decrypt(&encrypted_envelope).unwrap();
 	// check roundtrip data consistency, assert should always hold
-	assert_eq!(decrypted_data, data);
+	assert_eq!(&decrypted_data[..], data);
 
 	let mut corrupted_encrypted_envelope = encrypted_envelope.clone();
 	let last_element_index_envelope = corrupted_encrypted_envelope.len() - 1;

--- a/src/qos_p256/src/encrypt.rs
+++ b/src/qos_p256/src/encrypt.rs
@@ -12,7 +12,7 @@ use p256::{
 	elliptic_curve::sec1::ToEncodedPoint,
 };
 use sha2::Sha512;
-use zeroize::ZeroizeOnDrop;
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 use crate::{P256Error, PUB_KEY_LEN_UNCOMPRESSED, bytes_os_rng};
 
@@ -57,7 +57,7 @@ impl P256EncryptPair {
 	pub fn decrypt(
 		&self,
 		serialized_envelope: &[u8],
-	) -> Result<Vec<u8>, P256Error> {
+	) -> Result<Zeroizing<Vec<u8>>, P256Error> {
 		let Envelope {
 			nonce,
 			ephemeral_sender_public: ephemeral_sender_public_bytes,
@@ -93,6 +93,7 @@ impl P256EncryptPair {
 
 		cipher
 			.decrypt(nonce, payload)
+			.map(Zeroizing::new)
 			.map_err(|_| P256Error::AesGcm256DecryptError)
 	}
 
@@ -117,8 +118,8 @@ impl P256EncryptPair {
 
 	/// Serialize key to raw scalar byte slice.
 	#[must_use]
-	pub fn to_bytes(&self) -> Vec<u8> {
-		self.private.to_bytes().to_vec()
+	pub fn to_bytes(&self) -> Zeroizing<Vec<u8>> {
+		Zeroizing::new(self.private.to_bytes().to_vec())
 	}
 }
 
@@ -163,7 +164,7 @@ impl P256EncryptPublic {
 		let nonce = {
 			let random_bytes =
 				crate::bytes_os_rng::<{ BITS_96_AS_BYTES as usize }>();
-			*Nonce::from_slice(&random_bytes)
+			*Nonce::from_slice(&random_bytes[..])
 		};
 
 		let aad = create_additional_associated_data(
@@ -283,7 +284,7 @@ fn create_cipher(
 	ephemeral_sender_public: &SenderPublic,
 	receiver_public: &ReceiverPublic,
 ) -> Result<Aes256Gcm, P256Error> {
-	let shared_secret = match shared_secret {
+	let shared_secret = Zeroizing::new(match shared_secret {
 		PrivPubOrSharedSecret::PrivPub { private, public } => {
 			diffie_hellman(private.to_nonzero_scalar(), public.as_affine())
 				.raw_secret_bytes()
@@ -292,23 +293,25 @@ fn create_cipher(
 		PrivPubOrSharedSecret::SharedSecret { shared_secret } => {
 			shared_secret.to_vec()
 		}
-	};
+	});
 
 	// To help with entropy and add domain context, we do
 	// `sender_public||receiver_public||shared_secret` as the pre-image for the
 	// shared key.
-	let pre_image: Vec<u8> = ephemeral_sender_public
-		.0
-		.iter()
-		.chain(receiver_public.0)
-		.chain(shared_secret.iter())
-		.copied()
-		.collect();
+	let pre_image: Zeroizing<Vec<u8>> = Zeroizing::new(
+		ephemeral_sender_public
+			.0
+			.iter()
+			.chain(receiver_public.0)
+			.chain(shared_secret.iter())
+			.copied()
+			.collect(),
+	);
 
 	let mut mac = <HmacSha512 as KeyInit>::new_from_slice(&pre_image[..])
 		.expect("hmac can take a key of any size");
 	mac.update(QOS_ENCRYPTION_HMAC_MESSAGE);
-	let shared_key = mac.finalize().into_bytes();
+	let shared_key = Zeroizing::new(mac.finalize().into_bytes());
 
 	Aes256Gcm::new_from_slice(&shared_key[..AES256_KEY_LEN])
 		.map_err(|_| P256Error::FailedToCreateAes256GcmCipher)
@@ -362,10 +365,15 @@ pub struct SymmetricEnvelope {
 }
 
 /// Secret for performing encryption and decryption using a AES GCM 256 Cipher.
-#[derive(ZeroizeOnDrop)]
 #[cfg_attr(any(feature = "mock", test), derive(Clone, PartialEq, Eq))]
 pub struct AesGcm256Secret {
-	secret: [u8; AES256_KEY_LEN],
+	secret: Zeroizing<[u8; AES256_KEY_LEN]>,
+}
+
+impl Zeroize for AesGcm256Secret {
+	fn zeroize(&mut self) {
+		self.secret.zeroize();
+	}
 }
 
 impl AesGcm256Secret {
@@ -377,7 +385,7 @@ impl AesGcm256Secret {
 
 	/// The secret as bytes.
 	#[must_use]
-	pub fn to_bytes(&self) -> &[u8; AES256_KEY_LEN] {
+	pub fn to_bytes(&self) -> &Zeroizing<[u8; AES256_KEY_LEN]> {
 		&self.secret
 	}
 
@@ -388,7 +396,7 @@ impl AesGcm256Secret {
 	/// Returns [`P256Error::FailedToCreateAes256GcmCipher`] if the key is
 	/// invalid.
 	pub fn from_bytes(bytes: [u8; AES256_KEY_LEN]) -> Result<Self, P256Error> {
-		Ok(Self { secret: bytes })
+		Ok(Self { secret: Zeroizing::new(bytes) })
 	}
 
 	/// Encrypt the given `msg`.
@@ -405,11 +413,11 @@ impl AesGcm256Secret {
 	pub fn encrypt(&self, msg: &[u8]) -> Result<Vec<u8>, P256Error> {
 		let nonce = {
 			let random_bytes = bytes_os_rng::<{ BITS_96_AS_BYTES as usize }>();
-			*Nonce::from_slice(&random_bytes)
+			*Nonce::from_slice(&random_bytes[..])
 		};
 		let payload = Payload { aad: AES_GCM_256_HMAC_SHA512_TAG, msg };
 
-		let cipher = Aes256Gcm::new_from_slice(&self.secret)
+		let cipher = Aes256Gcm::new_from_slice(&self.secret[..])
 			.expect("secret is a valid aes256 key len. qed.");
 		let encrypted_message = cipher
 			.encrypt(&nonce, payload)
@@ -435,7 +443,7 @@ impl AesGcm256Secret {
 	pub fn decrypt(
 		&self,
 		serialized_envelope: &[u8],
-	) -> Result<Vec<u8>, P256Error> {
+	) -> Result<Zeroizing<Vec<u8>>, P256Error> {
 		let SymmetricEnvelope { nonce, encrypted_message } =
 			SymmetricEnvelope::try_from_slice(serialized_envelope)
 				.map_err(|_| P256Error::FailedToDeserializeEnvelope)?;
@@ -446,10 +454,11 @@ impl AesGcm256Secret {
 			msg: &encrypted_message,
 		};
 
-		let cipher = Aes256Gcm::new_from_slice(&self.secret)
+		let cipher = Aes256Gcm::new_from_slice(&self.secret[..])
 			.expect("secret is a valid aes256 key len. qed.");
 		cipher
 			.decrypt(nonce, payload)
+			.map(Zeroizing::new)
 			.map_err(|_| P256Error::AesGcm256DecryptError)
 	}
 }
@@ -469,7 +478,7 @@ mod test_asymmetric {
 
 		let decrypted = alice_pair.decrypt(&serialized_envelope).unwrap();
 
-		assert_eq!(decrypted, plaintext);
+		assert_eq!(&decrypted[..], plaintext);
 	}
 
 	#[test]
@@ -595,7 +604,7 @@ mod test_asymmetric {
 
 		let decrypted = alice_pair.decrypt(&serialized_envelope).unwrap();
 
-		assert_eq!(decrypted, plaintext);
+		assert_eq!(&decrypted[..], plaintext);
 	}
 
 	#[test]
@@ -632,6 +641,17 @@ mod test_asymmetric {
 
 		assert_eq!(raw_secret1, raw_secret2);
 	}
+
+	#[test]
+	fn private_key_bytes_are_zeroizing() {
+		let pair = P256EncryptPair::generate();
+		let raw_secret = pair.to_bytes();
+
+		assert!(
+			std::any::type_name_of_val(&raw_secret)
+				.starts_with("zeroize::Zeroizing<")
+		);
+	}
 }
 
 #[cfg(test)]
@@ -647,7 +667,7 @@ mod test_symmetric {
 		let envelope = key.encrypt(plaintext).unwrap();
 		let result = key.decrypt(&envelope).unwrap();
 
-		assert_eq!(result, plaintext);
+		assert_eq!(&result[..], plaintext);
 	}
 
 	#[test]
@@ -656,7 +676,7 @@ mod test_symmetric {
 		let bytes_original = key_original.to_bytes();
 
 		let key_reconstructed =
-			AesGcm256Secret::from_bytes(*bytes_original).unwrap();
+			AesGcm256Secret::from_bytes(**bytes_original).unwrap();
 		let bytes_reconstructed = key_reconstructed.to_bytes();
 
 		assert!(key_original == key_reconstructed);

--- a/src/qos_p256/src/lib.rs
+++ b/src/qos_p256/src/lib.rs
@@ -6,7 +6,7 @@ use encrypt::AesGcm256Secret;
 use hkdf::Hkdf;
 use p256::elliptic_curve::rand_core::{OsRng, RngCore};
 use sha2::Sha512;
-use zeroize::ZeroizeOnDrop;
+use zeroize::{ZeroizeOnDrop, Zeroizing};
 
 use crate::{
 	encrypt::{P256EncryptPair, P256EncryptPublic},
@@ -82,6 +82,8 @@ pub enum P256Error {
 	MasterSeedInvalidUtf8,
 	/// Master seed was not the correct length.
 	MasterSeedInvalidLength,
+	/// Master seed file contents were invalid.
+	InvalidMasterSeed,
 	/// Failed to convert a len (usize) to a u8. This is an internal error and
 	/// the code has a bug.
 	CannotCoerceLenToU8,
@@ -106,22 +108,22 @@ impl From<qos_hex::HexError> for P256Error {
 pub fn derive_secret(
 	seed: &[u8; MASTER_SEED_LEN],
 	derive_path: &[u8],
-) -> Result<[u8; P256_SECRET_LEN], P256Error> {
+) -> Result<Zeroizing<[u8; P256_SECRET_LEN]>, P256Error> {
 	let hk = Hkdf::<Sha512>::new(Some(derive_path), seed);
 
-	let mut buf = [0u8; P256_SECRET_LEN];
-	hk.expand(&[], &mut buf).map_err(|_| P256Error::HkdfExpansionFailed)?;
+	let mut buf = Zeroizing::new([0u8; P256_SECRET_LEN]);
+	hk.expand(&[], &mut *buf).map_err(|_| P256Error::HkdfExpansionFailed)?;
 
 	Ok(buf)
 }
 
 /// Helper function to generate a `N` length byte buffer.
 #[must_use]
-pub fn bytes_os_rng<const N: usize>() -> [u8; N] {
+pub fn bytes_os_rng<const N: usize>() -> Zeroizing<[u8; N]> {
 	let mut key = [0u8; N];
 	OsRng.fill_bytes(&mut key);
 
-	key
+	Zeroizing::new(key)
 }
 
 /// P256 private key pair for signing and encryption. Internally this uses a
@@ -131,7 +133,7 @@ pub fn bytes_os_rng<const N: usize>() -> [u8; N] {
 pub struct P256Pair {
 	p256_encrypt_private: P256EncryptPair,
 	sign_private: P256SignPair,
-	master_seed: [u8; MASTER_SEED_LEN],
+	master_seed: Zeroizing<[u8; MASTER_SEED_LEN]>,
 	aes_gcm_256_secret: AesGcm256Secret,
 }
 
@@ -152,11 +154,11 @@ impl P256Pair {
 
 		Ok(Self {
 			p256_encrypt_private: P256EncryptPair::from_bytes(
-				&p256_encrypt_secret,
+				&p256_encrypt_secret[..],
 			)?,
-			sign_private: P256SignPair::from_bytes(&p256_sign_secret)?,
+			sign_private: P256SignPair::from_bytes(&p256_sign_secret[..])?,
 			master_seed,
-			aes_gcm_256_secret: AesGcm256Secret::from_bytes(aes_gcm_secret)?,
+			aes_gcm_256_secret: AesGcm256Secret::from_bytes(*aes_gcm_secret)?,
 		})
 	}
 
@@ -180,7 +182,7 @@ impl P256Pair {
 	pub fn aes_gcm_256_decrypt(
 		&self,
 		serialized_envelope: &[u8],
-	) -> Result<Vec<u8>, P256Error> {
+	) -> Result<Zeroizing<Vec<u8>>, P256Error> {
 		self.aes_gcm_256_secret.decrypt(serialized_envelope)
 	}
 
@@ -192,7 +194,7 @@ impl P256Pair {
 	pub fn decrypt(
 		&self,
 		serialized_envelope: &[u8],
-	) -> Result<Vec<u8>, P256Error> {
+	) -> Result<Zeroizing<Vec<u8>>, P256Error> {
 		self.p256_encrypt_private.decrypt(serialized_envelope)
 	}
 
@@ -228,11 +230,13 @@ impl P256Pair {
 		let aes_gcm_256_encrypt = derive_secret(master_seed, AES_GCM_256_PATH)?;
 
 		Ok(Self {
-			p256_encrypt_private: P256EncryptPair::from_bytes(&encrypt_secret)?,
-			sign_private: P256SignPair::from_bytes(&sign_secret)?,
-			master_seed: *master_seed,
+			p256_encrypt_private: P256EncryptPair::from_bytes(
+				&encrypt_secret[..],
+			)?,
+			sign_private: P256SignPair::from_bytes(&sign_secret[..])?,
+			master_seed: Zeroizing::new(*master_seed),
 			aes_gcm_256_secret: AesGcm256Secret::from_bytes(
-				aes_gcm_256_encrypt,
+				*aes_gcm_256_encrypt,
 			)?,
 		})
 	}
@@ -240,15 +244,15 @@ impl P256Pair {
 	/// Get the raw master seed used to create this pair.
 	/// CAUTION: this is secret material and should be used with care.
 	#[must_use]
-	pub fn to_master_seed(&self) -> &[u8; MASTER_SEED_LEN] {
+	pub fn to_master_seed(&self) -> &Zeroizing<[u8; MASTER_SEED_LEN]> {
 		&self.master_seed
 	}
 
 	/// Convert to hex bytes.
 	/// CAUTION: this is secret material and should be used with care.
 	#[must_use]
-	pub fn to_master_seed_hex(&self) -> Vec<u8> {
-		qos_hex::encode_to_vec(&self.master_seed)
+	pub fn to_master_seed_hex(&self) -> Zeroizing<Vec<u8>> {
+		Zeroizing::new(qos_hex::encode_to_vec(&self.master_seed[..]))
 	}
 
 	/// Write the raw master seed to file as hex encoded.
@@ -260,7 +264,7 @@ impl P256Pair {
 		&self,
 		path: P,
 	) -> Result<(), P256Error> {
-		let hex_string = qos_hex::encode(&self.master_seed);
+		let hex_string = Zeroizing::new(qos_hex::encode(&self.master_seed[..]));
 		std::fs::write(&path, hex_string.as_bytes()).map_err(|e| {
 			P256Error::IOError(format!(
 				"failed to write master secret to {}: {e}",
@@ -276,18 +280,18 @@ impl P256Pair {
 	/// Returns [`P256Error`] if the file cannot be read, the hex is invalid,
 	/// or the seed length is wrong.
 	pub fn from_hex_file<P: AsRef<Path>>(path: P) -> Result<Self, P256Error> {
-		let hex_bytes = std::fs::read(&path).map_err(|e| {
+		let hex_bytes = Zeroizing::new(std::fs::read(&path).map_err(|e| {
 			P256Error::IOError(format!(
 				"failed to read master seed from {}: {e}",
 				path.as_ref().display()
 			))
-		})?;
+		})?);
 
-		let master_seed =
-			qos_hex::decode_from_vec(hex_bytes).map_err(P256Error::from)?;
-		let master_seed: [u8; MASTER_SEED_LEN] = master_seed
-			.try_into()
-			.map_err(|_| P256Error::MasterSeedInvalidLength)?;
+		let hex_str = std::str::from_utf8(&hex_bytes)
+			.map_err(|_| P256Error::InvalidMasterSeed)?;
+		let mut master_seed = Zeroizing::new([0u8; MASTER_SEED_LEN]);
+		qos_hex::decode_to_buf(hex_str.trim(), &mut *master_seed)
+			.map_err(|_| P256Error::InvalidMasterSeed)?;
 		Self::from_master_seed(&master_seed)
 	}
 
@@ -307,6 +311,14 @@ impl P256Pair {
 	#[must_use]
 	pub fn encryption_key(&self) -> &p256::SecretKey {
 		&self.p256_encrypt_private.private
+	}
+
+	/// Get a reference to the underlying AES-GCM-256 secret.
+	///
+	/// CAUTION: this is secret material and should be used with care.
+	#[must_use]
+	pub fn aes_gcm_256_secret(&self) -> &Zeroizing<[u8; 32]> {
+		self.aes_gcm_256_secret.to_bytes()
 	}
 }
 
@@ -488,7 +500,11 @@ mod test {
 		let serialized_envelope = alice_public.encrypt(plaintext).unwrap();
 
 		let decrypted = alice_pair.decrypt(&serialized_envelope).unwrap();
-		assert_eq!(decrypted, plaintext);
+		assert_eq!(&decrypted[..], plaintext);
+		assert!(
+			std::any::type_name_of_val(&decrypted)
+				.starts_with("zeroize::Zeroizing<")
+		);
 	}
 
 	#[test]
@@ -525,7 +541,7 @@ mod test {
 		let plaintext = b"rust test message";
 		let serialized_envelope = alice_public2.encrypt(plaintext).unwrap();
 		let decrypted = alice_pair.decrypt(&serialized_envelope).unwrap();
-		assert_eq!(decrypted, plaintext);
+		assert_eq!(&decrypted[..], plaintext);
 
 		let message = b"a message to authenticate";
 		let signature = alice_pair.sign(message).unwrap();
@@ -546,7 +562,7 @@ mod test {
 		let plaintext = b"rust test message";
 		let serialized_envelope = alice_public2.encrypt(plaintext).unwrap();
 		let decrypted = alice_pair.decrypt(&serialized_envelope).unwrap();
-		assert_eq!(decrypted, plaintext);
+		assert_eq!(&decrypted[..], plaintext);
 
 		let message = b"a message to authenticate";
 		let signature = alice_pair.sign(message).unwrap();
@@ -564,11 +580,58 @@ mod test {
 		let plaintext = b"rust test message";
 		let serialized_envelope = public_key.encrypt(plaintext).unwrap();
 		let decrypted = alice_pair2.decrypt(&serialized_envelope).unwrap();
-		assert_eq!(decrypted, plaintext);
+		assert_eq!(&decrypted[..], plaintext);
 
 		let message = b"a message to authenticate";
 		let signature = alice_pair2.sign(message).unwrap();
 		assert!(public_key.verify(message, &signature).is_ok());
+	}
+
+	#[test]
+	fn generated_and_derived_secrets_are_zeroizing() {
+		let master_seed = bytes_os_rng::<MASTER_SEED_LEN>();
+		let derived_secret =
+			derive_secret(&master_seed, P256_ENCRYPT_DERIVE_PATH).unwrap();
+		let hex_master_seed = P256Pair::from_master_seed(&master_seed)
+			.unwrap()
+			.to_master_seed_hex();
+
+		assert!(
+			std::any::type_name_of_val(&master_seed)
+				.starts_with("zeroize::Zeroizing<")
+		);
+		assert!(
+			std::any::type_name_of_val(
+				P256Pair::from_master_seed(&master_seed)
+					.unwrap()
+					.to_master_seed()
+			)
+			.starts_with("zeroize::Zeroizing<")
+		);
+		assert!(
+			std::any::type_name_of_val(&derived_secret)
+				.starts_with("zeroize::Zeroizing<")
+		);
+		assert!(
+			std::any::type_name_of_val(&hex_master_seed)
+				.starts_with("zeroize::Zeroizing<")
+		);
+	}
+
+	#[test]
+	fn aes_gcm_256_secret_accessor_returns_underlying_zeroizing_secret() {
+		let master_seed = bytes_os_rng::<MASTER_SEED_LEN>();
+		let pair = P256Pair::from_master_seed(&master_seed).unwrap();
+		let expected_secret =
+			derive_secret(&master_seed, AES_GCM_256_PATH).unwrap();
+
+		let aes_gcm_256_secret = pair.aes_gcm_256_secret();
+
+		assert_eq!(&aes_gcm_256_secret[..], &expected_secret[..]);
+		assert!(
+			std::any::type_name_of_val(aes_gcm_256_secret)
+				.starts_with("zeroize::Zeroizing<")
+		);
 	}
 
 	#[test]
@@ -585,11 +648,24 @@ mod test {
 		let serialized_envelope =
 			alice_pair.public_key().encrypt(plaintext).unwrap();
 		let decrypted = alice_pair2.decrypt(&serialized_envelope).unwrap();
-		assert_eq!(decrypted, plaintext);
+		assert_eq!(&decrypted[..], plaintext);
 
 		let message = b"a message to authenticate";
 		let signature = alice_pair2.sign(message).unwrap();
 		assert!(alice_pair.public_key().verify(message, &signature).is_ok());
+	}
+
+	#[test]
+	fn from_hex_file_returns_opaque_error_for_invalid_master_seed() {
+		let path = PathWrapper::from(
+			"/tmp/from_hex_file_returns_opaque_error_for_invalid_master_seed.secret",
+		);
+		std::fs::write(&*path, b"not a valid seed").unwrap();
+
+		assert!(matches!(
+			P256Pair::from_hex_file(&*path),
+			Err(P256Error::InvalidMasterSeed)
+		));
 	}
 
 	mod aes_gcm_256 {
@@ -604,7 +680,11 @@ mod test {
 			let envelope = key.aes_gcm_256_encrypt(plaintext).unwrap();
 			let result = key.aes_gcm_256_decrypt(&envelope).unwrap();
 
-			assert_eq!(result, plaintext);
+			assert_eq!(&result[..], plaintext);
+			assert!(
+				std::any::type_name_of_val(&result)
+					.starts_with("zeroize::Zeroizing<")
+			);
 		}
 
 		#[test]

--- a/src/qos_p256/src/sign.rs
+++ b/src/qos_p256/src/sign.rs
@@ -5,7 +5,7 @@ use p256::ecdsa::{
 	signature::{Signer, Verifier},
 };
 use p256::elliptic_curve::rand_core::OsRng;
-use zeroize::ZeroizeOnDrop;
+use zeroize::{ZeroizeOnDrop, Zeroizing};
 
 use crate::{P256Error, PUB_KEY_LEN_UNCOMPRESSED};
 
@@ -57,8 +57,8 @@ impl P256SignPair {
 
 	/// Serialize key to raw scalar byte slice.
 	#[must_use]
-	pub fn to_bytes(&self) -> Vec<u8> {
-		self.private.to_bytes().to_vec()
+	pub fn to_bytes(&self) -> Zeroizing<Vec<u8>> {
+		Zeroizing::new(self.private.to_bytes().to_vec())
 	}
 }
 
@@ -183,6 +183,17 @@ mod tests {
 		let raw_secret2 = pair2.to_bytes();
 
 		assert_eq!(raw_secret1, raw_secret2);
+	}
+
+	#[test]
+	fn private_key_bytes_are_zeroizing() {
+		let pair = P256SignPair::generate();
+		let raw_secret = pair.to_bytes();
+
+		assert!(
+			std::any::type_name_of_val(&raw_secret)
+				.starts_with("zeroize::Zeroizing<")
+		);
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

We want to normalize on using zeroize for secrets. To help make this easier, I figured it would be good to return zeroizeing types in the first place

## How I Tested These Changes

Unit tests that assert the type is zeroize

## Pre merge check list

- [x] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
