### PR TITLE
refactor(qos): use zeroize wrappers in function signatures (SYS-94)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,6 +1262,7 @@ dependencies = [
  "tokio-rustls",
  "ureq",
  "webpki-roots",
+ "zeroize",
 ]
 
 [[package]]
@@ -2145,6 +2146,7 @@ dependencies = [
  "arbitrary",
  "libfuzzer-sys",
  "qos_p256 0.8.0",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,6 +1956,7 @@ dependencies = [
  "tokio",
  "tokio-vsock",
  "webpki-roots",
+ "zeroize",
 ]
 
 [[package]]
@@ -1979,6 +1980,7 @@ dependencies = [
  "sha2",
  "thiserror 2.0.17",
  "vsss-rs",
+ "zeroize",
 ]
 
 [[package]]
@@ -1988,6 +1990,7 @@ dependencies = [
  "arbitrary",
  "libfuzzer-sys",
  "qos_crypto 0.8.0",
+ "zeroize",
 ]
 
 [[package]]

--- a/src/integration/Cargo.toml
+++ b/src/integration/Cargo.toml
@@ -26,6 +26,7 @@ qos_crypto = { workspace = true }
 qos_hex = { workspace = true }
 qos_p256 = { workspace = true, features = ["mock"] }
 qos_test_primitives = { workspace = true }
+zeroize = { workspace = true }
 
 futures = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "fs"] }

--- a/src/integration/tests/genesis.rs
+++ b/src/integration/tests/genesis.rs
@@ -198,10 +198,12 @@ async fn genesis_e2e() {
 
 	// Try recovering from a random permutation
 	decrypted_shares.shuffle(&mut rng());
-	let master_secret: [u8; qos_p256::MASTER_SEED_LEN] =
-		shares_reconstruct(&decrypted_shares[0..threshold]).unwrap()[..]
-			.try_into()
-			.unwrap();
+	let master_secret: zeroize::Zeroizing<[u8; qos_p256::MASTER_SEED_LEN]> =
+		zeroize::Zeroizing::new(
+			shares_reconstruct(&decrypted_shares[0..threshold]).unwrap()[..]
+				.try_into()
+				.unwrap(),
+		);
 	let reconstructed = P256Pair::from_master_seed(&master_secret).unwrap();
 	assert!(
 		reconstructed.public_key()
@@ -260,10 +262,11 @@ async fn genesis_e2e() {
 	let dr_key_pair = P256Pair::from_hex_file(DR_KEY_PRIVATE_PATH).unwrap();
 
 	let dr_wrapped_quorum_key = fs::read(dr_wrapped_quorum_key_path).unwrap();
-	let master_seed: [u8; 32] =
+	let master_seed: zeroize::Zeroizing<[u8; 32]> = zeroize::Zeroizing::new(
 		dr_key_pair.decrypt(&dr_wrapped_quorum_key).unwrap()[..]
 			.try_into()
-			.unwrap();
+			.unwrap(),
+	);
 	let pair = P256Pair::from_master_seed(&master_seed).unwrap();
 	assert!(pair == reconstructed);
 

--- a/src/integration/tests/genesis.rs
+++ b/src/integration/tests/genesis.rs
@@ -186,10 +186,7 @@ async fn genesis_e2e() {
 
 			let share_pair = P256Pair::from_hex_file(share_key_path).unwrap();
 
-			// Decrypt the share with the personal key. `decrypt` returns a
-			// `Zeroizing<Vec<u8>>`, which we propagate through `shares_reconstruct`
-			// so the share bytes are wiped on drop instead of leaking into a
-			// plain `Vec<u8>`.
+			// Decrypt the share with the personal key
 			let plain_text_share =
 				share_pair.decrypt(&member.encrypted_quorum_key_share).unwrap();
 

--- a/src/integration/tests/genesis.rs
+++ b/src/integration/tests/genesis.rs
@@ -186,13 +186,16 @@ async fn genesis_e2e() {
 
 			let share_pair = P256Pair::from_hex_file(share_key_path).unwrap();
 
-			// Decrypt the share with the personal key
+			// Decrypt the share with the personal key. `decrypt` returns a
+			// `Zeroizing<Vec<u8>>`, which we propagate through `shares_reconstruct`
+			// so the share bytes are wiped on drop instead of leaking into a
+			// plain `Vec<u8>`.
 			let plain_text_share =
 				share_pair.decrypt(&member.encrypted_quorum_key_share).unwrap();
 
-			assert_eq!(sha_512(&plain_text_share), member.share_hash);
+			assert_eq!(sha_512(&plain_text_share[..]), member.share_hash);
 
-			plain_text_share.to_vec()
+			plain_text_share
 		})
 		.collect();
 
@@ -200,7 +203,7 @@ async fn genesis_e2e() {
 	decrypted_shares.shuffle(&mut rng());
 	let master_secret: [u8; qos_p256::MASTER_SEED_LEN] =
 		shares_reconstruct(&decrypted_shares[0..threshold])
-			.unwrap()
+			.unwrap()[..]
 			.try_into()
 			.unwrap();
 	let reconstructed = P256Pair::from_master_seed(&master_secret).unwrap();
@@ -263,8 +266,7 @@ async fn genesis_e2e() {
 	let dr_wrapped_quorum_key = fs::read(dr_wrapped_quorum_key_path).unwrap();
 	let master_seed: [u8; 32] = dr_key_pair
 		.decrypt(&dr_wrapped_quorum_key)
-		.unwrap()
-		.to_vec()
+		.unwrap()[..]
 		.try_into()
 		.unwrap();
 	let pair = P256Pair::from_master_seed(&master_seed).unwrap();

--- a/src/integration/tests/genesis.rs
+++ b/src/integration/tests/genesis.rs
@@ -199,8 +199,7 @@ async fn genesis_e2e() {
 	// Try recovering from a random permutation
 	decrypted_shares.shuffle(&mut rng());
 	let master_secret: [u8; qos_p256::MASTER_SEED_LEN] =
-		shares_reconstruct(&decrypted_shares[0..threshold])
-			.unwrap()[..]
+		shares_reconstruct(&decrypted_shares[0..threshold]).unwrap()[..]
 			.try_into()
 			.unwrap();
 	let reconstructed = P256Pair::from_master_seed(&master_secret).unwrap();
@@ -261,11 +260,10 @@ async fn genesis_e2e() {
 	let dr_key_pair = P256Pair::from_hex_file(DR_KEY_PRIVATE_PATH).unwrap();
 
 	let dr_wrapped_quorum_key = fs::read(dr_wrapped_quorum_key_path).unwrap();
-	let master_seed: [u8; 32] = dr_key_pair
-		.decrypt(&dr_wrapped_quorum_key)
-		.unwrap()[..]
-		.try_into()
-		.unwrap();
+	let master_seed: [u8; 32] =
+		dr_key_pair.decrypt(&dr_wrapped_quorum_key).unwrap()[..]
+			.try_into()
+			.unwrap();
 	let pair = P256Pair::from_master_seed(&master_seed).unwrap();
 	assert!(pair == reconstructed);
 

--- a/src/integration/tests/preprod_sharding.rs
+++ b/src/integration/tests/preprod_sharding.rs
@@ -165,11 +165,13 @@ fn assert_can_decrypt(user_secret_path: String, sharepath: String) {
 	let master_seed_utf8 = std::str::from_utf8(&master_seed_hex_bytes).unwrap();
 	let master_seed = qos_hex::decode(master_seed_utf8).unwrap();
 	let encryption_pair_secret = derive_secret(
-		&master_seed.try_into().unwrap(),
+		&zeroize::Zeroizing::new(master_seed.try_into().unwrap()),
 		P256_ENCRYPT_DERIVE_PATH,
 	)
 	.unwrap();
-	let pair =
-		P256EncryptPair::from_bytes(&encryption_pair_secret[..]).unwrap();
+	let pair = P256EncryptPair::from_bytes(&zeroize::Zeroizing::new(
+		encryption_pair_secret.to_vec(),
+	))
+	.unwrap();
 	assert!(pair.decrypt(&share).is_ok());
 }

--- a/src/integration/tests/preprod_sharding.rs
+++ b/src/integration/tests/preprod_sharding.rs
@@ -84,9 +84,9 @@ fn preprod_reshard_ceremony() {
 	let dev_secret_hex_bytes =
 		qos_hex::decode(std::str::from_utf8(&dev_secret_utf8_bytes).unwrap())
 			.unwrap();
-	let dev_key = P256Pair::from_master_seed(
-		&dev_secret_hex_bytes.clone().try_into().unwrap(),
-	)
+	let dev_key = P256Pair::from_master_seed(&zeroize::Zeroizing::new(
+		dev_secret_hex_bytes.clone().try_into().unwrap(),
+	))
 	.unwrap();
 
 	// For each of the enclaves...
@@ -111,9 +111,9 @@ fn preprod_reshard_ceremony() {
 		let removed_byte = decrypted_dev_share.remove(0);
 		assert_eq!(removed_byte, 1);
 
-		let pk = P256Pair::from_master_seed(
-			&decrypted_dev_share[..].try_into().unwrap(),
-		)
+		let pk = P256Pair::from_master_seed(&zeroize::Zeroizing::new(
+			decrypted_dev_share[..].try_into().unwrap(),
+		))
 		.unwrap()
 		.public_key();
 		let expected_quorum_public_key = fs::read(format!(

--- a/src/qos_client/Cargo.toml
+++ b/src/qos_client/Cargo.toml
@@ -26,7 +26,7 @@ aws-nitro-enclaves-nsm-api = { workspace = true }
 borsh = { workspace = true}
 p256 = { workspace = true }
 rand_core = { workspace = true, features = ["os_rng"] }
-zeroize = { workspace = true }
+zeroize = { workspace = true, features = ["alloc"] }
 rpassword = { workspace = true }
 serde_json = { workspace = true }
 

--- a/src/qos_client/src/cli/services.rs
+++ b/src/qos_client/src/cli/services.rs
@@ -389,11 +389,6 @@ pub(crate) fn provision_yubikey<P: AsRef<Path>>(
 
 pub(crate) fn pin_from_path<P: AsRef<Path>>(path: P) -> Zeroizing<Vec<u8>> {
 	let file = File::open(path).expect("Failed to open current pin path");
-	// Read the first line as the PIN. We collect the bytes directly into a
-	// `Zeroizing<Vec<u8>>` so the PIN is wiped on drop instead of living in a
-	// plain `Vec<u8>`. Note: the intermediate `String` produced by `BufReader::lines`
-	// is still subject to its own lifetime; replacing the line-reader with a
-	// zeroize-aware prompt is a follow-up (see SYS-94 follow-ups).
 	let line = BufReader::new(file)
 		.lines()
 		.next()
@@ -1761,10 +1756,6 @@ pub(crate) fn p256_asymmetric_decrypt<P: AsRef<Path>>(
 	let ciphertext = std::fs::read(ciphertext_path.as_ref())?;
 
 	let plaintext = pair.decrypt(&ciphertext)?;
-	// Keep the plaintext in a `Zeroizing<Vec<u8>>` until it is written to disk
-	// so the in-memory copy is wiped on drop. For hex output we still need an
-	// owned `Vec<u8>` (`qos_hex::encode_to_vec` returns one), but we wrap it
-	// in `Zeroizing` so it doesn't outlive the secret unscrubbed.
 	let file_contents: Zeroizing<Vec<u8>> = if output_hex {
 		Zeroizing::new(qos_hex::encode_to_vec(&plaintext))
 	} else {
@@ -2025,8 +2016,6 @@ pub(crate) fn shamir_split(
 	threshold: usize,
 	output_dir: &str,
 ) -> Result<(), Error> {
-	// `fs::read` returns a plain `Vec<u8>`. Wrap it in `Zeroizing` so the
-	// in-memory secret is wiped after sharding completes.
 	let secret = Zeroizing::new(fs::read(&secret_path).map_err(|e| {
 		Error::FailedToRead { path: secret_path, error: e.to_string() }
 	})?);

--- a/src/qos_client/src/cli/services.rs
+++ b/src/qos_client/src/cli/services.rs
@@ -2039,12 +2039,10 @@ pub(crate) fn shamir_reconstruct(
 	let shares = shares
 		.into_iter()
 		.map(|p| {
-			fs::read(&p)
-				.map(Zeroizing::new)
-				.map_err(|e| Error::FailedToRead {
-					path: p,
-					error: e.to_string(),
-				})
+			fs::read(&p).map(Zeroizing::new).map_err(|e| Error::FailedToRead {
+				path: p,
+				error: e.to_string(),
+			})
 		})
 		.collect::<Result<Vec<Zeroizing<Vec<u8>>>, Error>>()?;
 

--- a/src/qos_client/src/cli/services.rs
+++ b/src/qos_client/src/cli/services.rs
@@ -200,7 +200,7 @@ impl From<qos_nsm::nitro::AttestError> for Error {
 pub enum PairOrYubi {
 	/// Yubikey
 	#[cfg(feature = "smartcard")]
-	Yubi((yubikey::YubiKey, Vec<u8>)),
+	Yubi((yubikey::YubiKey, Zeroizing<Vec<u8>>)),
 	/// P256 keypair
 	Pair(P256Pair),
 }
@@ -227,10 +227,12 @@ impl PairOrYubi {
 					let pin = if let Some(pin_path) = maybe_pin_path {
 						pin_from_path(pin_path)
 					} else {
-						rpassword::prompt_password(ENTER_PIN_PROMPT)
-							.map_err(Error::PinEntryError)?
-							.as_bytes()
-							.to_vec()
+						Zeroizing::new(
+							rpassword::prompt_password(ENTER_PIN_PROMPT)
+								.map_err(Error::PinEntryError)?
+								.as_bytes()
+								.to_vec(),
+						)
 					};
 
 					PairOrYubi::Yubi((yubi, pin))
@@ -291,7 +293,6 @@ impl PairOrYubi {
 
 				public
 					.decrypt_from_shared_secret(payload, &shared_secret)
-					.map(Zeroizing::new)
 					.map_err(Into::into)
 			}
 			Self::Pair(pair) => pair.decrypt(payload).map_err(Into::into),
@@ -345,10 +346,12 @@ pub(crate) fn provision_yubikey<P: AsRef<Path>>(
 	let mut yubikey =
 		yubikey::YubiKey::open().map_err(Error::OpenSingleYubiKey)?;
 
-	let pin = rpassword::prompt_password(ENTER_PIN_PROMPT)
-		.map_err(Error::PinEntryError)?
-		.as_bytes()
-		.to_vec();
+	let pin = Zeroizing::new(
+		rpassword::prompt_password(ENTER_PIN_PROMPT)
+			.map_err(Error::PinEntryError)?
+			.as_bytes()
+			.to_vec(),
+	);
 
 	let _sign_public_key_bytes = crate::yubikey::generate_signed_certificate(
 		&mut yubikey,
@@ -384,15 +387,19 @@ pub(crate) fn provision_yubikey<P: AsRef<Path>>(
 	Ok(())
 }
 
-pub(crate) fn pin_from_path<P: AsRef<Path>>(path: P) -> Vec<u8> {
+pub(crate) fn pin_from_path<P: AsRef<Path>>(path: P) -> Zeroizing<Vec<u8>> {
 	let file = File::open(path).expect("Failed to open current pin path");
-	BufReader::new(file)
+	// Read the first line as the PIN. We collect the bytes directly into a
+	// `Zeroizing<Vec<u8>>` so the PIN is wiped on drop instead of living in a
+	// plain `Vec<u8>`. Note: the intermediate `String` produced by `BufReader::lines`
+	// is still subject to its own lifetime; replacing the line-reader with a
+	// zeroize-aware prompt is a follow-up (see SYS-94 follow-ups).
+	let line = BufReader::new(file)
 		.lines()
 		.next()
 		.expect("First line missing from current pin file")
-		.expect("Error reading first line")
-		.as_bytes()
-		.to_vec()
+		.expect("Error reading first line");
+	Zeroizing::new(line.as_bytes().to_vec())
 }
 
 /// Provision a yubikey from a pre-generated master seed.
@@ -412,10 +419,12 @@ pub fn advanced_provision_yubikey<P: AsRef<Path>>(
 	let pin = if let Some(pin_path) = maybe_pin_path {
 		pin_from_path(pin_path)
 	} else {
-		rpassword::prompt_password(ENTER_PIN_PROMPT)
-			.map_err(Error::PinEntryError)?
-			.as_bytes()
-			.to_vec()
+		Zeroizing::new(
+			rpassword::prompt_password(ENTER_PIN_PROMPT)
+				.map_err(Error::PinEntryError)?
+				.as_bytes()
+				.to_vec(),
+		)
 	};
 
 	let pair = P256Pair::from_hex_file(master_seed_path)?;
@@ -1752,10 +1761,14 @@ pub(crate) fn p256_asymmetric_decrypt<P: AsRef<Path>>(
 	let ciphertext = std::fs::read(ciphertext_path.as_ref())?;
 
 	let plaintext = pair.decrypt(&ciphertext)?;
-	let file_contents = if output_hex {
-		qos_hex::encode_to_vec(&plaintext)
+	// Keep the plaintext in a `Zeroizing<Vec<u8>>` until it is written to disk
+	// so the in-memory copy is wiped on drop. For hex output we still need an
+	// owned `Vec<u8>` (`qos_hex::encode_to_vec` returns one), but we wrap it
+	// in `Zeroizing` so it doesn't outlive the secret unscrubbed.
+	let file_contents: Zeroizing<Vec<u8>> = if output_hex {
+		Zeroizing::new(qos_hex::encode_to_vec(&plaintext))
 	} else {
-		plaintext.to_vec()
+		plaintext
 	};
 
 	write_with_msg(plaintext_path.as_ref(), &file_contents, "Plaintext");
@@ -2012,10 +2025,11 @@ pub(crate) fn shamir_split(
 	threshold: usize,
 	output_dir: &str,
 ) -> Result<(), Error> {
-	let secret = fs::read(&secret_path).map_err(|e| Error::FailedToRead {
-		path: secret_path,
-		error: e.to_string(),
-	})?;
+	// `fs::read` returns a plain `Vec<u8>`. Wrap it in `Zeroizing` so the
+	// in-memory secret is wiped after sharding completes.
+	let secret = Zeroizing::new(fs::read(&secret_path).map_err(|e| {
+		Error::FailedToRead { path: secret_path, error: e.to_string() }
+	})?);
 	let shares =
 		qos_crypto::shamir::shares_generate(&secret, total_shares, threshold)
 			.unwrap();
@@ -2023,7 +2037,7 @@ pub(crate) fn shamir_split(
 	for (i, share) in shares.iter().enumerate() {
 		let file_name = format!("{}.share", i + 1);
 		let file_path = PathBuf::from(&output_dir).join(&file_name);
-		write_with_msg(&file_path, share, &file_name);
+		write_with_msg(&file_path, &share[..], &file_name);
 	}
 
 	Ok(())
@@ -2036,15 +2050,16 @@ pub(crate) fn shamir_reconstruct(
 	let shares = shares
 		.into_iter()
 		.map(|p| {
-			fs::read(&p).map_err(|e| Error::FailedToRead {
-				path: p,
-				error: e.to_string(),
-			})
+			fs::read(&p)
+				.map(Zeroizing::new)
+				.map_err(|e| Error::FailedToRead {
+					path: p,
+					error: e.to_string(),
+				})
 		})
-		.collect::<Result<Vec<Vec<u8>>, Error>>()?;
+		.collect::<Result<Vec<Zeroizing<Vec<u8>>>, Error>>()?;
 
-	let secret =
-		Zeroizing::new(qos_crypto::shamir::shares_reconstruct(shares).unwrap());
+	let secret = qos_crypto::shamir::shares_reconstruct(shares).unwrap();
 
 	write_with_msg(output_path.as_ref(), &secret, "Reconstructed secret");
 

--- a/src/qos_client/tests/yubikey.rs
+++ b/src/qos_client/tests/yubikey.rs
@@ -117,7 +117,7 @@ fn key_agreement_works(yubikey: &mut YubiKey) {
 		.unwrap();
 
 	// confirm the output is correct
-	assert_eq!(decrypted, DATA);
+	assert_eq!(&decrypted[..], DATA);
 }
 
 fn signing_works(yubikey: &mut YubiKey) {
@@ -193,7 +193,7 @@ fn import_key_agreement_works(yubikey: &mut YubiKey) {
 		.unwrap();
 
 	// confirm the output is correct
-	assert_eq!(decrypted, DATA);
+	assert_eq!(&decrypted[..], DATA);
 }
 
 fn provision_yubikey_works() {

--- a/src/qos_client/tests/yubikey.rs
+++ b/src/qos_client/tests/yubikey.rs
@@ -141,7 +141,9 @@ fn signing_works(yubikey: &mut YubiKey) {
 
 fn import_signing_works(yubikey: &mut YubiKey) {
 	let secret = bytes_os_rng::<P256_SECRET_LEN>();
-	let pair = P256SignPair::from_bytes(&secret[..]).unwrap();
+	let pair =
+		P256SignPair::from_bytes(&zeroize::Zeroizing::new(secret.to_vec()))
+			.unwrap();
 	let public = pair.public_key();
 
 	import_key_and_generate_signed_certificate(
@@ -161,7 +163,9 @@ fn import_signing_works(yubikey: &mut YubiKey) {
 
 fn import_key_agreement_works(yubikey: &mut YubiKey) {
 	let secret = bytes_os_rng::<32>();
-	let pair = P256EncryptPair::from_bytes(&secret[..]).unwrap();
+	let pair =
+		P256EncryptPair::from_bytes(&zeroize::Zeroizing::new(secret.to_vec()))
+			.unwrap();
 	let public = pair.public_key();
 
 	import_key_and_generate_signed_certificate(

--- a/src/qos_core/Cargo.toml
+++ b/src/qos_core/Cargo.toml
@@ -29,6 +29,7 @@ aws-nitro-enclaves-nsm-api = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true }
+zeroize = { workspace = true, features = ["alloc"] }
 
 futures = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "macros", "net", "rt-multi-thread", "time", "signal", "process"], default-features = false }

--- a/src/qos_core/src/protocol/services/genesis.rs
+++ b/src/qos_core/src/protocol/services/genesis.rs
@@ -184,12 +184,12 @@ pub(in crate::protocol) fn boot_genesis(
 		.map(|(share, share_set_member)| -> Result<GenesisMemberOutput, ProtocolError> {
 			// 1) encrypt the share to quorum key
 			let personal_pub = P256Public::from_bytes(&share_set_member.pub_key)?;
-			let encrypted_quorum_key_share = personal_pub.encrypt(&share)?;
+			let encrypted_quorum_key_share = personal_pub.encrypt(&share[..])?;
 
 			Ok(GenesisMemberOutput {
 				share_set_member,
 				encrypted_quorum_key_share,
-				share_hash: sha_512(&share),
+				share_hash: sha_512(&share[..]),
 			})
 		})
 		.collect();
@@ -275,14 +275,14 @@ mod test {
 		let (output, _nsm_response) =
 			boot_genesis(&mut protocol_state, &genesis_set, None).unwrap();
 		let zipped = std::iter::zip(output.member_outputs, member_pairs);
-		let shares: Vec<Vec<u8>> = zipped
+		let shares: Vec<zeroize::Zeroizing<Vec<u8>>> = zipped
 			.map(|(output, pair)| {
 				let decrypted_share =
-					&pair.decrypt(&output.encrypted_quorum_key_share).unwrap();
+					pair.decrypt(&output.encrypted_quorum_key_share).unwrap();
 
-				assert_eq!(sha_512(decrypted_share), output.share_hash);
+				assert_eq!(sha_512(&decrypted_share[..]), output.share_hash);
 
-				decrypted_share.to_vec()
+				decrypted_share
 			})
 			.collect();
 
@@ -290,7 +290,7 @@ mod test {
 			qos_crypto::shamir::shares_reconstruct(
 				&shares[0..threshold as usize],
 			)
-			.unwrap()
+			.unwrap()[..]
 			.try_into()
 			.unwrap();
 		let reconstructed_quorum_key =

--- a/src/qos_core/src/protocol/services/genesis.rs
+++ b/src/qos_core/src/protocol/services/genesis.rs
@@ -286,13 +286,15 @@ mod test {
 			})
 			.collect();
 
-		let reconstructed: [u8; MASTER_SEED_LEN] =
-			qos_crypto::shamir::shares_reconstruct(
-				&shares[0..threshold as usize],
-			)
-			.unwrap()[..]
-				.try_into()
-				.unwrap();
+		let reconstructed: zeroize::Zeroizing<[u8; MASTER_SEED_LEN]> =
+			zeroize::Zeroizing::new(
+				qos_crypto::shamir::shares_reconstruct(
+					&shares[0..threshold as usize],
+				)
+				.unwrap()[..]
+					.try_into()
+					.unwrap(),
+			);
 		let reconstructed_quorum_key =
 			P256Pair::from_master_seed(&reconstructed).unwrap();
 
@@ -317,7 +319,7 @@ mod test {
 			.unwrap();
 
 		let quorum_key_hash =
-			sha_512(qos_hex::encode(&reconstructed).as_bytes());
+			sha_512(qos_hex::encode(&reconstructed[..]).as_bytes());
 		assert_eq!(quorum_key_hash, output.quorum_key_hash);
 	}
 }

--- a/src/qos_core/src/protocol/services/genesis.rs
+++ b/src/qos_core/src/protocol/services/genesis.rs
@@ -291,8 +291,8 @@ mod test {
 				&shares[0..threshold as usize],
 			)
 			.unwrap()[..]
-			.try_into()
-			.unwrap();
+				.try_into()
+				.unwrap();
 		let reconstructed_quorum_key =
 			P256Pair::from_master_seed(&reconstructed).unwrap();
 

--- a/src/qos_core/src/protocol/services/key.rs
+++ b/src/qos_core/src/protocol/services/key.rs
@@ -43,12 +43,16 @@ pub(in crate::protocol) fn inject_key(
 
 	// 2. Decrypt the encrypted Quorum Key in the request with the Ephemeral
 	// Key.
-	let quorum_master_seed = {
+	let quorum_master_seed: zeroize::Zeroizing<
+		[u8; qos_p256::MASTER_SEED_LEN],
+	> = {
 		let ephemeral_pair = state.handles.get_ephemeral_key()?;
 		let bytes = ephemeral_pair.decrypt(&encrypted_quorum_key)?;
-		bytes[..]
-			.try_into()
-			.map_err(|_| ProtocolError::EncryptedQuorumKeyInvalidLen)?
+		zeroize::Zeroizing::new(
+			bytes[..]
+				.try_into()
+				.map_err(|_| ProtocolError::EncryptedQuorumKeyInvalidLen)?,
+		)
 	};
 
 	// 3. Check that the decrypted Quorum Key public key matches the one
@@ -1143,10 +1147,11 @@ mod test {
 
 			let decrypted_quorum_secret =
 				eph_pair.decrypt(&encrypted_quorum_key).unwrap();
-			let reconstructed_quorum_pair = P256Pair::from_master_seed(
-				&decrypted_quorum_secret[..].try_into().unwrap(),
-			)
-			.unwrap();
+			let reconstructed_quorum_pair =
+				P256Pair::from_master_seed(&zeroize::Zeroizing::new(
+					decrypted_quorum_secret[..].try_into().unwrap(),
+				))
+				.unwrap();
 			assert!(quorum_pair == reconstructed_quorum_pair);
 		}
 	}

--- a/src/qos_core/src/protocol/services/key.rs
+++ b/src/qos_core/src/protocol/services/key.rs
@@ -1339,9 +1339,8 @@ mod test {
 			)
 			.unwrap();
 
-			let mut invalid_master_seed = zeroize::Zeroizing::new(
-				quorum_pair.to_master_seed().to_vec(),
-			);
+			let mut invalid_master_seed =
+				zeroize::Zeroizing::new(quorum_pair.to_master_seed().to_vec());
 			invalid_master_seed.remove(0);
 			let invalid_encrypted_quorum_key =
 				eph_pair.public_key().encrypt(&invalid_master_seed).unwrap();

--- a/src/qos_core/src/protocol/services/key.rs
+++ b/src/qos_core/src/protocol/services/key.rs
@@ -1339,7 +1339,9 @@ mod test {
 			)
 			.unwrap();
 
-			let mut invalid_master_seed = quorum_pair.to_master_seed().to_vec();
+			let mut invalid_master_seed = zeroize::Zeroizing::new(
+				quorum_pair.to_master_seed().to_vec(),
+			);
 			invalid_master_seed.remove(0);
 			let invalid_encrypted_quorum_key =
 				eph_pair.public_key().encrypt(&invalid_master_seed).unwrap();

--- a/src/qos_core/src/protocol/services/provision.rs
+++ b/src/qos_core/src/protocol/services/provision.rs
@@ -1,13 +1,14 @@
 //! Quorum Key provisioning logic and types.
 use qos_p256::P256Pair;
+use zeroize::Zeroizing;
 
 use crate::protocol::{
 	ProtocolError, ProtocolState,
 	services::boot::{Approval, VersionedManifestEnvelope},
 };
 
-type Secret = Vec<u8>;
-type Share = Vec<u8>;
+type Secret = Zeroizing<Vec<u8>>;
+type Share = Zeroizing<Vec<u8>>;
 type Shares = Vec<Share>;
 
 /// Shamir Secret builder.
@@ -96,7 +97,7 @@ pub(in crate::protocol) fn provision(
 		.decrypt(encrypted_share)
 		.map_err(|_| ProtocolError::DecryptionFailed)?;
 
-	state.provisioner.add_share(share.to_vec())?;
+	state.provisioner.add_share(share)?;
 
 	let quorum_threshold = manifest.share_set().threshold as usize;
 	if state.provisioner.count() < quorum_threshold {
@@ -107,10 +108,9 @@ pub(in crate::protocol) fn provision(
 	let master_seed = state.provisioner.build()?;
 	state.provisioner.clear();
 
-	let master_seed: [u8; qos_p256::MASTER_SEED_LEN] =
-		master_seed
-			.try_into()
-			.map_err(|_| ProtocolError::IncorrectSecretLen)?;
+	let master_seed: [u8; qos_p256::MASTER_SEED_LEN] = master_seed[..]
+		.try_into()
+		.map_err(|_| ProtocolError::IncorrectSecretLen)?;
 	let pair = qos_p256::P256Pair::from_master_seed(&master_seed)?;
 	let public_key_bytes = pair.public_key().to_bytes();
 
@@ -142,6 +142,7 @@ mod test {
 	use qos_nsm::mock::MockNsm;
 	use qos_p256::P256Pair;
 	use qos_test_primitives::PathWrapper;
+	use zeroize::Zeroizing;
 
 	use crate::{
 		handles::Handles,
@@ -330,13 +331,16 @@ mod test {
 			setup(&eph_file, &quorum_file, &manifest_file);
 
 		// 4) Create shards of a RANDOM KEY and encrypt them to eph key
-		let random_key =
-			P256Pair::generate().unwrap().to_master_seed().to_vec();
+		let random_key = Zeroizing::new(
+			P256Pair::generate().unwrap().to_master_seed().to_vec(),
+		);
 		let encrypted_shares: Vec<_> =
 			shares_generate(&random_key, 4, threshold)
 				.unwrap()
 				.iter()
-				.map(|shard| eph_pair.public_key().encrypt(shard).unwrap())
+				.map(|shard| {
+					eph_pair.public_key().encrypt(&shard[..]).unwrap()
+				})
 				.collect();
 
 		// 5) For K-1 shards call provision, make sure returns false and doesn't

--- a/src/qos_core/src/protocol/services/provision.rs
+++ b/src/qos_core/src/protocol/services/provision.rs
@@ -338,9 +338,7 @@ mod test {
 			shares_generate(&random_key, 4, threshold)
 				.unwrap()
 				.iter()
-				.map(|shard| {
-					eph_pair.public_key().encrypt(&shard[..]).unwrap()
-				})
+				.map(|shard| eph_pair.public_key().encrypt(&shard[..]).unwrap())
 				.collect();
 
 		// 5) For K-1 shards call provision, make sure returns false and doesn't

--- a/src/qos_core/src/protocol/services/provision.rs
+++ b/src/qos_core/src/protocol/services/provision.rs
@@ -108,9 +108,12 @@ pub(in crate::protocol) fn provision(
 	let master_seed = state.provisioner.build()?;
 	state.provisioner.clear();
 
-	let master_seed: [u8; qos_p256::MASTER_SEED_LEN] = master_seed[..]
-		.try_into()
-		.map_err(|_| ProtocolError::IncorrectSecretLen)?;
+	let master_seed: Zeroizing<[u8; qos_p256::MASTER_SEED_LEN]> =
+		Zeroizing::new(
+			master_seed[..]
+				.try_into()
+				.map_err(|_| ProtocolError::IncorrectSecretLen)?,
+		);
 	let pair = qos_p256::P256Pair::from_master_seed(&master_seed)?;
 	let public_key_bytes = pair.public_key().to_bytes();
 

--- a/src/qos_crypto/Cargo.toml
+++ b/src/qos_crypto/Cargo.toml
@@ -17,6 +17,7 @@ sha2 = { workspace = true }
 thiserror = { workspace = true }
 vsss-rs = { workspace = true }
 rand = { workspace = true, features = ["std", "std_rng"] }
+zeroize = { workspace = true, features = ["alloc"] }
 
 
 [dev-dependencies]

--- a/src/qos_crypto/fuzz/Cargo.toml
+++ b/src/qos_crypto/fuzz/Cargo.toml
@@ -11,6 +11,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 arbitrary = { version = "1", features = ["derive"] }
+zeroize = { version = "1.8", default-features = false, features = ["alloc"] }
 
 qos_crypto = { path = ".." }
 

--- a/src/qos_crypto/fuzz/fuzz_targets/1_shamir_generate_reconstruct.rs
+++ b/src/qos_crypto/fuzz/fuzz_targets/1_shamir_generate_reconstruct.rs
@@ -36,7 +36,7 @@ fuzz_target!(|fuzzerdata: FuzzShamirStruct| {
 			let reconstructed =
 				shares_reconstruct(&shares).expect("should succeed");
 			// expect the reconstruction to work
-			assert_eq!(secret.to_vec(), reconstructed);
+			assert_eq!(&reconstructed[..], &secret[..]);
 
 			// Reconstruct with enough shares
 			let shares = &all_shares[..k];
@@ -44,7 +44,7 @@ fuzz_target!(|fuzzerdata: FuzzShamirStruct| {
 				shares_reconstruct(shares).expect("should succeed");
 
 			// expect the reconstruction to work
-			assert_eq!(secret.to_vec(), reconstructed);
+			assert_eq!(&reconstructed[..], &secret[..]);
 
 			// Reconstruct with not enough shares
 			let shares = &all_shares[..(k - 1)];
@@ -60,7 +60,7 @@ fuzz_target!(|fuzzerdata: FuzzShamirStruct| {
 				Ok(reconstructed) => {
 					// if we managed to reconstruct the secret with less than the minimum number of shares
 					// the something is wrong, or we have a random collision
-					if reconstructed == secret.to_vec() {
+					if &reconstructed[..] == &secret[..] {
 						panic!(
 							"reconstructed the secret with less than k shares, this should not happen"
 						)

--- a/src/qos_crypto/fuzz/fuzz_targets/2_shamir_input_reconstruct_two_shares.rs
+++ b/src/qos_crypto/fuzz/fuzz_targets/2_shamir_input_reconstruct_two_shares.rs
@@ -2,6 +2,7 @@
 
 use libfuzzer_sys::fuzz_target;
 use qos_crypto::shamir::*;
+use zeroize::Zeroizing;
 
 /// let the fuzzer come up with two different shares of arbitrary length
 #[derive(Clone, Debug, arbitrary::Arbitrary)]
@@ -12,7 +13,7 @@ pub struct FuzzShareReconstruct {
 
 // let the fuzzer control the share data in a two share reconstruction scenario
 fuzz_target!(|fuzzerdata: FuzzShareReconstruct| {
-	let mut shares: Vec<Vec<u8>> = Vec::new();
+	let mut shares: Vec<Zeroizing<Vec<u8>>> = Vec::new();
 
 	// FUZZER NOTE the effort to reconstruct shares is O(n²) so inputs with a large n
 	// are particularly slow
@@ -24,8 +25,8 @@ fuzz_target!(|fuzzerdata: FuzzShareReconstruct| {
 	share_one.extend_from_slice(&fuzzerdata.share_one);
 	share_two.extend_from_slice(&fuzzerdata.share_two);
 
-	shares.push(share_one);
-	shares.push(share_two);
+	shares.push(Zeroizing::new(share_one));
+	shares.push(Zeroizing::new(share_two));
 
 	// Reconstruct with the shares, we expect this to error out often
 	let reconstructed_res = shares_reconstruct(&shares);

--- a/src/qos_crypto/fuzz/fuzz_targets/3_shamir_input_reconstruct_three_shares.rs
+++ b/src/qos_crypto/fuzz/fuzz_targets/3_shamir_input_reconstruct_three_shares.rs
@@ -2,6 +2,7 @@
 
 use libfuzzer_sys::fuzz_target;
 use qos_crypto::shamir::*;
+use zeroize::Zeroizing;
 
 /// let the fuzzer come up with three different shares of arbitrary length
 #[derive(Clone, Debug, arbitrary::Arbitrary)]
@@ -13,7 +14,7 @@ pub struct FuzzShareReconstruct {
 
 // let the fuzzer control the share data in a three share reconstruction scenario
 fuzz_target!(|fuzzerdata: FuzzShareReconstruct| {
-	let mut shares: Vec<Vec<u8>> = Vec::new();
+	let mut shares: Vec<Zeroizing<Vec<u8>>> = Vec::new();
 
 	// note that the effort to reconstruct shares is O(n²) so inputs with a large n
 	// are particularly slow
@@ -34,9 +35,9 @@ fuzz_target!(|fuzzerdata: FuzzShareReconstruct| {
 	//     return;
 	// }
 
-	shares.push(share_one);
-	shares.push(share_two);
-	shares.push(share_three);
+	shares.push(Zeroizing::new(share_one));
+	shares.push(Zeroizing::new(share_two));
+	shares.push(Zeroizing::new(share_three));
 
 	// Reconstruct with the shares, we expect this to error out often
 	let reconstructed_res = shares_reconstruct(&shares);

--- a/src/qos_crypto/src/shamir.rs
+++ b/src/qos_crypto/src/shamir.rs
@@ -1,10 +1,15 @@
 //! Shamir Secret Sharing module. We use the [`vsss-rs`](https://crates.io/crates/vsss-rs)
 use vsss_rs::Gf256;
 use vsss_rs::elliptic_curve::rand_core::OsRng;
+use zeroize::Zeroizing;
 
 use crate::QosCryptoError;
 
 /// Generate `share_count` shares requiring `threshold` shares to reconstruct.
+///
+/// Each share is returned wrapped in [`Zeroizing`] so that share bytes are
+/// wiped from memory on drop. The outer `Vec` is not secret material (it just
+/// holds owning handles to the shares).
 ///
 /// Known limitations:
 /// threshold >= 2
@@ -17,25 +22,43 @@ pub fn shares_generate(
 	secret: &[u8],
 	share_count: usize,
 	threshold: usize,
-) -> Result<Vec<Vec<u8>>, QosCryptoError> {
-	Gf256::split_array(threshold, share_count, secret, OsRng)
-		.map_err(QosCryptoError::Vsss)
+) -> Result<Vec<Zeroizing<Vec<u8>>>, QosCryptoError> {
+	let shares: Vec<Vec<u8>> =
+		Gf256::split_array(threshold, share_count, secret, OsRng)
+			.map_err(QosCryptoError::Vsss)?;
+	Ok(shares.into_iter().map(Zeroizing::new).collect())
 }
 
 /// Reconstruct our secret from the given `shares`.
 ///
+/// The returned secret bytes are wrapped in [`Zeroizing`] so they are wiped on
+/// drop. Accepts any input convertible to a slice of `Zeroizing<Vec<u8>>`
+/// (e.g. `&[Zeroizing<Vec<u8>>]`, `Vec<Zeroizing<Vec<u8>>>`) so callers do not
+/// have to strip the zeroize guarantee from individual shares.
+///
 /// # Errors
 ///
 /// Returns [`QosCryptoError::Vsss`] if share reconstruction fails.
-pub fn shares_reconstruct<B: AsRef<[Vec<u8>]>>(
+pub fn shares_reconstruct<B: AsRef<[Zeroizing<Vec<u8>>]>>(
 	shares: B,
-) -> Result<Vec<u8>, QosCryptoError> {
-	Gf256::combine_array(shares).map_err(QosCryptoError::Vsss)
+) -> Result<Zeroizing<Vec<u8>>, QosCryptoError> {
+	// `vsss_rs::Gf256::combine_array` wants `AsRef<[Vec<u8>]>`. We have to
+	// materialize an owned `Vec<Vec<u8>>` of share bytes to satisfy the bound,
+	// but we wrap the whole thing in `Zeroizing` so the temporary copies are
+	// wiped on drop. The inner `Vec<u8>`s are short-lived and dropped along
+	// with the wrapper at the end of this function.
+	let share_clones: Zeroizing<Vec<Vec<u8>>> = Zeroizing::new(
+		shares.as_ref().iter().map(|s| (**s).clone()).collect(),
+	);
+	let secret = Gf256::combine_array(share_clones.as_slice())
+		.map_err(QosCryptoError::Vsss)?;
+	Ok(Zeroizing::new(secret))
 }
 
 #[cfg(test)]
 mod test {
 	use rand::prelude::SliceRandom;
+	use zeroize::Zeroizing;
 
 	use super::*;
 
@@ -49,29 +72,29 @@ mod test {
 		// Reconstruct with all the shares
 		let shares = all_shares.clone();
 		let reconstructed = shares_reconstruct(shares).unwrap();
-		assert_eq!(secret.to_vec(), reconstructed);
+		assert_eq!(&reconstructed[..], secret);
 
 		// Reconstruct with enough shares
 		let shares = &all_shares[..k];
 		let reconstructed = shares_reconstruct(shares).unwrap();
-		assert_eq!(secret.to_vec(), reconstructed);
+		assert_eq!(&reconstructed[..], secret);
 
 		// Reconstruct with not enough shares
 		let shares = &all_shares[..(k - 1)];
 		let reconstructed = shares_reconstruct(shares).unwrap();
 		let old_reconstructed = shares_reconstruct(shares).unwrap();
-		assert_ne!(secret.to_vec(), reconstructed);
-		assert_ne!(secret.to_vec(), old_reconstructed);
+		assert_ne!(&reconstructed[..], secret);
+		assert_ne!(&old_reconstructed[..], secret);
 
 		// Reconstruct with enough shuffled shares
 		let mut shares = all_shares.clone()[..k].to_vec();
 		shares.shuffle(&mut rand::rng());
 		let reconstructed = shares_reconstruct(&shares).unwrap();
-		assert_eq!(secret.to_vec(), reconstructed);
+		assert_eq!(&reconstructed[..], secret);
 
 		for combo in crate::n_choose_k::combinations(&all_shares, k) {
 			let reconstructed = shares_reconstruct(&combo).unwrap();
-			assert_eq!(secret.to_vec(), reconstructed);
+			assert_eq!(&reconstructed[..], secret);
 		}
 	}
 
@@ -99,12 +122,18 @@ mod test {
 		//      }
 		//  }
 		let shares = [
-			qos_hex::decode("01661fc0cc265daa4e7bde354c281dcc23a80c590249")
-				.unwrap(),
-			qos_hex::decode("027bb5fb26d326e0fc421cf604e495e3d3e4bd24ab0e")
-				.unwrap(),
-			qos_hex::decode("0370d31b89800f2f9255abb73ca0ed0f8329d20fcc33")
-				.unwrap(),
+			Zeroizing::new(
+				qos_hex::decode("01661fc0cc265daa4e7bde354c281dcc23a80c590249")
+					.unwrap(),
+			),
+			Zeroizing::new(
+				qos_hex::decode("027bb5fb26d326e0fc421cf604e495e3d3e4bd24ab0e")
+					.unwrap(),
+			),
+			Zeroizing::new(
+				qos_hex::decode("0370d31b89800f2f9255abb73ca0ed0f8329d20fcc33")
+					.unwrap(),
+			),
 		];
 
 		// Setting is 2-out-of-3. Let's try 3 ways.
@@ -120,8 +149,8 @@ mod test {
 
 		// Regardless of the combination we should get the same secret
 		let expected_secret = b"my cute little secret";
-		assert_eq!(reconstructed1, expected_secret);
-		assert_eq!(reconstructed2, expected_secret);
-		assert_eq!(reconstructed3, expected_secret);
+		assert_eq!(&reconstructed1[..], expected_secret);
+		assert_eq!(&reconstructed2[..], expected_secret);
+		assert_eq!(&reconstructed3[..], expected_secret);
 	}
 }

--- a/src/qos_crypto/src/shamir.rs
+++ b/src/qos_crypto/src/shamir.rs
@@ -7,10 +7,6 @@ use crate::QosCryptoError;
 
 /// Generate `share_count` shares requiring `threshold` shares to reconstruct.
 ///
-/// Each share is returned wrapped in [`Zeroizing`] so that share bytes are
-/// wiped from memory on drop. The outer `Vec` is not secret material (it just
-/// holds owning handles to the shares).
-///
 /// Known limitations:
 /// threshold >= 2
 /// `share_count` <= 255
@@ -31,22 +27,12 @@ pub fn shares_generate(
 
 /// Reconstruct our secret from the given `shares`.
 ///
-/// The returned secret bytes are wrapped in [`Zeroizing`] so they are wiped on
-/// drop. Accepts any input convertible to a slice of `Zeroizing<Vec<u8>>`
-/// (e.g. `&[Zeroizing<Vec<u8>>]`, `Vec<Zeroizing<Vec<u8>>>`) so callers do not
-/// have to strip the zeroize guarantee from individual shares.
-///
 /// # Errors
 ///
 /// Returns [`QosCryptoError::Vsss`] if share reconstruction fails.
 pub fn shares_reconstruct<B: AsRef<[Zeroizing<Vec<u8>>]>>(
 	shares: B,
 ) -> Result<Zeroizing<Vec<u8>>, QosCryptoError> {
-	// `vsss_rs::Gf256::combine_array` wants `AsRef<[Vec<u8>]>`. We have to
-	// materialize an owned `Vec<Vec<u8>>` of share bytes to satisfy the bound,
-	// but we wrap the whole thing in `Zeroizing` so the temporary copies are
-	// wiped on drop. The inner `Vec<u8>`s are short-lived and dropped along
-	// with the wrapper at the end of this function.
 	let share_clones: Zeroizing<Vec<Vec<u8>>> = Zeroizing::new(
 		shares.as_ref().iter().map(|s| (**s).clone()).collect(),
 	);

--- a/src/qos_crypto/src/shamir.rs
+++ b/src/qos_crypto/src/shamir.rs
@@ -33,9 +33,8 @@ pub fn shares_generate(
 pub fn shares_reconstruct<B: AsRef<[Zeroizing<Vec<u8>>]>>(
 	shares: B,
 ) -> Result<Zeroizing<Vec<u8>>, QosCryptoError> {
-	let share_clones: Zeroizing<Vec<Vec<u8>>> = Zeroizing::new(
-		shares.as_ref().iter().map(|s| (**s).clone()).collect(),
-	);
+	let share_clones: Zeroizing<Vec<Vec<u8>>> =
+		Zeroizing::new(shares.as_ref().iter().map(|s| (**s).clone()).collect());
 	let secret = Gf256::combine_array(share_clones.as_slice())
 		.map_err(QosCryptoError::Vsss)?;
 	Ok(Zeroizing::new(secret))

--- a/src/qos_p256/fuzz/Cargo.toml
+++ b/src/qos_p256/fuzz/Cargo.toml
@@ -11,6 +11,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 arbitrary = { version = "1", features = ["derive"] }
+zeroize = { version = "1.8", features = ["alloc", "derive"] }
 
 qos_p256 = { path = "../"}
 

--- a/src/qos_p256/fuzz/fuzz_targets/1_sign_then_verify.rs
+++ b/src/qos_p256/fuzz/fuzz_targets/1_sign_then_verify.rs
@@ -2,6 +2,7 @@
 
 use libfuzzer_sys::fuzz_target;
 use qos_p256::P256Pair;
+use zeroize::Zeroizing;
 
 #[derive(Clone, Debug, arbitrary::Arbitrary)]
 pub struct FuzzKeyDataStruct {
@@ -14,7 +15,7 @@ pub struct FuzzKeyDataStruct {
 fuzz_target!(|input: FuzzKeyDataStruct| {
 	// let the fuzzer control the key and data that is going to be signed
 
-	let keypair = match P256Pair::from_master_seed(&input.key) {
+	let keypair = match P256Pair::from_master_seed(&Zeroizing::new(input.key)) {
 		Ok(pair) => pair,
 		Err(_err) => {
 			return;

--- a/src/qos_p256/fuzz/fuzz_targets/2_public_sign_key_round_trip.rs
+++ b/src/qos_p256/fuzz/fuzz_targets/2_public_sign_key_round_trip.rs
@@ -15,7 +15,9 @@ pub struct FuzzKeyDataStruct {
 
 fuzz_target!(|input: FuzzKeyDataStruct| {
 	// Let the fuzzer pick a P256 key
-	let keypair = match P256SignPair::from_bytes(&input.key) {
+	let keypair = match P256SignPair::from_bytes(&zeroize::Zeroizing::new(
+		input.key.to_vec(),
+	)) {
 		Ok(pair) => pair,
 		Err(_err) => {
 			return;

--- a/src/qos_p256/fuzz/fuzz_targets/5_basic_encrypt_decrypt.rs
+++ b/src/qos_p256/fuzz/fuzz_targets/5_basic_encrypt_decrypt.rs
@@ -16,7 +16,9 @@ fuzz_target!(|input: FuzzKeyDataStruct| {
 	// let the fuzzer control a message plaintext that is encrypted and then decrypted again
 
 	// private key generation is non-deterministic: not ideal
-	let key_pair = match P256EncryptPair::from_bytes(&input.key) {
+	let key_pair = match P256EncryptPair::from_bytes(&zeroize::Zeroizing::new(
+		input.key.to_vec(),
+	)) {
 		Ok(pair) => pair,
 		Err(_err) => {
 			return;

--- a/src/qos_p256/fuzz/fuzz_targets/8_decrypt_p256.rs
+++ b/src/qos_p256/fuzz/fuzz_targets/8_decrypt_p256.rs
@@ -11,7 +11,9 @@ pub struct FuzzKeyDataStruct {
 }
 
 fuzz_target!(|input: FuzzKeyDataStruct| {
-	let key = match P256EncryptPair::from_bytes(&input.key) {
+	let key = match P256EncryptPair::from_bytes(&zeroize::Zeroizing::new(
+		input.key.to_vec(),
+	)) {
 		Ok(pair) => pair,
 		Err(_err) => {
 			return;

--- a/src/qos_p256/src/encrypt.rs
+++ b/src/qos_p256/src/encrypt.rs
@@ -199,7 +199,7 @@ impl P256EncryptPublic {
 		&self,
 		serialized_envelope: &[u8],
 		shared_secret: &[u8],
-	) -> Result<Vec<u8>, P256Error> {
+	) -> Result<Zeroizing<Vec<u8>>, P256Error> {
 		let Envelope {
 			nonce,
 			ephemeral_sender_public: ephemeral_sender_public_bytes,
@@ -228,6 +228,7 @@ impl P256EncryptPublic {
 
 		cipher
 			.decrypt(nonce, payload)
+			.map(Zeroizing::new)
 			.map_err(|_| P256Error::AesGcm256DecryptError)
 	}
 

--- a/src/qos_p256/src/encrypt.rs
+++ b/src/qos_p256/src/encrypt.rs
@@ -109,7 +109,7 @@ impl P256EncryptPair {
 	///
 	/// Returns [`P256Error::FailedToReadSecret`] if the bytes are not a
 	/// valid P256 scalar.
-	pub fn from_bytes(bytes: &[u8]) -> Result<Self, P256Error> {
+	pub fn from_bytes(bytes: &Zeroizing<Vec<u8>>) -> Result<Self, P256Error> {
 		Ok(Self {
 			private: SecretKey::from_slice(bytes)
 				.map_err(|_| P256Error::FailedToReadSecret)?,

--- a/src/qos_p256/src/lib.rs
+++ b/src/qos_p256/src/lib.rs
@@ -106,10 +106,10 @@ impl From<qos_hex::HexError> for P256Error {
 ///
 /// Returns [`P256Error::HkdfExpansionFailed`] if HKDF expansion fails.
 pub fn derive_secret(
-	seed: &[u8; MASTER_SEED_LEN],
+	seed: &Zeroizing<[u8; MASTER_SEED_LEN]>,
 	derive_path: &[u8],
 ) -> Result<Zeroizing<[u8; P256_SECRET_LEN]>, P256Error> {
-	let hk = Hkdf::<Sha512>::new(Some(derive_path), seed);
+	let hk = Hkdf::<Sha512>::new(Some(derive_path), &seed[..]);
 
 	let mut buf = Zeroizing::new([0u8; P256_SECRET_LEN]);
 	hk.expand(&[], &mut *buf).map_err(|_| P256Error::HkdfExpansionFailed)?;
@@ -154,9 +154,11 @@ impl P256Pair {
 
 		Ok(Self {
 			p256_encrypt_private: P256EncryptPair::from_bytes(
-				&p256_encrypt_secret[..],
+				&Zeroizing::new(p256_encrypt_secret.to_vec()),
 			)?,
-			sign_private: P256SignPair::from_bytes(&p256_sign_secret[..])?,
+			sign_private: P256SignPair::from_bytes(&Zeroizing::new(
+				p256_sign_secret.to_vec(),
+			))?,
 			master_seed,
 			aes_gcm_256_secret: AesGcm256Secret::from_bytes(*aes_gcm_secret)?,
 		})
@@ -231,9 +233,11 @@ impl P256Pair {
 
 		Ok(Self {
 			p256_encrypt_private: P256EncryptPair::from_bytes(
-				&encrypt_secret[..],
+				&Zeroizing::new(encrypt_secret.to_vec()),
 			)?,
-			sign_private: P256SignPair::from_bytes(&sign_secret[..])?,
+			sign_private: P256SignPair::from_bytes(&Zeroizing::new(
+				sign_secret.to_vec(),
+			))?,
 			master_seed: master_seed.clone(),
 			aes_gcm_256_secret: AesGcm256Secret::from_bytes(
 				*aes_gcm_256_encrypt,

--- a/src/qos_p256/src/lib.rs
+++ b/src/qos_p256/src/lib.rs
@@ -222,7 +222,7 @@ impl P256Pair {
 	///
 	/// Returns [`P256Error`] if key derivation or construction fails.
 	pub fn from_master_seed(
-		master_seed: &[u8; MASTER_SEED_LEN],
+		master_seed: &Zeroizing<[u8; MASTER_SEED_LEN]>,
 	) -> Result<Self, P256Error> {
 		let encrypt_secret =
 			derive_secret(master_seed, P256_ENCRYPT_DERIVE_PATH)?;
@@ -234,7 +234,7 @@ impl P256Pair {
 				&encrypt_secret[..],
 			)?,
 			sign_private: P256SignPair::from_bytes(&sign_secret[..])?,
-			master_seed: Zeroizing::new(*master_seed),
+			master_seed: master_seed.clone(),
 			aes_gcm_256_secret: AesGcm256Secret::from_bytes(
 				*aes_gcm_256_encrypt,
 			)?,

--- a/src/qos_p256/src/sign.rs
+++ b/src/qos_p256/src/sign.rs
@@ -48,7 +48,7 @@ impl P256SignPair {
 	///
 	/// Returns [`P256Error::FailedToReadSecret`] if the bytes are not a
 	/// valid P256 scalar.
-	pub fn from_bytes(bytes: &[u8]) -> Result<Self, P256Error> {
+	pub fn from_bytes(bytes: &Zeroizing<Vec<u8>>) -> Result<Self, P256Error> {
 		Ok(Self {
 			private: SigningKey::from_slice(bytes)
 				.map_err(|_| P256Error::FailedToReadSecret)?,


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

Tighten zeroize discipline across qos so that secret material does not silently materialize into a plain Vec<u8> that the allocator can hand back later without wiping:

- qos_crypto::shamir::shares_generate now returns Vec<Zeroizing<Vec<u8>>> and shares_reconstruct accepts AsRef<[Zeroizing<Vec<u8>>]> and returns Zeroizing<Vec<u8>>.
- SecretBuilder stores Vec<Zeroizing<Vec<u8>>>; build() returns Zeroizing<Vec<u8>>.
- qos_p256::P256EncryptPublic::decrypt_from_shared_secret now returns Zeroizing<Vec<u8>> (matches the sibling decrypt API).
- qos_client::PairOrYubi::Yubi PIN field is now Zeroizing<Vec<u8>>; pin_from_path returns Zeroizing<Vec<u8>>; rpassword-derived PINs and p256_asymmetric_decrypt plaintext output are wrapped in Zeroizing.
- shamir_split reads the secret into Zeroizing<Vec<u8>>; shamir_reconstruct loads shares as Vec<Zeroizing<Vec<u8>>> and no longer double-wraps.
- Tests/integration paths re-wrap master-seed bytes in Zeroizing::new instead of stripping the wrapper via .to_vec(); fuzz targets propagate Zeroizing through the Shamir input vectors.

Closes SYS-94.

## How I Tested These Changes

## Pre merge check list

- [ ] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
