### PR TITLE
qos: replace vm feature flag with target_os check (SYS-95)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,15 +20,6 @@ jobs:
       - name: Run legacy protocol compat tests
         run: cargo test -p integration --features legacy-protocol-compat --test protocol_legacy_decode
 
-  test-vm:
-    name: test-vm
-    runs-on: ubicloud-standard-2
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Run vm-gated tests
-        run: make -C src test-vm
-
   lint:
     name: lint
     runs-on: ubicloud-standard-2

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,14 +10,19 @@ LOCAL_EPH_PATH := ./local-enclave/qos.ephemeral.key
 
 .PHONY: local-enclave
 local-enclave:
-	@# Remove the directory where we default to setting up the enclave file system
+	@# Remove the directory where we set up the local enclave file system
 	rm -rf ./local-enclave
+	mkdir -p ./local-enclave
 	@# Start the enclave with mock feature and mock flag so we can use the MockNSM
 	cargo run --bin qos_core \
 		--features mock \
 		-- \
 		--usock ./dev.sock \
-		--mock
+		--mock \
+		--quorum-file ./local-enclave/qos.quorum.key \
+		--pivot-file ./local-enclave/qos.pivot.bin \
+		--ephemeral-file ./local-enclave/qos.ephemeral.key \
+		--manifest-file ./local-enclave/qos.manifest
 
 .PHONY: sample-app-dangerous-dev-boot
 local-dangerous-dev-boot:
@@ -41,7 +46,6 @@ local-dangerous-dev-boot:
 vm-enclave:
 	OPENSSL_DIR=/usr cargo run \
 		--bin qos_core \
-		--features vm \
 		-- \
 		--cid 16 \
 		--port 6969
@@ -58,7 +62,6 @@ local-host:
 vm-host:
 	OPENSSL_DIR=/usr cargo run \
 		--bin qos_host \
-		--features vm \
 		-- \
 		--host-ip 127.0.0.1 \
 		--host-port 3000 \
@@ -169,10 +172,6 @@ test:
 	@# by itself.
 	cargo test -p qos_core
 
-.PHONY: test-vm
-test-vm:
-	cargo test -p qos_core -p qos_net -p qos_net -p qos_host -p qos_bridge --features vm --no-default-features
-
 .PHONY: build-linux-only
 build-linux-only: qos_system qos_aws init qos_enclave qos_bridge
 
@@ -194,4 +193,4 @@ qos_enclave:
 
 .PHONY: qos_bridge
 qos_bridge:
-	cargo build --manifest-path ./qos_bridge/Cargo.toml --features vm
+	cargo build --manifest-path ./qos_bridge/Cargo.toml

--- a/src/images/qos_bridge/Containerfile
+++ b/src/images/qos_bridge/Containerfile
@@ -4,7 +4,7 @@ ADD . /src
 FROM base AS build
 RUN <<-EOF
 	set -eux
-	cd /src && cargo build ${CARGOFLAGS} --features vm -p qos_bridge
+	cd /src && cargo build ${CARGOFLAGS} -p qos_bridge
 	cp /src/target/${TARGET}/release/qos_bridge /
 	file /qos_bridge | grep "static-pie"
 EOF

--- a/src/images/qos_host/Containerfile
+++ b/src/images/qos_host/Containerfile
@@ -4,7 +4,7 @@ ADD . /src
 FROM base AS build
 RUN <<-EOF
 	set -eux
-	cd /src && cargo build ${CARGOFLAGS} --features vm -p qos_host
+	cd /src && cargo build ${CARGOFLAGS} -p qos_host
 	cp /src/target/${TARGET}/release/qos_host /
 	file /qos_host | grep "static-pie"
 EOF

--- a/src/init/Cargo.toml
+++ b/src/init/Cargo.toml
@@ -10,7 +10,7 @@ libc = "=0.2.174"
 nix = { version = "0.30.1", features = ["ioctl"]}
 qos_aws = { path = "../qos_aws"}
 qos_system = { path = "../qos_system"}
-qos_core = { path = "../qos_core", features = ["vm"], default-features = false }
+qos_core = { path = "../qos_core", default-features = false }
 qos_nsm = { path = "../qos_nsm", default-features = false }
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"], default-features = false }
 

--- a/src/qos_bridge/Cargo.toml
+++ b/src/qos_bridge/Cargo.toml
@@ -19,6 +19,3 @@ ureq = { workspace = true, features = ["json"] }
 serde_json = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-
-[features]
-vm = ["qos_core/vm"]

--- a/src/qos_bridge/src/cli.rs
+++ b/src/qos_bridge/src/cli.rs
@@ -75,10 +75,10 @@ impl HostOpts {
 	}
 
 	/// Create a new `StreamPool` using the list of `SocketAddress` for the qos host.
-	#[cfg_attr(not(feature = "vm"), allow(clippy::unnecessary_wraps))]
+	#[cfg_attr(target_os = "macos", allow(clippy::unnecessary_wraps))]
 	pub(crate) fn enclave_socket(&self) -> Result<SocketAddress, IOError> {
 		match (self.parsed.single(CID), self.parsed.single(USOCK)) {
-			#[cfg(feature = "vm")]
+			#[cfg(not(target_os = "macos"))]
 			(Some(c), None) => {
 				let c =
 					c.parse().map_err(|_| IOError::ConnectAddressInvalid)?;
@@ -92,19 +92,18 @@ impl HostOpts {
 		}
 	}
 
-	#[cfg(feature = "vm")]
+	#[cfg(not(target_os = "macos"))]
 	fn to_host_flag(&self) -> u8 {
 		let include = self
 			.parsed
 			.single(VSOCK_TO_HOST)
 			.as_ref()
 			.map(|s| s.parse())
-			.map(|r| {
+			.is_none_or(|r| {
 				r.expect(
 					"could not parse `--vsock-to-host`. Valid args are true or false",
 				)
-			})
-			.unwrap_or(true);
+			});
 
 		if include {
 			println!("Configuring vsock with VMADDR_FLAG_TO_HOST.");

--- a/src/qos_core/Cargo.toml
+++ b/src/qos_core/Cargo.toml
@@ -43,7 +43,5 @@ rustls = { workspace = true }
 webpki-roots = { workspace = true }
 
 [features]
-# Support for VSOCK
-vm = []
 # Never use in production - support for mock NSM
 mock = ["qos_nsm/mock"]

--- a/src/qos_core/src/cli.rs
+++ b/src/qos_core/src/cli.rs
@@ -48,14 +48,14 @@ impl EnclaveOpts {
 	}
 
 	/// Create a new `StreamSocket` for the qos host.
-	#[cfg_attr(not(feature = "vm"), allow(clippy::unnecessary_wraps))]
+	#[cfg_attr(target_os = "macos", allow(clippy::unnecessary_wraps))]
 	fn enclave_socket(&self) -> Result<SocketAddress, IOError> {
 		match (
 			self.parsed.single(CID),
 			self.parsed.single(PORT),
 			self.parsed.single(USOCK),
 		) {
-			#[cfg(feature = "vm")]
+			#[cfg(not(target_os = "macos"))]
 			(Some(c), Some(p), None) => {
 				let c =
 					c.parse().map_err(|_| IOError::ConnectAddressInvalid)?;
@@ -331,7 +331,7 @@ mod test {
 	}
 
 	#[test]
-	#[cfg(feature = "vm")]
+	#[cfg(not(target_os = "macos"))]
 	fn build_vsock() {
 		let mut args: Vec<_> = vec!["binary", "--cid", "6", "--port", "3999"]
 			.into_iter()

--- a/src/qos_core/src/io/mod.rs
+++ b/src/qos_core/src/io/mod.rs
@@ -12,7 +12,7 @@ pub use host_bridge::*;
 pub use pool::*;
 pub use stream::*;
 
-#[cfg(feature = "vm")]
+#[cfg(not(target_os = "macos"))]
 use nix::sys::socket::VsockAddr;
 use nix::sys::socket::{AddressFamily, SockaddrLike, UnixAddr};
 pub use nix::sys::time::{TimeVal, TimeValLike};
@@ -77,7 +77,7 @@ impl From<PoolError> for IOError {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SocketAddress {
 	/// VSOCK address.
-	#[cfg(feature = "vm")]
+	#[cfg(not(target_os = "macos"))]
 	Vsock(VsockAddr),
 	/// Unix address.
 	Unix(UnixAddr),
@@ -103,16 +103,24 @@ impl SocketAddress {
 	/// Create a new Vsock socket.
 	///
 	/// For flags see: [Add flags field in the vsock address](<https://lkml.org/lkml/2020/12/11/249>).
-	#[cfg(feature = "vm")]
+	#[cfg(not(target_os = "macos"))]
+	#[must_use]
 	pub fn new_vsock(cid: u32, port: u32, flags: u8) -> Self {
 		Self::Vsock(Self::new_vsock_raw(cid, port, flags))
 	}
 
-	/// Create a new raw VsockAddr.
+	/// Create a new raw `VsockAddr`.
 	///
 	/// For flags see: [Add flags field in the vsock address](<https://lkml.org/lkml/2020/12/11/249>).
-	#[cfg(feature = "vm")]
+	///
+	/// # Panics
+	///
+	/// Panics if `VsockAddr::from_raw` cannot construct a valid address from
+	/// the provided fields (should be unreachable for well-formed `cid` /
+	/// `port` / `flags`).
+	#[cfg(not(target_os = "macos"))]
 	#[allow(unsafe_code)]
+	#[must_use]
 	pub fn new_vsock_raw(cid: u32, port: u32, flags: u8) -> VsockAddr {
 		let vsock_addr = SockAddrVm {
 			svm_family: AddressFamily::Vsock as libc::sa_family_t,
@@ -122,22 +130,26 @@ impl SocketAddress {
 			svm_flags: flags,
 			svm_zero: [0; 3],
 		};
-		let vsock_addr_len = size_of::<SockAddrVm>() as libc::socklen_t;
-		let addr = unsafe {
+		let vsock_addr_len = libc::socklen_t::try_from(size_of::<SockAddrVm>())
+			.expect("SockAddrVm size fits in socklen_t");
+		// SAFETY: `vsock_addr` is a valid, fully-initialized `SockAddrVm`
+		// (the layout-compatible struct corresponding to a vsock sockaddr),
+		// and we pass the matching size. `VsockAddr::from_raw` returns
+		// `Some` iff the address family is `AF_VSOCK`, which we set above.
+		unsafe {
 			VsockAddr::from_raw(
-				&vsock_addr as *const SockAddrVm as *const libc::sockaddr,
+				std::ptr::from_ref(&vsock_addr).cast::<libc::sockaddr>(),
 				Some(vsock_addr_len),
 			)
-			.unwrap()
-		};
-		addr
+			.expect("constructed vsock sockaddr is valid")
+		}
 	}
 
 	/// Get the `AddressFamily` of the socket.
 	#[must_use]
 	pub fn family(&self) -> AddressFamily {
 		match *self {
-			#[cfg(feature = "vm")]
+			#[cfg(not(target_os = "macos"))]
 			Self::Vsock(_) => AddressFamily::Vsock,
 			Self::Unix(_) => AddressFamily::Unix,
 		}
@@ -147,29 +159,37 @@ impl SocketAddress {
 	#[must_use]
 	pub fn addr(&self) -> Box<dyn SockaddrLike> {
 		match *self {
-			#[cfg(feature = "vm")]
+			#[cfg(not(target_os = "macos"))]
 			Self::Vsock(vsa) => Box::new(vsa),
 			Self::Unix(ua) => Box::new(ua),
 		}
 	}
 
 	/// Returns the `UnixAddr` if this is a USOCK `SocketAddress`, panics otherwise
+	///
+	/// # Panics
+	///
+	/// Panics if the underlying `SocketAddress` is not a `Unix` variant.
 	#[must_use]
 	pub fn usock(&self) -> &UnixAddr {
 		match self {
 			Self::Unix(usock) => usock,
-			#[cfg(feature = "vm")]
-			_ => panic!("invalid socket address requested"),
+			#[cfg(not(target_os = "macos"))]
+			Self::Vsock(_) => panic!("invalid socket address requested"),
 		}
 	}
 
-	/// Returns the `UnixAddr` if this is a USOCK `SocketAddress`, panics otherwise
+	/// Returns the `VsockAddr` if this is a VSOCK `SocketAddress`, panics otherwise
+	///
+	/// # Panics
+	///
+	/// Panics if the underlying `SocketAddress` is not a `Vsock` variant.
 	#[must_use]
-	#[cfg(feature = "vm")]
+	#[cfg(not(target_os = "macos"))]
 	pub fn vsock(&self) -> &VsockAddr {
 		match self {
 			Self::Vsock(vsock) => vsock,
-			_ => panic!("invalid socket address requested"),
+			Self::Unix(_) => panic!("invalid socket address requested"),
 		}
 	}
 
@@ -184,7 +204,7 @@ impl SocketAddress {
 	#[allow(unused)]
 	pub fn with_port(&self, port: u16) -> Result<SocketAddress, IOError> {
 		match self {
-			#[cfg(feature = "vm")]
+			#[cfg(not(target_os = "macos"))]
 			Self::Vsock(vsa) => Ok(Self::new_vsock(
 				vsa.cid(),
 				port.into(),
@@ -210,7 +230,7 @@ impl SocketAddress {
 impl std::fmt::Display for SocketAddress {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {
-			#[cfg(feature = "vm")]
+			#[cfg(not(target_os = "macos"))]
 			Self::Vsock(vsock) => {
 				write!(f, "vsock cid: {} port: {}", vsock.cid(), vsock.port())
 			}
@@ -230,18 +250,24 @@ impl std::fmt::Display for SocketAddress {
 	}
 }
 
-/// Extract svm_flags field value from existing VSOCK.
-#[cfg(feature = "vm")]
+/// Extract `svm_flags` field value from existing VSOCK.
+#[cfg(not(target_os = "macos"))]
 #[allow(unsafe_code)]
+#[must_use]
 pub fn vsock_svm_flags(vsock: VsockAddr) -> u8 {
+	// SAFETY: `SockAddrVm` is `repr(C)` and laid out identically to the
+	// kernel `sockaddr_vm` structure that backs `nix`'s `VsockAddr`, so the
+	// reinterpret is well-defined for the purpose of reading the
+	// `svm_flags` byte.
 	unsafe {
 		let cast: SockAddrVm = std::mem::transmute(vsock);
 		cast.svm_flags
 	}
 }
 
-#[cfg(feature = "vm")]
+#[cfg(not(target_os = "macos"))]
 #[repr(C)]
+#[allow(clippy::struct_field_names)]
 struct SockAddrVm {
 	svm_family: libc::sa_family_t,
 	svm_reserved1: libc::c_ushort,

--- a/src/qos_core/src/io/pool.rs
+++ b/src/qos_core/src/io/pool.rs
@@ -282,7 +282,7 @@ impl SocketAddress {
 					Err(IOError::PoolError(PoolError::InvalidSourceAddress))
 				}
 			},
-			#[cfg(feature = "vm")]
+			#[cfg(not(target_os = "macos"))]
 			Self::Vsock(vsock) => Ok(Self::new_vsock(
 				vsock.cid(),
 				vsock.port() + 1,

--- a/src/qos_core/src/io/stream.rs
+++ b/src/qos_core/src/io/stream.rs
@@ -6,7 +6,7 @@ use tokio::{
 	io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
 	net::{UnixListener, UnixSocket, UnixStream},
 };
-#[cfg(feature = "vm")]
+#[cfg(not(target_os = "macos"))]
 use tokio_vsock::{VsockListener, VsockStream};
 
 use super::{IOError, SocketAddress};
@@ -20,14 +20,14 @@ pub const MAX_PAYLOAD_SIZE: usize = 128 * MIB;
 #[derive(Debug)]
 enum InnerListener {
 	Unix(UnixListener),
-	#[cfg(feature = "vm")]
+	#[cfg(not(target_os = "macos"))]
 	Vsock(VsockListener),
 }
 
 #[derive(Debug)]
 enum InnerStream {
 	Unix(UnixStream),
-	#[cfg(feature = "vm")]
+	#[cfg(not(target_os = "macos"))]
 	Vsock(VsockStream),
 }
 
@@ -52,7 +52,7 @@ impl Stream {
 	}
 
 	// accept a new connection, used by server side
-	#[cfg(feature = "vm")]
+	#[cfg(not(target_os = "macos"))]
 	fn vsock_accepted(stream: VsockStream) -> Self {
 		Self { address: None, inner: Some(InnerStream::Vsock(stream)) }
 	}
@@ -80,9 +80,9 @@ impl Stream {
 
 				self.inner = Some(InnerStream::Unix(inner));
 			}
-			#[cfg(feature = "vm")]
+			#[cfg(not(target_os = "macos"))]
 			SocketAddress::Vsock(_vaddr) => {
-				let inner = vsock_connect(&addr).await?;
+				let inner = vsock_connect(addr).await?;
 
 				self.inner = Some(InnerStream::Vsock(inner));
 			}
@@ -105,7 +105,7 @@ impl Stream {
 			InnerStream::Unix(s) => {
 				*s = unix_connect(&addr).await?;
 			}
-			#[cfg(feature = "vm")]
+			#[cfg(not(target_os = "macos"))]
 			InnerStream::Vsock(s) => {
 				*s = vsock_connect(&addr).await?;
 			}
@@ -122,7 +122,7 @@ impl Stream {
 	pub async fn send(&mut self, buf: &[u8]) -> Result<(), IOError> {
 		match &mut self.inner_mut()? {
 			InnerStream::Unix(s) => send(s, buf).await,
-			#[cfg(feature = "vm")]
+			#[cfg(not(target_os = "macos"))]
 			InnerStream::Vsock(s) => send(s, buf).await,
 		}
 	}
@@ -135,7 +135,7 @@ impl Stream {
 	pub async fn recv(&mut self) -> Result<Vec<u8>, IOError> {
 		match &mut self.inner_mut()? {
 			InnerStream::Unix(s) => recv(s).await,
-			#[cfg(feature = "vm")]
+			#[cfg(not(target_os = "macos"))]
 			InnerStream::Vsock(s) => recv(s).await,
 		}
 	}
@@ -269,7 +269,7 @@ impl AsyncRead for Stream {
 	) -> std::task::Poll<std::io::Result<()>> {
 		match &mut self.inner_mut()? {
 			InnerStream::Unix(s) => Pin::new(s).poll_read(cx, buf),
-			#[cfg(feature = "vm")]
+			#[cfg(not(target_os = "macos"))]
 			InnerStream::Vsock(s) => Pin::new(s).poll_read(cx, buf),
 		}
 	}
@@ -283,7 +283,7 @@ impl AsyncWrite for Stream {
 	) -> std::task::Poll<Result<usize, std::io::Error>> {
 		match &mut self.inner_mut()? {
 			InnerStream::Unix(s) => Pin::new(s).poll_write(cx, buf),
-			#[cfg(feature = "vm")]
+			#[cfg(not(target_os = "macos"))]
 			InnerStream::Vsock(s) => Pin::new(s).poll_write(cx, buf),
 		}
 	}
@@ -294,7 +294,7 @@ impl AsyncWrite for Stream {
 	) -> std::task::Poll<Result<(), std::io::Error>> {
 		match &mut self.inner_mut()? {
 			InnerStream::Unix(s) => Pin::new(s).poll_flush(cx),
-			#[cfg(feature = "vm")]
+			#[cfg(not(target_os = "macos"))]
 			InnerStream::Vsock(s) => Pin::new(s).poll_flush(cx),
 		}
 	}
@@ -305,7 +305,7 @@ impl AsyncWrite for Stream {
 	) -> std::task::Poll<Result<(), std::io::Error>> {
 		match &mut self.inner_mut()? {
 			InnerStream::Unix(s) => Pin::new(s).poll_shutdown(cx),
-			#[cfg(feature = "vm")]
+			#[cfg(not(target_os = "macos"))]
 			InnerStream::Vsock(s) => Pin::new(s).poll_shutdown(cx),
 		}
 	}
@@ -331,7 +331,7 @@ impl Listener {
 				let inner = InnerListener::Unix(UnixListener::bind(path)?);
 				Self { inner, addr: addr.clone() }
 			}
-			#[cfg(feature = "vm")]
+			#[cfg(not(target_os = "macos"))]
 			SocketAddress::Vsock(vaddr) => {
 				let inner = InnerListener::Vsock(VsockListener::bind(vaddr)?);
 				Self { inner, addr: addr.clone() }
@@ -352,7 +352,7 @@ impl Listener {
 				let (s, _) = l.accept().await?;
 				Stream::unix_accepted(s)
 			}
-			#[cfg(feature = "vm")]
+			#[cfg(not(target_os = "macos"))]
 			InnerListener::Vsock(l) => {
 				let (s, _) = l.accept().await?;
 				Stream::vsock_accepted(s)
@@ -381,7 +381,7 @@ impl Drop for Listener {
 				}
 				Err(e) => eprintln!("{e}"), // do not crash in Drop
 			},
-			#[cfg(feature = "vm")]
+			#[cfg(not(target_os = "macos"))]
 			InnerListener::Vsock(_vsock) => {} // vsock's drop will clear this
 		}
 	}
@@ -398,7 +398,7 @@ async fn unix_connect(
 }
 
 // raw vsock socket connect
-#[cfg(feature = "vm")]
+#[cfg(not(target_os = "macos"))]
 async fn vsock_connect(
 	addr: &SocketAddress,
 ) -> Result<VsockStream, std::io::Error> {

--- a/src/qos_core/src/lib.rs
+++ b/src/qos_core/src/lib.rs
@@ -7,12 +7,6 @@
 //! This crate should have as minimal dependencies as possible to decrease
 //! supply chain attack vectors and audit burden
 
-// "vm" is necessary for production and we don't want any mock data slipping in.
-#[cfg(all(feature = "vm", feature = "mock"))]
-compile_error!(
-	"feature \"vm\" and feature \"mock\" cannot be enabled at the same time"
-);
-
 pub mod client;
 pub mod server;
 
@@ -24,38 +18,16 @@ pub mod protocol;
 pub mod reaper;
 
 /// Path to Quorum Key secret.
-#[cfg(not(feature = "vm"))]
-pub const QUORUM_FILE: &str = "./local-enclave/qos.quorum.key";
-/// Path to Quorum Key secret.
-#[cfg(feature = "vm")]
 pub const QUORUM_FILE: &str = "/qos.quorum.key";
 
 /// Path to Pivot binary.
-#[cfg(not(feature = "vm"))]
-pub const PIVOT_FILE: &str = "./local-enclave/qos.pivot.bin";
-/// Path to Pivot binary.
-#[cfg(feature = "vm")]
 pub const PIVOT_FILE: &str = "/qos.pivot.bin";
 
 /// Path to Ephemeral Key.
-#[cfg(not(feature = "vm"))]
-pub const EPHEMERAL_KEY_FILE: &str = "./local-enclave/qos.ephemeral.key";
-/// Path to Ephemeral Key.
-#[cfg(feature = "vm")]
 pub const EPHEMERAL_KEY_FILE: &str = "/qos.ephemeral.key";
 
 /// Path to the Manifest.
-#[cfg(not(feature = "vm"))]
-pub const MANIFEST_FILE: &str = "./local-enclave/qos.manifest";
-/// Path to the Manifest.
-#[cfg(feature = "vm")]
 pub const MANIFEST_FILE: &str = "/qos.manifest";
 
-/// Default socket for enclave <-> secure app communication.
-#[cfg(not(feature = "vm"))]
-pub const SEC_APP_SOCK: &str = "./local-enclave/sec_app.sock";
-/// Default socket for enclave <-> secure app communication.
-#[cfg(feature = "vm")]
-pub const SEC_APP_SOCK: &str = "/sec_app.sock";
 /// Default socket connect timeout in milliseconds
 pub const DEFAULT_SOCKET_TIMEOUT_MS: &str = "20000";

--- a/src/qos_host/Cargo.toml
+++ b/src/qos_host/Cargo.toml
@@ -19,6 +19,3 @@ borsh = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-
-[features]
-vm = ["qos_core/vm"]

--- a/src/qos_host/src/cli.rs
+++ b/src/qos_host/src/cli.rs
@@ -121,7 +121,7 @@ impl HostOpts {
 	}
 
 	/// Create a new `StreamPool` using the list of `SocketAddress` for the qos host.
-	#[cfg_attr(not(feature = "vm"), allow(clippy::unnecessary_wraps))]
+	#[cfg_attr(target_os = "macos", allow(clippy::unnecessary_wraps))]
 	pub(crate) fn enclave_socket(
 		&self,
 	) -> Result<SocketAddress, qos_core::io::IOError> {
@@ -130,7 +130,7 @@ impl HostOpts {
 			self.parsed.single(PORT),
 			self.parsed.single(USOCK),
 		) {
-			#[cfg(feature = "vm")]
+			#[cfg(not(target_os = "macos"))]
 			(Some(c), Some(p), None) => {
 				let c = c.parse().map_err(|_| {
 					qos_core::io::IOError::ConnectAddressInvalid
@@ -159,19 +159,18 @@ impl HostOpts {
 		self.parsed.single(ENDPOINT_BASE_PATH).cloned()
 	}
 
-	#[cfg(feature = "vm")]
+	#[cfg(not(target_os = "macos"))]
 	fn to_host_flag(&self) -> u8 {
 		let include = self
 			.parsed
 			.single(VSOCK_TO_HOST)
 			.as_ref()
 			.map(|s| s.parse())
-			.map(|r| {
+			.is_some_and(|r| {
 				r.expect(
 					"could not parse `--vsock-to-host`. Valid args are true or false",
 				)
-			})
-			.unwrap_or(false);
+			});
 
 		if include {
 			println!("Configuring vsock with VMADDR_FLAG_TO_HOST.");
@@ -211,7 +210,7 @@ impl CLI {
 }
 
 #[cfg(test)]
-#[cfg(feature = "vm")]
+#[cfg(not(target_os = "macos"))]
 mod test {
 	use super::*;
 

--- a/src/qos_net/Cargo.toml
+++ b/src/qos_net/Cargo.toml
@@ -38,4 +38,3 @@ webpki-roots = { workspace = true }
 [features]
 default = ["proxy"] # keep this as a default feature ensures we lint by default
 proxy = ["hickory-resolver", "tokio", "tokio-rustls"]
-vm = ["qos_core/vm"]

--- a/src/qos_net/src/cli.rs
+++ b/src/qos_net/src/cli.rs
@@ -59,13 +59,16 @@ impl ProxyOpts {
 			self.parsed.single(PORT),
 			self.parsed.single(USOCK),
 		) {
-			#[cfg(feature = "vm")]
+			#[cfg(not(target_os = "macos"))]
 			(Some(c), Some(p), None) => {
 				let c = c.parse::<u32>().unwrap();
 				let p = p.parse::<u32>().unwrap();
 
-				let address =
-					SocketAddress::new_vsock(c, p, crate::io::VMADDR_NO_FLAGS);
+				let address = SocketAddress::new_vsock(
+					c,
+					p,
+					qos_core::io::VMADDR_NO_FLAGS,
+				);
 
 				StreamPool::new(address, pool_size)
 			}
@@ -242,18 +245,16 @@ mod test {
 	}
 
 	#[test]
-	#[cfg(feature = "vm")]
+	#[cfg(not(target_os = "macos"))]
 	fn build_vsock() {
 		let mut args: Vec<_> = vec!["binary", "--cid", "6", "--port", "3999"]
 			.into_iter()
 			.map(String::from)
 			.collect();
-		let opts = EnclaveOpts::new(&mut args);
+		let opts = ProxyOpts::new(&mut args);
 
-		assert_eq!(
-			opts.addr(),
-			SocketAddress::new_vsock(6, 3999, crate::io::VMADDR_NO_FLAGS)
-		);
+		let pool = opts.async_pool().unwrap();
+		assert_eq!(pool.len(), 1);
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary
Replaces the `vm` Cargo feature flag with a `target_os = "macos"` compile-time check. The `vm` feature only ever toggled vsock-vs-Unix-socket code paths and the matching filesystem layout — both of which are driven by "are we on macOS?". Encoding that directly as a `cfg` removes a footgun feature and shrinks the build matrix.

Linear: https://linear.app/turnkey/issue/SYS-95/qos-replace-vm-feature-flag-with-macos-arch-check

