### PR TITLE
fix: use version in qos-json workspace def

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ qos_client = { path = "src/qos_client", version = "0.8.0", default-features = fa
 qos_core = { path = "src/qos_core", version = "0.8.0", default-features = false }
 qos_crypto = { path = "src/qos_crypto", version = "0.8.0", default-features = false }
 qos_hex = { path = "src/qos_hex", version = "0.8.0", default-features = false }
-qos_json = { path = "src/qos_json" }
+qos_json = { path = "src/qos_json", version = "0.8.0" }
 qos_net = { path = "src/qos_net", version = "0.8.0", default-features = false }
 qos_nsm = { path = "src/qos_nsm", version = "0.8.0", default-features = false }
 qos_p256 = { path = "src/qos_p256", version = "0.8.0" }

--- a/src/release-plz.toml
+++ b/src/release-plz.toml
@@ -70,6 +70,12 @@ publish = true
 changelog_update = true
 version_group = "qos"
 
+[[package]]
+name = "qos_json"
+publish = true
+changelog_update = true
+version_group = "qos"
+
 # Unpublished packages
 
 [[package]]


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

We must appease release plz 🙏 

```
  qos_core   normal   ^0.8.0   src/qos_json
  qos_nsm    normal   ^0.8.0   src/qos_json
  qos_client normal   ^0.8.0   src/qos_json
```

## How I Tested These Changes

CI

## Pre merge check list

- [ ] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
