### PR TITLE
chore(qos_net): cargo fmt for hickory_patch2

### DIFF
--- a/src/qos_net/src/proxy_connection.rs
+++ b/src/qos_net/src/proxy_connection.rs
@@ -6,11 +6,11 @@ use std::{
 };
 
 use hickory_resolver::{
+	TokioResolver,
 	config::{
 		ConnectionConfig, NameServerConfig, ResolverConfig, ResolverOpts,
 	},
 	net::runtime::TokioRuntimeProvider,
-	TokioResolver,
 };
 use tokio::{
 	io::{AsyncReadExt, AsyncWriteExt},


### PR DESCRIPTION
Fixes the lint failure on #691 (`cargo fmt --check`). Failing run: https://github.com/tkhq/qos/actions/runs/26111566632

Only change: rustfmt-ordered `use hickory_resolver::{ ... }` imports in `src/qos_net/src/proxy_connection.rs`.