### PR TITLE
chore(ci): check crates build without feature unification

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,6 +45,36 @@ jobs:
       - name: Run linting
         run: make -C src lint
 
+  check-publishable-crates-standalone:
+    name: check-publishable-crates-standalone (${{ matrix.package }})
+    runs-on: ubicloud-standard-2
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - qos_client
+          - qos_core
+          - qos_crypto
+          - qos_hex
+          - qos_net
+          - qos_p256
+          - qos_nsm
+          - qos_test_primitives
+          - qos_json
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+      - name: Install Linux deps
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libpcsclite-dev
+      - name: Check publishable crates standalone
+        # Check one selected package at a time so unrelated workspace members
+        # cannot hide missing direct dependency features through unification.
+        run: cargo check -p ${{ matrix.package }}
+
   build-linux-only-crates:
     name: build-linux-only-crates
     runs-on: ubicloud-standard-8

--- a/src/qos_nsm/Cargo.toml
+++ b/src/qos_nsm/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography"]
 workspace = true
 
 [dependencies]
-qos_hex = { workspace = true, features = ["serde"] }
+qos_hex = { workspace = true }
 qos_json = { workspace = true }
 borsh = { workspace = true }
 serde = { workspace = true }

--- a/src/qos_nsm/Cargo.toml
+++ b/src/qos_nsm/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography"]
 workspace = true
 
 [dependencies]
-qos_hex = { workspace = true }
+qos_hex = { workspace = true, features = ["serde"] }
 qos_json = { workspace = true }
 borsh = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

Due to workspace feature resolution, crates will build fine when we build the whole workspace together, but fail when built independently due to misconfigured feature gates. This affects us when publishing crates

Solution: run cargo check on each package we publish in a CI job

## How I Tested These Changes

Failing CI on [cec90a4](https://github.com/tkhq/qos/pull/709/commits/cec90a43738ad470cde5cdc14ed8fa1ce89a4d9b)
And working once I fixed the issue on [c0d666e](https://github.com/tkhq/qos/pull/709/commits/c0d666e2b27a808cfd80ff85cf784602927b3d5b)

## Pre merge check list

- [ ] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
