### PR TITLE
qos_core: add new transparent egress support

### DIFF
--- a/.github/workflows/stagex-release.yml
+++ b/.github/workflows/stagex-release.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           # Extract version from tag (e.g. "qos_core-v0.5.0" -> "v0.5.0")
           version="${release_tag#qos_core-}"
-          for name in qos_client qos_host qos_enclave qos_bridge; do
+          for name in qos_client qos_host qos_enclave qos_enclave_egress qos_bridge qos_bridge_egress; do
             env -C out/${name} tar -cf - . | docker load
             docker tag "qos-local/${name}:latest" "ghcr.io/tkhq/${name}:${version}"
             docker tag "qos-local/${name}:latest" "ghcr.io/tkhq/${name}:latest"
@@ -67,13 +67,13 @@ jobs:
             docker push "ghcr.io/tkhq/${name}:latest"
           done
 
-      - name: Extract PCRs
+      - name: Extract PCRs (qos_enclave)
         run: |
           id=$(docker create "qos-local/qos_enclave:latest")
           docker cp "${id}:/nitro.pcrs" out/nitro.pcrs
           docker rm "${id}"
 
-      - name: Upload PCRs to GitHub release
+      - name: Upload PCRs to GitHub release (qos_enclave)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # upload to qos_core release tag

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,12 +121,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,9 +186,9 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
+ "http",
+ "http-body",
+ "hyper",
  "itoa",
  "matchit",
  "memchr",
@@ -205,9 +199,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "sync_wrapper 0.1.2",
+ "sync_wrapper",
  "tokio",
- "tower 0.4.13",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -221,8 +215,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
+ "http",
+ "http-body",
  "mime",
  "rustversion",
  "tower-layer",
@@ -1060,46 +1054,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
-dependencies = [
- "bytes",
- "itoa",
-]
-
-[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
-dependencies = [
- "bytes",
- "http 1.4.1",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
-dependencies = [
- "bytes",
- "futures-core",
- "http 1.4.1",
- "http-body 1.0.1",
+ "http",
  "pin-project-lite",
 ]
 
@@ -1134,8 +1095,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -1145,49 +1106,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
-]
-
-[[package]]
-name = "hyper"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
-dependencies = [
- "atomic-waker",
- "bytes",
- "futures-channel",
- "futures-core",
- "http 1.4.1",
- "http-body 1.0.1",
- "httparse",
- "itoa",
- "pin-project-lite",
- "smallvec",
- "tokio",
- "want",
-]
-
-[[package]]
-name = "hyper-util"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-util",
- "http 1.4.1",
- "http-body 1.0.1",
- "hyper 1.10.1",
- "ipnet",
- "libc",
- "percent-encoding",
- "pin-project-lite",
- "socket2 0.6.0",
- "tokio",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -1375,7 +1293,6 @@ dependencies = [
  "qos_p256 0.10.0",
  "qos_test_primitives",
  "rand 0.9.4",
- "reqwest",
  "rustls",
  "serde_json",
  "sha2",
@@ -2387,37 +2304,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
-name = "reqwest"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http 1.4.1",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.10.1",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "sync_wrapper 1.0.2",
- "tokio",
- "tower 0.5.3",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2872,15 +2758,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
-name = "sync_wrapper"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3115,39 +2992,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project-lite",
- "sync_wrapper 1.0.2",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
-dependencies = [
- "bitflags 2.9.4",
- "bytes",
- "futures-util",
- "http 1.4.1",
- "http-body 1.0.1",
- "pin-project-lite",
- "tower 0.5.3",
- "tower-layer",
- "tower-service",
- "url",
-]
-
-[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3377,19 +3221,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
-dependencies = [
- "cfg-if",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3419,16 +3250,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,9 +192,9 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
  "itoa",
  "matchit",
  "memchr",
@@ -199,9 +205,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
 ]
@@ -215,8 +221,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
@@ -1054,13 +1060,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.4.1",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1095,8 +1134,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1106,6 +1145,49 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "hyper 1.10.1",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2 0.6.0",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1293,11 +1375,14 @@ dependencies = [
  "qos_p256 0.10.0",
  "qos_test_primitives",
  "rand 0.9.4",
+ "reqwest",
  "rustls",
  "serde_json",
+ "sha2",
  "tokio",
  "tokio-rustls",
  "ureq",
+ "url",
  "webpki-roots",
  "zeroize",
 ]
@@ -2302,6 +2387,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.10.1",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2756,6 +2872,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2990,6 +3115,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.9.4",
+ "bytes",
+ "futures-util",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "pin-project-lite",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3219,6 +3377,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3248,6 +3419,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-trait"
 version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +678,15 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "etherparse"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ac016aaf11dfe643edcd088a166234bfcb72e7f06691abfcf21e9af524037f4"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "ff"
@@ -1963,6 +1978,7 @@ version = "0.10.0"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "borsh",
+ "etherparse",
  "futures",
  "libc",
  "nix 0.30.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,6 @@ qos_test_primitives = { path = "src/qos_test_primitives", version = "0.10.0" }
 
 # used for pivot_download integration/example only
 url = { version = "2.5.7", default-features = false }
-reqwest = { version = "0.13.4", default-features = false }
 
 # custom profile for qos_bridge/egress so we can abort in case of failures in any thread if using egress
 [profile.release-panic-abort]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ aws-nitro-enclaves-nsm-api = { version = "0.4", default-features = false }
 axum = { version = "0.6.20", features = ["http1", "tokio", "json"], default-features = false }
 borsh = { version = "1.0", features = ["std", "derive"], default-features = false }
 chunked_transfer = { version = "1.5.0", default-features = false }
+etherparse = { version = "0.20.1", default-features = false }
 futures = { version = "0.3.30" }
 der = { version = "0.7", default-features = false }
 hex-literal = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,11 @@ qos_nsm = { path = "src/qos_nsm", version = "0.10.0", default-features = false }
 qos_p256 = { path = "src/qos_p256", version = "0.10.0" }
 qos_test_primitives = { path = "src/qos_test_primitives", version = "0.10.0" }
 
+# custom profile for qos_bridge so we can abort in case of failures in any thread
+[profile.qos-bridge]
+inherits = "release"
+panic = "abort"
+
 # Option for the future: build all QOS applications with additional runtime checks
 # to intentionally panic on integer overflows instead of continuing execution
 # with unexpected values.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,10 @@ qos_nsm = { path = "src/qos_nsm", version = "0.10.0", default-features = false }
 qos_p256 = { path = "src/qos_p256", version = "0.10.0" }
 qos_test_primitives = { path = "src/qos_test_primitives", version = "0.10.0" }
 
+# used for pivot_download integration/example only
+url = { version = "2.5.7", default-features = false }
+reqwest = { version = "0.13.4", default-features = false }
+
 # custom profile for qos_bridge/egress so we can abort in case of failures in any thread if using egress
 [profile.release-panic-abort]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,8 +113,8 @@ qos_nsm = { path = "src/qos_nsm", version = "0.10.0", default-features = false }
 qos_p256 = { path = "src/qos_p256", version = "0.10.0" }
 qos_test_primitives = { path = "src/qos_test_primitives", version = "0.10.0" }
 
-# custom profile for qos_bridge so we can abort in case of failures in any thread
-[profile.qos-bridge]
+# custom profile for qos_bridge/egress so we can abort in case of failures in any thread if using egress
+[profile.release-panic-abort]
 inherits = "release"
 panic = "abort"
 

--- a/Containerfile.qemu
+++ b/Containerfile.qemu
@@ -5,6 +5,8 @@ FROM stagex/gen_initramfs:6.8@sha256:f5b9271cca6003e952cbbb9ef041ffa92ba328894f5
 #FROM stagex/linux-nitro:5.19.6@sha256:e6c8a861f9b18edfad56b1aa130feb822a25987c71e2b2932b020750dd7325bc AS linux-nitro
 FROM stagex/linux-nitro:sx2024.03.0@sha256:073c4603686e3bdc0ed6755fee3203f6f6f1512e0ded09eaea8866b002b04264 AS linux-nitro
 FROM stagex/core-libunwind:1.7.2@sha256:eb66122d8fc543f5e2f335bb1616f8c3a471604383e2c0a9df4a8e278505d3bc AS libunwind
+FROM stagex/iproute2:sx2024.11.0@sha256:65da03aa94d17dd6310b022f426a6cc8b3c55bb267e4bac1697bc57d6c850570 AS iproute2
+FROM stagex/musl:sx2024.11.0@sha256:d7f6c365f5724c65cadb2b96d9f594e46132ceb366174c89dbf7554897f2bc53 AS musl
 
 FROM ghcr.io/tkhq/base/rust:sha-bfaaeb25fd43e17468e6583208166fc7c4313226@sha256:9868bdab0b602a487ec9ea42995992ac0a381d7fc34d5ba9c41d14c18be716d2 AS build
 ADD . /src/
@@ -19,6 +21,12 @@ RUN cargo build ${CARGOFLAGS}
 RUN cp target/x86_64-unknown-linux-musl/release/init /
 RUN file /init | grep "static-pie"
 
+FROM build AS build-qos-bridge
+WORKDIR /src/src/qos_bridge
+RUN cargo build --features vm ${CARGOFLAGS}
+RUN cp ../../target/x86_64-unknown-linux-musl/release/qos_bridge /
+RUN file /qos_bridge | grep "static-pie"
+
 FROM build AS build-eif
 WORKDIR /build_cpio
 COPY --from=eif_build . /
@@ -26,6 +34,9 @@ COPY --from=gen_initramfs . /
 COPY --from=libunwind . /
 COPY --from=build-init /init .
 COPY --from=linux-nitro /nsm.ko .
+COPY --from=iproute2 . /
+COPY --from=musl . /
+COPY --from=build-qos-bridge /qos_bridge .
 COPY <<-EOF initramfs.list
 	file /init     init    0700 0 0
 	file /nsm.ko   nsm.ko  0600 0 0
@@ -45,6 +56,9 @@ COPY <<-EOF initramfs.list
 	dir  /dev/shm          0755 0 0
 	dir  /dev/pts          0755 0 0
 	nod  /dev/console      0600 0 0 c 5 1
+	file /qos_bridge       /qos_bridge      0700 0 0
+	file /usr/sbin/ip      /usr/sbin/ip     0700 0 0
+	file /lib/ld-musl-x86  /usr/lib/ld-musl-x86_64.so.1                   0700 0 0
 EOF
 ENV CPIO_TIMESTAMP=1
 ENV KBUILD_BUILD_TIMESTAMP=1

--- a/Containerfile.qemu
+++ b/Containerfile.qemu
@@ -48,7 +48,6 @@ COPY <<-EOF initramfs.list
 	dir  /proc             0755 0 0
 	dir  /sys              0755 0 0
 	dir  /usr              0755 0 0
-	dir  /lib              0755 0 0
 	dir  /usr/bin          0755 0 0
 	dir  /usr/sbin         0755 0 0
 	dir  /usr/lib          0755 0 0

--- a/Containerfile.qemu
+++ b/Containerfile.qemu
@@ -17,15 +17,15 @@ ENV RUSTFLAGS='-C target-feature=+crt-static'
 
 FROM build AS build-init
 WORKDIR /src/src/init
-RUN cargo build ${CARGOFLAGS}
+RUN cargo build --features egress ${CARGOFLAGS}
 RUN cp target/x86_64-unknown-linux-musl/release/init /
 RUN file /init | grep "static-pie"
 
-FROM build AS build-qos-bridge
+FROM build AS build-egress
 WORKDIR /src/src/qos_bridge
-RUN cargo build --features vm ${CARGOFLAGS}
-RUN cp ../../target/x86_64-unknown-linux-musl/release/qos_bridge /
-RUN file /qos_bridge | grep "static-pie"
+RUN cargo build --features egress ${CARGOFLAGS} --bin egress
+RUN cp ../../target/x86_64-unknown-linux-musl/release/egress /egress
+RUN file /egress | grep "static-pie"
 
 FROM build AS build-eif
 WORKDIR /build_cpio
@@ -36,7 +36,7 @@ COPY --from=build-init /init .
 COPY --from=linux-nitro /nsm.ko .
 COPY --from=iproute2 . /
 COPY --from=musl . /
-COPY --from=build-qos-bridge /qos_bridge .
+COPY --from=build-egress /egress .
 COPY <<-EOF initramfs.list
 	file /init     init    0700 0 0
 	file /nsm.ko   nsm.ko  0600 0 0
@@ -56,7 +56,7 @@ COPY <<-EOF initramfs.list
 	dir  /dev/shm          0755 0 0
 	dir  /dev/pts          0755 0 0
 	nod  /dev/console      0600 0 0 c 5 1
-	file /qos_bridge       /qos_bridge      0700 0 0
+	file /egress   /egress 0700 0 0
 	file /usr/sbin/ip      /usr/sbin/ip     0700 0 0
 	file /lib/ld-musl-x86  /usr/lib/ld-musl-x86_64.so.1                   0700 0 0
 EOF

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ qemu-stop:
 /tmp/vhost4.socket:
 	vhost-device-vsock --vm guest-cid=4,forward-cid=1,forward-listen=9001,socket=/tmp/vhost4.socket &
 
-out/nitro.tar: Containerfile.qemu src/init/* /tmp/vhost4.socket
+out/nitro.tar: Containerfile.qemu src/init/* src/qos_core/Cargo.toml src/qos_core/src/**/*.rs /tmp/vhost4.socket
 	docker build -t qos-qemu-base -f Containerfile.qemu . --output type=tar,dest=out/nitro.tar
 
 out/nitro.eif: out/nitro.tar

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 include src/macros.mk
 
+PIVOT_BIN ?= pivot_download
+PIVOT_ARGS ?= [http://objdump.katona.me/program.bin,109.123.250.238:0]
 REGISTRY := local
 CARGO_WORKSPACE_FILES := Cargo.toml Cargo.lock
 .DEFAULT_GOAL :=
@@ -43,10 +45,6 @@ shell: out/.common-loaded
 		qos-local/common:latest \
 		/bin/bash
 
-.PHONY: build
-build:
-	cargo build --all-features --locked
-
 qemu: out/nitro.eif /tmp/vhost4.socket
 	qemu-system-x86_64 -M nitro-enclave,vsock=c,id=hello-world -kernel out/nitro.eif -nographic -m 4G --enable-kvm -cpu host -chardev socket,id=c,path=/tmp/vhost4.socket
 
@@ -57,22 +55,42 @@ stop:
 	rm -f /tmp/vhost4.socket
 
 /tmp/vhost4.socket:
-	vhost-device-vsock --vm guest-cid=4,forward-cid=1,forward-listen=9001,socket=/tmp/vhost4.socket &
+	vhost-device-vsock --vm guest-cid=4,forward-cid=1,forward-listen=3000+9001+9002,socket=/tmp/vhost4.socket &
 
 .PHONY: host
 host:
-	cargo run -p qos_host --features qemu -- \
+	cargo run --locked -p qos_host --features qemu -- \
 		--host-ip 0.0.0.0 \
 		--host-port 3001 \
 		--cid 1 \
 		--port 9001
 
 .PHONY: bridge
-bridge:
-	cargo run -p qos_bridge --bin ingress --features egress -- \
+bridge: target/x86_64-unknown-linux-musl/release-panic-abort/egress
+	cargo run -p qos_bridge --locked --bin ingress --features egress,qemu -- \
 		--cid 1 \
 		--control-url http://127.0.0.1:3001/qos \
-		--egress-bin-path ./target/debug/
+		--vsock-to-host false \
+		--egress-bin-path target/x86_64-unknown-linux-musl/release-panic-abort/egress
+
+.PHONY: boot
+boot:
+	cd src/integration && cargo run --locked -p integration --example boot_enclave -- ../../target/x86_64-unknown-linux-musl/release/examples/$(PIVOT_BIN) $(PIVOT_ARGS)
+
+# used for egress testing as our pivot, expects a single http url for file download
+target/x86_64-unknown-linux-musl/release/examples/pivot_download: \
+	src/integration/examples/pivot_download.rs \
+	src/integration/Cargo.toml \
+	Cargo.toml
+	cargo build --release --locked --target x86_64-unknown-linux-musl -p integration --example pivot_download
+
+# used for egress testing as our separate egress host proxy
+target/x86_64-unknown-linux-musl/release-panic-abort/egress: \
+	src/qos_bridge/Cargo.toml \
+	src/qos_bridge/src/bin/egress.rs \
+	src/qos_bridge/src/*.rs \
+	Cargo.toml
+	cargo build --profile release-panic-abort --features egress,qemu --locked --target x86_64-unknown-linux-musl -p qos_bridge --bin egress
 
 out/nitro.eif: \
 	src/images/qemu/Containerfile \

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,9 @@ default: \
 	out/qos_client/index.json \
 	out/qos_host/index.json \
 	out/qos_enclave/index.json \
-	out/qos_bridge/index.json
+	out/qos_bridge/index.json \
+	out/qos_enclave_egress/index.json \
+	out/qos_bridge_egress/index.json
 
 .PHONY: test
 test: out/.common-loaded
@@ -70,6 +72,7 @@ out/qos_enclave/index.json: \
 		src/init \
 		src/qos_enclave \
 		src/qos_core \
+		src/qos_bridge \
 		src/qos_aws \
 		src/qos_system \
 	)

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,19 @@ out/qos_enclave/index.json: \
 	)
 	$(call build,qos_enclave)
 
+out/qos_enclave_egress/index.json: \
+	out/common/index.json \
+	$(CARGO_WORKSPACE_FILES) \
+	src/images/qos_enclave_egress/Containerfile \
+	$(shell git ls-files \
+		src/init \
+		src/qos_enclave \
+		src/qos_core \
+		src/qos_aws \
+		src/qos_system \
+	)
+	$(call build,qos_enclave_egress)
+
 out/qos_host/index.json: \
 	out/common/index.json \
 	$(CARGO_WORKSPACE_FILES) \
@@ -111,6 +124,19 @@ out/qos_bridge/index.json: \
 		src/qos_nsm \
 	)
 	$(call build,qos_bridge)
+
+out/qos_bridge_egress/index.json: \
+	out/common/index.json \
+	$(CARGO_WORKSPACE_FILES) \
+	src/images/qos_bridge_egress/Containerfile \
+	$(shell git ls-files \
+		src/qos_bridge \
+		src/qos_host \
+		src/qos_core \
+		src/qos_hex \
+		src/qos_nsm \
+	)
+	$(call build,qos_bridge_egress)
 
 out/common/index.json: \
 	src/images/common/Containerfile

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ shell: out/.common-loaded
 		qos-local/common:latest \
 		/bin/bash
 
-qemu: out/nitro.eif
+qemu: out/nitro.eif /tmp/vhost4.socket
 	qemu-system-x86_64 -M nitro-enclave,vsock=c,id=hello-world -kernel out/nitro.eif -nographic -m 4G --enable-kvm -cpu host -chardev socket,id=c,path=/tmp/vhost4.socket
 
 .PHONY: qemu-stop
@@ -55,12 +55,19 @@ qemu-stop:
 /tmp/vhost4.socket:
 	vhost-device-vsock --vm guest-cid=4,forward-cid=1,forward-listen=9001,socket=/tmp/vhost4.socket &
 
+.PHONY: host
+host:
+	cargo run -p qos_host -- \
+		--host-ip 0.0.0.0 \
+		--host-port 3001 \
+		--cid 1 \
+		--port 9001
+
 out/nitro.eif: \
 	src/images/qemu/Containerfile \
 	Cargo.toml \
 	Cargo.lock \
-	$(shell git ls-files src/init src/qos_core src/qos_bridge) \
-	/tmp/vhost4.socket
+	$(shell git ls-files src/init src/qos_core src/qos_bridge)
 	docker build -t qos-qemu-base -f src/images/qemu/Containerfile . --output type=tar,dest=out/nitro.tar
 	tar -xf out/nitro.tar -C out && rm -f out/nitro.tar
 

--- a/Makefile
+++ b/Makefile
@@ -53,16 +53,15 @@ qemu-stop:
 /tmp/vhost4.socket:
 	vhost-device-vsock --vm guest-cid=4,forward-cid=1,forward-listen=9001,socket=/tmp/vhost4.socket &
 
-out/nitro.tar: \
-	Containerfile.qemu \
+out/nitro.eif: \
+	src/images/qemu/Containerfile \
 	Cargo.toml \
 	Cargo.lock \
 	$(shell git ls-files src/init src/qos_core src/qos_bridge) \
 	/tmp/vhost4.socket
-	docker build -t qos-qemu-base -f Containerfile.qemu . --output type=tar,dest=out/nitro.tar
-
-out/nitro.eif: out/nitro.tar
+	docker build -t qos-qemu-base -f src/images/qemu/Containerfile . --output type=tar,dest=out/nitro.tar
 	tar -xf out/nitro.tar -C out
+	rm -f out/nitro.tar
 
 out/qos_enclave/index.json: \
 	out/common/index.json \

--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,7 @@ out/nitro.eif: \
 	$(shell git ls-files src/init src/qos_core src/qos_bridge) \
 	/tmp/vhost4.socket
 	docker build -t qos-qemu-base -f src/images/qemu/Containerfile . --output type=tar,dest=out/nitro.tar
-	tar -xf out/nitro.tar -C out
-	rm -f out/nitro.tar
+	tar -xf out/nitro.tar -C out && rm -f out/nitro.tar
 
 out/qos_enclave/index.json: \
 	out/common/index.json \

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,12 @@ qemu-stop:
 /tmp/vhost4.socket:
 	vhost-device-vsock --vm guest-cid=4,forward-cid=1,forward-listen=9001,socket=/tmp/vhost4.socket &
 
-out/nitro.tar: Containerfile.qemu src/init/* src/qos_core/Cargo.toml src/qos_core/src/**/*.rs /tmp/vhost4.socket
+out/nitro.tar: \
+	Containerfile.qemu \
+	Cargo.toml \
+	Cargo.lock \
+	$(shell git ls-files src/init src/qos_core src/qos_bridge) \
+	/tmp/vhost4.socket
 	docker build -t qos-qemu-base -f Containerfile.qemu . --output type=tar,dest=out/nitro.tar
 
 out/nitro.eif: out/nitro.tar

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include src/macros.mk
 
 PIVOT_BIN ?= pivot_download
-PIVOT_ARGS ?= [http://objdump.katona.me/program.bin,109.123.250.238:0]
+PIVOT_ARGS ?= [http://objdump.katona.me/program.bin,109.123.250.238:80]
 REGISTRY := local
 CARGO_WORKSPACE_FILES := Cargo.toml Cargo.lock
 .DEFAULT_GOAL :=

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ shell: out/.common-loaded
 qemu: out/nitro.eif /tmp/vhost4.socket
 	qemu-system-x86_64 -M nitro-enclave,vsock=c,id=hello-world -kernel out/nitro.eif -nographic -m 4G --enable-kvm -cpu host -chardev socket,id=c,path=/tmp/vhost4.socket
 
-.PHONY: qemu-stop
-qemu-stop:
+.PHONY: stop
+stop:
 	-killall qemu-system-x86_64
 	-killall vhost-device-vsock
 	rm -f /tmp/vhost4.socket
@@ -57,7 +57,7 @@ qemu-stop:
 
 .PHONY: host
 host:
-	cargo run -p qos_host -- \
+	cargo run -p qos_host --features qemu -- \
 		--host-ip 0.0.0.0 \
 		--host-port 3001 \
 		--cid 1 \

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,10 @@ shell: out/.common-loaded
 		qos-local/common:latest \
 		/bin/bash
 
+.PHONY: build
+build:
+	cargo build --all-features --locked
+
 qemu: out/nitro.eif /tmp/vhost4.socket
 	qemu-system-x86_64 -M nitro-enclave,vsock=c,id=hello-world -kernel out/nitro.eif -nographic -m 4G --enable-kvm -cpu host -chardev socket,id=c,path=/tmp/vhost4.socket
 
@@ -62,6 +66,13 @@ host:
 		--host-port 3001 \
 		--cid 1 \
 		--port 9001
+
+.PHONY: bridge
+bridge:
+	cargo run -p qos_bridge --bin ingress --features egress -- \
+		--cid 1 \
+		--control-url http://127.0.0.1:3001/qos \
+		--egress-bin-path ./target/debug/
 
 out/nitro.eif: \
 	src/images/qemu/Containerfile \

--- a/README.md
+++ b/README.md
@@ -85,20 +85,33 @@ PRs also need to pass the `build-linux-only` job (part of the `pr` workflow). Th
 
 ### Running in qemu
 
-NOTE: this has only been tested on a linux x86_64 host.
+NOTE: this has only been tested on a linux x86_64 host
+
+#### Dependencies
+
 Some additional dependencies are needed in order to run `qos` in the `nitro-enclave` machine in `qemu`.
 
 1. [vhost-device-vsock](https://github.com/rust-vmm/vhost-device/blob/main/vhost-device-vsock/README.md) is required to provide the hypervisor link for the vsock
 2. [qemu](https://www.qemu.org/) itself needs to be installed, `v11.0.0` or later
 
-#### Bare bones qos
+#### Egress support on host
+
+To setup the egress tunnel you need root priviledges on the host machine and know your main internet route interface.
+Run `src/scripts/enclave_egress_interfaces.sh <interface>` after each boot to provide the egress tunnel setup.
+
+#### Running
 
 Run `make qemu` to start a bare-bones qos instance that will await boot instructions.
-This initiates local vsock on cid `1` and port `9001` and starts the enclave. The unix socket connector is at `/tmp/vhost4.socket`.
+This initiates local vsock on cid `1` and port `9001` for control and `9002` for egress and starts the enclave. The unix socket connector is at `/tmp/vhost4.socket`.
 
-You can follow up by running `qos_host` and pointing to the right vsock and sending in the boot instructions via `qos_client` afterwards.
+You can follow up by running `make host` and booting up the enclave.
+You can also run the bridges by running `make bridge` which expects port `3000` to be used for the app host port.
+Egress is enabled by default for the qemu setup and should start provided the manifest has egress defined.
 
-To stop the enclave and qemu run `make qemu-stop`.
+
+To do a boot standard without needing manual steps, run `make boot`. You can override the pivot binary and arguments used for this by providing them in the `PIVOT_BIN` and `PIVOT_ARGS` env vars (don't forget that pivot args are in the format of `[arg1,arg2]`). The default program will attempt a download of a ~1MB file.
+
+To stop the enclave and qemu run `make stop`.
 
 ## Releases
 

--- a/src/images/qemu/Containerfile
+++ b/src/images/qemu/Containerfile
@@ -67,7 +67,7 @@ RUN <<-EOF
 	find . -exec touch -hcd "@0" "{}" +
     mkdir /build_eif
 	gen_init_cpio -t 1 initramfs.list > /build_eif/rootfs.cpio
-	touch -hcd "@0" rootfs.cpio
+	touch -hcd "@0" /build_eif/rootfs.cpio
 EOF
 WORKDIR /build_eif
 COPY --from=linux-nitro /bzImage .
@@ -78,7 +78,7 @@ RUN eif_build \
 	--kernel_config linux.config \
 	--pcrs_output /nitro.pcrs \
 	--output /nitro.eif \
-	--cmdline 'reboot=k initrd=0x2000000,3228672 root=/dev/ram0 panic=1 pci=off nomodules console=ttyS0 i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd'
+	--cmdline "reboot=k initrd=0x2000000 root=/dev/ram0 panic=1 pci=off nomodules console=ttyS0 i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd"
 
 # Starting "FROM scratch" is important here given this interacts with the nitro enclave to boot it
 # No shell, no access to "core", just the bare minimum.

--- a/src/images/qemu/Containerfile
+++ b/src/images/qemu/Containerfile
@@ -48,6 +48,7 @@ COPY <<-EOF initramfs.list
 	dir  /proc             0755 0 0
 	dir  /sys              0755 0 0
 	dir  /usr              0755 0 0
+	dir  /lib              0755 0 0
 	dir  /usr/bin          0755 0 0
 	dir  /usr/sbin         0755 0 0
 	dir  /usr/lib          0755 0 0

--- a/src/images/qemu/Containerfile
+++ b/src/images/qemu/Containerfile
@@ -17,7 +17,7 @@ ENV RUSTFLAGS='-C target-feature=+crt-static'
 
 FROM build AS build-init
 WORKDIR /src/src/init
-RUN cargo build --features egress ${CARGOFLAGS}
+RUN cargo build --features egress,qemu ${CARGOFLAGS}
 RUN cp target/x86_64-unknown-linux-musl/release/init /
 RUN file /init | grep "static-pie"
 

--- a/src/images/qemu/Containerfile
+++ b/src/images/qemu/Containerfile
@@ -24,7 +24,7 @@ RUN file /init | grep "static-pie"
 FROM build AS build-egress
 ENV CARGOFLAGS="--locked --no-default-features --profile release-panic-abort --target ${TARGET}"
 WORKDIR /src/src/qos_bridge
-RUN cargo build --features egress ${CARGOFLAGS} --bin egress
+RUN cargo build --features egress,qemu ${CARGOFLAGS} --bin egress
 RUN cp ../../target/x86_64-unknown-linux-musl/release-panic-abort/egress /egress
 RUN file /egress | grep "static-pie"
 
@@ -57,7 +57,7 @@ COPY <<-EOF initramfs.list
 	dir  /dev/shm          0755 0 0
 	dir  /dev/pts          0755 0 0
 	nod  /dev/console      0600 0 0 c 5 1
-	file /egress   /egress 0700 0 0
+	file /egress   egress 0700 0 0
 	file /usr/sbin/ip      /usr/sbin/ip     0700 0 0
 	file /lib/ld-musl-x86  /usr/lib/ld-musl-x86_64.so.1                   0700 0 0
 EOF

--- a/src/images/qemu/Containerfile
+++ b/src/images/qemu/Containerfile
@@ -22,9 +22,10 @@ RUN cp target/x86_64-unknown-linux-musl/release/init /
 RUN file /init | grep "static-pie"
 
 FROM build AS build-egress
+ENV CARGOFLAGS="--locked --no-default-features --profile release-panic-abort --target ${TARGET}"
 WORKDIR /src/src/qos_bridge
 RUN cargo build --features egress ${CARGOFLAGS} --bin egress
-RUN cp ../../target/x86_64-unknown-linux-musl/release/egress /egress
+RUN cp ../../target/x86_64-unknown-linux-musl/release-panic-abort/egress /egress
 RUN file /egress | grep "static-pie"
 
 FROM build AS build-eif

--- a/src/images/qos_bridge/Containerfile
+++ b/src/images/qos_bridge/Containerfile
@@ -4,7 +4,7 @@ ADD . /src
 FROM base AS build
 RUN <<-EOF
 	set -eux
-	cd /src && cargo build ${CARGOFLAGS} --features egress -p qos_bridge --bin ingress
+	cd /src && cargo build ${CARGOFLAGS} -p qos_bridge --bin ingress
 	cp /src/target/${TARGET}/release/ingress /qos_bridge
 	file /qos_bridge | grep "static-pie"
 EOF

--- a/src/images/qos_bridge/Containerfile
+++ b/src/images/qos_bridge/Containerfile
@@ -4,8 +4,8 @@ ADD . /src
 FROM base AS build
 RUN <<-EOF
 	set -eux
-	cd /src && cargo build ${CARGOFLAGS} -p qos_bridge
-	cp /src/target/${TARGET}/release/qos_bridge /
+	cd /src && cargo build ${CARGOFLAGS} --features egress -p qos_bridge --bin ingress
+	cp /src/target/${TARGET}/release/ingress /qos_bridge
 	file /qos_bridge | grep "static-pie"
 EOF
 

--- a/src/images/qos_bridge_egress/Containerfile
+++ b/src/images/qos_bridge_egress/Containerfile
@@ -1,0 +1,23 @@
+FROM common AS base
+ADD . /src
+
+FROM base AS build
+RUN <<-EOF
+	set -eux
+	cd /src && \
+		cargo build ${CARGOFLAGS} -p qos_bridge --bin ingress &&
+		cargo build ${CARGOFLAGS} -p qos_bridge --bin egress --features egress
+	cp /src/target/${TARGET}/release/ingress /qos_bridge
+	cp /src/target/${TARGET}/release/egress /qos_egress
+	file /qos_bridge | grep "static-pie"
+	file /qos_egress | grep "static-pie"
+EOF
+
+FROM base AS install
+WORKDIR /rootfs
+COPY --from=build /qos_bridge .
+RUN find . -exec touch -hcd "@0" "{}" +
+
+FROM scratch AS package
+COPY --from=install /rootfs .
+ENTRYPOINT ["/qos_bridge"]

--- a/src/images/qos_bridge_egress/Containerfile
+++ b/src/images/qos_bridge_egress/Containerfile
@@ -16,6 +16,7 @@ EOF
 FROM base AS install
 WORKDIR /rootfs
 COPY --from=build /qos_bridge .
+COPY --from=build /qos_egress .
 RUN find . -exec touch -hcd "@0" "{}" +
 
 FROM scratch AS package

--- a/src/images/qos_enclave/Containerfile
+++ b/src/images/qos_enclave/Containerfile
@@ -27,14 +27,15 @@ RUN file /qos_enclave | grep "static-pie"
 
 FROM base AS build-init
 WORKDIR /qos/src/init
-RUN --network=none cargo build ${CARGOFLAGS}
+RUN --network=none cargo build --features egress ${CARGOFLAGS}
 RUN cp target/x86_64-unknown-linux-musl/release/init /
 RUN file /init | grep "static-pie"
 
 FROM base AS build-egress
+ENV CARGOFLAGS="--locked --no-default-features --profile release-panic-abort --target ${TARGET}"
 WORKDIR /qos/src/qos_bridge
 RUN --network=none cargo build --features egress ${CARGOFLAGS} --bin egress
-RUN cp ../../target/x86_64-unknown-linux-musl/release/egress /egress
+RUN cp ../../target/x86_64-unknown-linux-musl/release-panic-abort/egress /egress
 RUN file /egress | grep "static-pie"
 
 FROM base AS build-eif

--- a/src/images/qos_enclave/Containerfile
+++ b/src/images/qos_enclave/Containerfile
@@ -31,11 +31,11 @@ RUN --network=none cargo build ${CARGOFLAGS}
 RUN cp target/x86_64-unknown-linux-musl/release/init /
 RUN file /init | grep "static-pie"
 
-FROM base AS build-qos-bridge
+FROM base AS build-egress
 WORKDIR /qos/src/qos_bridge
-RUN --network=none cargo build --features vm ${CARGOFLAGS}
-RUN cp ../../target/x86_64-unknown-linux-musl/release/qos_bridge /
-RUN file /qos_bridge | grep "static-pie"
+RUN --network=none cargo build --features egress ${CARGOFLAGS} --bin egress
+RUN cp ../../target/x86_64-unknown-linux-musl/release/egress /egress
+RUN file /egress | grep "static-pie"
 
 FROM base AS build-eif
 WORKDIR /build_cpio
@@ -47,7 +47,7 @@ COPY --from=build-init /init .
 COPY --from=linux-nitro /nsm.ko .
 COPY --from=iproute2 . /
 COPY --from=musl . /
-COPY --from=build-qos-bridge /qos_bridge .
+COPY --from=build-egress /egress .
 COPY <<-EOF initramfs.list
 	file /init     init    0755 0 0
 	file /nsm.ko   nsm.ko  0755 0 0
@@ -66,7 +66,7 @@ COPY <<-EOF initramfs.list
 	dir  /dev/shm          0755 0 0
 	dir  /dev/pts          0755 0 0
 	nod  /dev/console      0600 0 0 c 5 1
-	file /qos_bridge       /qos_bridge      0700 0 0
+	file /egress           /egress          0700 0 0
 	file /usr/sbin/ip      /usr/sbin/ip     0700 0 0
 	file /lib/ld-musl-x86  /usr/lib/ld-musl-x86_64.so.1                   0700 0 0
 EOF

--- a/src/images/qos_enclave/Containerfile
+++ b/src/images/qos_enclave/Containerfile
@@ -57,13 +57,11 @@ COPY <<-EOF initramfs.list
 EOF
 ENV CPIO_TIMESTAMP=1
 ENV KBUILD_BUILD_TIMESTAMP=1
-ENV INITRD_SIZE=3228672
 RUN <<-EOF
 	find . -exec touch -hcd "@0" "{}" +
 	mkdir /build_eif
 	gen_init_cpio -t 1 initramfs.list > /build_eif/rootfs.cpio
-	touch -hcd "@0" rootfs.cpio
-	INITRD_SIZE=$(stat -c %s rootfs.cpio)
+	touch -hcd "@0" /build_eif/rootfs.cpio
 EOF
 WORKDIR /build_eif
 COPY --from=linux-nitro /bzImage .
@@ -74,7 +72,7 @@ RUN eif_build \
 	--kernel_config linux.config \
 	--pcrs_output /nitro.pcrs \
 	--output /nitro.eif \
-	--cmdline 'reboot=k initrd=0x2000000,3228672 root=/dev/ram0 panic=1 pci=off nomodules console=ttyS0 i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd'
+	--cmdline 'reboot=k initrd=0x2000000 root=/dev/ram0 panic=1 pci=off nomodules console=ttyS0 i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd'
 
 FROM scratch AS package
 COPY --from=build-eif /nitro.eif .

--- a/src/images/qos_enclave/Containerfile
+++ b/src/images/qos_enclave/Containerfile
@@ -31,6 +31,12 @@ RUN --network=none cargo build ${CARGOFLAGS}
 RUN cp target/x86_64-unknown-linux-musl/release/init /
 RUN file /init | grep "static-pie"
 
+FROM base AS build-qos-bridge
+WORKDIR /qos/src/qos_bridge
+RUN --network=none cargo build --features vm ${CARGOFLAGS}
+RUN cp ../../target/x86_64-unknown-linux-musl/release/qos_bridge /
+RUN file /qos_bridge | grep "static-pie"
+
 FROM base AS build-eif
 WORKDIR /build_cpio
 COPY --from=eif_build . /
@@ -39,6 +45,7 @@ COPY --from=libunwind . /
 COPY --from=gen_initramfs . /
 COPY --from=build-init /init .
 COPY --from=linux-nitro /nsm.ko .
+COPY --from=build-qos-bridge /qos_bridge .
 COPY <<-EOF initramfs.list
 	file /init     init    0755 0 0
 	file /nsm.ko   nsm.ko  0755 0 0
@@ -58,6 +65,7 @@ COPY <<-EOF initramfs.list
 	dir  /dev/pts          0755 0 0
 	nod  /dev/console      0600 0 0 c 5 1
 	file /usr/sbin/ip      /usr/sbin/ip     0700 0 0
+	file /qos_bridge       /qos_bridge      0700 0 0
 	file /lib/ld-musl-x86  /usr/lib/ld-musl-x86_64.so.1                   0700 0 0
 	file /usr/lib/libc.musl-x86_64.so.1 /usr/lib/libc.musl-x86_64.so.1    0644 0 0
 EOF

--- a/src/images/qos_enclave/Containerfile
+++ b/src/images/qos_enclave/Containerfile
@@ -45,6 +45,8 @@ COPY --from=libunwind . /
 COPY --from=gen_initramfs . /
 COPY --from=build-init /init .
 COPY --from=linux-nitro /nsm.ko .
+COPY --from=iproute2 . /
+COPY --from=musl . /
 COPY --from=build-qos-bridge /qos_bridge .
 COPY <<-EOF initramfs.list
 	file /init     init    0755 0 0
@@ -64,10 +66,9 @@ COPY <<-EOF initramfs.list
 	dir  /dev/shm          0755 0 0
 	dir  /dev/pts          0755 0 0
 	nod  /dev/console      0600 0 0 c 5 1
-	file /usr/sbin/ip      /usr/sbin/ip     0700 0 0
 	file /qos_bridge       /qos_bridge      0700 0 0
+	file /usr/sbin/ip      /usr/sbin/ip     0700 0 0
 	file /lib/ld-musl-x86  /usr/lib/ld-musl-x86_64.so.1                   0700 0 0
-	file /usr/lib/libc.musl-x86_64.so.1 /usr/lib/libc.musl-x86_64.so.1    0644 0 0
 EOF
 ENV CPIO_TIMESTAMP=1
 ENV KBUILD_BUILD_TIMESTAMP=1

--- a/src/images/qos_enclave/Containerfile
+++ b/src/images/qos_enclave/Containerfile
@@ -50,7 +50,6 @@ COPY <<-EOF initramfs.list
 	dir  /usr              0755 0 0
 	dir  /usr/bin          0755 0 0
 	dir  /usr/sbin         0755 0 0
-	dir  /usr/lib          0755 0 0
 	dir  /dev              0755 0 0
 	dir  /dev/shm          0755 0 0
 	dir  /dev/pts          0755 0 0

--- a/src/images/qos_enclave/Containerfile
+++ b/src/images/qos_enclave/Containerfile
@@ -3,6 +3,8 @@ FROM stagex/gen_initramfs:6.8@sha256:f5b9271cca6003e952cbbb9ef041ffa92ba328894f5
 FROM stagex/linux-nitro:sx2024.03.0@sha256:073c4603686e3bdc0ed6755fee3203f6f6f1512e0ded09eaea8866b002b04264 AS linux-nitro
 FROM stagex/core-gcc:15.2.0@sha256:ceae6035d43fe3653e142e638fd78d72950cd51e7a5dba4755d1db081c54de77 AS gcc
 FROM stagex/core-libunwind:1.7.2@sha256:eb66122d8fc543f5e2f335bb1616f8c3a471604383e2c0a9df4a8e278505d3bc AS libunwind
+FROM stagex/iproute2:sx2024.11.0@sha256:65da03aa94d17dd6310b022f426a6cc8b3c55bb267e4bac1697bc57d6c850570 AS iproute2
+FROM stagex/musl:sx2024.11.0@sha256:d7f6c365f5724c65cadb2b96d9f594e46132ceb366174c89dbf7554897f2bc53 AS musl
 
 FROM common AS base
 
@@ -50,10 +52,14 @@ COPY <<-EOF initramfs.list
 	dir  /usr              0755 0 0
 	dir  /usr/bin          0755 0 0
 	dir  /usr/sbin         0755 0 0
+	dir  /usr/lib          0755 0 0
 	dir  /dev              0755 0 0
 	dir  /dev/shm          0755 0 0
 	dir  /dev/pts          0755 0 0
 	nod  /dev/console      0600 0 0 c 5 1
+	file /usr/sbin/ip      /usr/sbin/ip     0700 0 0
+	file /lib/ld-musl-x86  /usr/lib/ld-musl-x86_64.so.1                   0700 0 0
+	file /usr/lib/libc.musl-x86_64.so.1 /usr/lib/libc.musl-x86_64.so.1    0644 0 0
 EOF
 ENV CPIO_TIMESTAMP=1
 ENV KBUILD_BUILD_TIMESTAMP=1

--- a/src/images/qos_enclave/Containerfile
+++ b/src/images/qos_enclave/Containerfile
@@ -57,11 +57,13 @@ COPY <<-EOF initramfs.list
 EOF
 ENV CPIO_TIMESTAMP=1
 ENV KBUILD_BUILD_TIMESTAMP=1
+ENV INITRD_SIZE=3228672
 RUN <<-EOF
 	find . -exec touch -hcd "@0" "{}" +
 	mkdir /build_eif
 	gen_init_cpio -t 1 initramfs.list > /build_eif/rootfs.cpio
 	touch -hcd "@0" rootfs.cpio
+	INITRD_SIZE=$(stat -c %s rootfs.cpio)
 EOF
 WORKDIR /build_eif
 COPY --from=linux-nitro /bzImage .

--- a/src/images/qos_enclave_egress/Containerfile
+++ b/src/images/qos_enclave_egress/Containerfile
@@ -3,6 +3,8 @@ FROM stagex/gen_initramfs:6.8@sha256:f5b9271cca6003e952cbbb9ef041ffa92ba328894f5
 FROM stagex/linux-nitro:sx2024.03.0@sha256:073c4603686e3bdc0ed6755fee3203f6f6f1512e0ded09eaea8866b002b04264 AS linux-nitro
 FROM stagex/core-gcc:15.2.0@sha256:ceae6035d43fe3653e142e638fd78d72950cd51e7a5dba4755d1db081c54de77 AS gcc
 FROM stagex/core-libunwind:1.7.2@sha256:eb66122d8fc543f5e2f335bb1616f8c3a471604383e2c0a9df4a8e278505d3bc AS libunwind
+FROM stagex/iproute2:sx2024.11.0@sha256:65da03aa94d17dd6310b022f426a6cc8b3c55bb267e4bac1697bc57d6c850570 AS iproute2
+FROM stagex/musl:sx2024.11.0@sha256:d7f6c365f5724c65cadb2b96d9f594e46132ceb366174c89dbf7554897f2bc53 AS musl
 
 FROM common AS base
 
@@ -25,9 +27,16 @@ RUN file /qos_enclave | grep "static-pie"
 
 FROM base AS build-init
 WORKDIR /qos/src/init
-RUN --network=none cargo build ${CARGOFLAGS}
+RUN --network=none cargo build --features egress ${CARGOFLAGS}
 RUN cp target/x86_64-unknown-linux-musl/release/init /
 RUN file /init | grep "static-pie"
+
+FROM base AS build-egress
+ENV CARGOFLAGS="--locked --no-default-features --profile release-panic-abort --target ${TARGET}"
+WORKDIR /qos/src/qos_bridge
+RUN --network=none cargo build --features egress ${CARGOFLAGS} --bin egress
+RUN cp ../../target/x86_64-unknown-linux-musl/release-panic-abort/egress /egress
+RUN file /egress | grep "static-pie"
 
 FROM base AS build-eif
 WORKDIR /build_cpio
@@ -37,6 +46,9 @@ COPY --from=libunwind . /
 COPY --from=gen_initramfs . /
 COPY --from=build-init /init .
 COPY --from=linux-nitro /nsm.ko .
+COPY --from=iproute2 . /
+COPY --from=musl . /
+COPY --from=build-egress /egress .
 COPY <<-EOF initramfs.list
 	file /init     init    0755 0 0
 	file /nsm.ko   nsm.ko  0755 0 0
@@ -55,6 +67,9 @@ COPY <<-EOF initramfs.list
 	dir  /dev/shm          0755 0 0
 	dir  /dev/pts          0755 0 0
 	nod  /dev/console      0600 0 0 c 5 1
+	file /egress           /egress          0700 0 0
+	file /usr/sbin/ip      /usr/sbin/ip     0700 0 0
+	file /lib/ld-musl-x86  /usr/lib/ld-musl-x86_64.so.1                   0700 0 0
 EOF
 ENV CPIO_TIMESTAMP=1
 ENV KBUILD_BUILD_TIMESTAMP=1

--- a/src/images/qos_enclave_egress/Containerfile
+++ b/src/images/qos_enclave_egress/Containerfile
@@ -60,6 +60,7 @@ COPY <<-EOF initramfs.list
 	dir  /proc             0755 0 0
 	dir  /sys              0755 0 0
 	dir  /usr              0755 0 0
+	dir  /lib              0755 0 0
 	dir  /usr/bin          0755 0 0
 	dir  /usr/sbin         0755 0 0
 	dir  /usr/lib          0755 0 0

--- a/src/init/Cargo.lock
+++ b/src/init/Cargo.lock
@@ -86,6 +86,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,6 +476,15 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "etherparse"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ac016aaf11dfe643edcd088a166234bfcb72e7f06691abfcf21e9af524037f4"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "ff"
@@ -1186,6 +1201,7 @@ version = "0.10.0"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "borsh",
+ "etherparse",
  "futures",
  "libc",
  "nix 0.30.1",

--- a/src/init/Cargo.toml
+++ b/src/init/Cargo.toml
@@ -17,3 +17,6 @@ tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"], default-
 [[bin]]
 name = "init"
 path = "init.rs"
+
+[features]
+egress = ["qos_core/egress"]

--- a/src/init/Cargo.toml
+++ b/src/init/Cargo.toml
@@ -19,4 +19,7 @@ name = "init"
 path = "init.rs"
 
 [features]
+# Support for egress
 egress = ["qos_core/egress"]
+# Support for localhost qemu setup without forcing host to use root
+qemu = ["qos_core/qemu"]

--- a/src/init/init.rs
+++ b/src/init/init.rs
@@ -1,5 +1,4 @@
 use qos_core::{
-	egress::init_egress_tun,
 	handles::Handles,
 	io::{SocketAddress, VMADDR_NO_FLAGS},
 	reaper::Reaper,
@@ -57,7 +56,8 @@ fn boot() {
 	init_console();
 	init_platform();
 	init_localhost();
-	init_egress_tun();
+	#[cfg(feature = "egress")]
+	qos_core::egress::init_egress_tun();
 }
 
 #[tokio::main]

--- a/src/init/init.rs
+++ b/src/init/init.rs
@@ -57,7 +57,10 @@ fn boot() {
 	init_platform();
 	init_localhost();
 	#[cfg(feature = "egress")]
-	qos_core::egress::init_egress_tun();
+	{
+		dmesg("initializing egress tunnel interface".to_string());
+		qos_core::egress::init_egress_tun();
+	}
 }
 
 #[tokio::main]

--- a/src/init/init.rs
+++ b/src/init/init.rs
@@ -78,6 +78,9 @@ async fn main() {
 		PIVOT_FILE.to_string(),
 	);
 
+	#[cfg(feature = "qemu")]
+	const START_PORT: u32 = 9001; // avoid root level ports since we match on local host
+	#[cfg(not(feature = "qemu"))]
 	const START_PORT: u32 = 3;
 	let core_socket =
 		SocketAddress::new_vsock(cid, START_PORT, VMADDR_NO_FLAGS);

--- a/src/init/init.rs
+++ b/src/init/init.rs
@@ -1,8 +1,9 @@
 use qos_core::{
-	EPHEMERAL_KEY_FILE, MANIFEST_FILE, PIVOT_FILE, QUORUM_FILE,
+	egress::init_egress_tun,
 	handles::Handles,
 	io::{SocketAddress, VMADDR_NO_FLAGS},
 	reaper::Reaper,
+	EPHEMERAL_KEY_FILE, MANIFEST_FILE, PIVOT_FILE, QUORUM_FILE,
 };
 use qos_nsm::Nsm;
 use qos_system::{dmesg, freopen, get_local_cid, mount, reboot};
@@ -56,6 +57,7 @@ fn boot() {
 	init_console();
 	init_platform();
 	init_localhost();
+	init_egress_tun();
 }
 
 #[tokio::main]

--- a/src/integration/Cargo.toml
+++ b/src/integration/Cargo.toml
@@ -43,5 +43,4 @@ ureq = { workspace = true, features = ["json"] }
 qos_core_legacy = { package = "qos_core", version = "0.7", default-features = false }
 # src/bin/pivot_download.rs to test egress
 sha2 = { workspace = true }
-reqwest = { workspace = true, features = ["blocking"] }
 url = { workspace = true }

--- a/src/integration/Cargo.toml
+++ b/src/integration/Cargo.toml
@@ -41,3 +41,7 @@ tokio-rustls = { workspace = true }
 rand = { workspace = true, features = ["thread_rng"] }
 ureq = { workspace = true, features = ["json"] }
 qos_core_legacy = { package = "qos_core", version = "0.7", default-features = false }
+# src/bin/pivot_download.rs to test egress
+sha2 = { workspace = true }
+reqwest = { workspace = true, features = ["blocking"] }
+url = { workspace = true }

--- a/src/integration/examples/boot_enclave.rs
+++ b/src/integration/examples/boot_enclave.rs
@@ -20,7 +20,7 @@ use qos_core::protocol::{
 use qos_crypto::sha_256;
 use qos_host::EnclaveInfo;
 use qos_p256::P256Pair;
-use qos_test_primitives::{ChildWrapper, PathWrapper};
+use qos_test_primitives::PathWrapper;
 
 #[tokio::main]
 async fn main() {
@@ -33,12 +33,6 @@ async fn main() {
 	let tmp = PathWrapper::from("/tmp/enclave-example");
 	let _ = PathWrapper::from(PIVOT_HASH_PATH);
 	fs::create_dir_all(&tmp).unwrap();
-
-	let usock = tmp.join("example.sock");
-	let secret_path = tmp.join("example.secret");
-	let pivot_path = tmp.join("example.pivot");
-	let manifest_path = tmp.join("example.manifest");
-	let eph_path = tmp.join("ephemeral_key.secret");
 
 	let boot_dir = PathWrapper::from("boot-dir");
 	fs::create_dir_all(&boot_dir).unwrap();
@@ -65,11 +59,11 @@ async fn main() {
 
 	// -- CLIENT create manifest.
 	let pivot_args = std::env::args().nth(2).expect("No pivot args provided");
-	let pivot_env = "pivot_env_var=will be set";
 	let cli_manifest_path = boot_dir.join("manifest");
 	let app_host_port = 3000;
 
-	assert!(Command::new(integration::QOS_CLIENT_PATH)
+	assert!(
+		Command::new(integration::QOS_CLIENT_PATH)
 		.args([
 			"generate-manifest",
 			"--nonce",
@@ -88,8 +82,6 @@ async fn main() {
 			cli_manifest_path.to_str().unwrap(),
 			"--pivot-args",
 			&pivot_args,
-			"--pivot-env",
-			pivot_env,
 			"--manifest-set-dir",
 			"./mock/keys/manifest-set",
 			"--share-set-dir",
@@ -98,8 +90,10 @@ async fn main() {
 			"./mock/keys/manifest-set",
 			"--quorum-key-path",
 			"./mock/namespaces/quit-coding-to-vape/quorum_key.pub",
+			"--debug-mode",
+			"true",
 			"--bridge-config",
-			&format!("[{{\"type\": \"server\", \"port\": {app_host_port}, \"host\": \"0.0.0.0\"}}]"),
+			&format!("[{{\"type\": \"server\", \"port\": {app_host_port}, \"host\": \"0.0.0.0\"}},{{\"type\": \"client\", \"port\": 0}}]"),
 		])
 		.spawn()
 		.unwrap()
@@ -222,17 +216,6 @@ async fn main() {
 		assert_eq!(&stdout.next().unwrap().unwrap(), "(y/n)");
 		stdin.write_all("y\n".as_bytes()).expect("Failed to write to stdin");
 
-		assert_eq!(
-			&stdout.next().unwrap().unwrap(),
-			"Are these the correct pivot env vars:"
-		);
-		assert_eq!(
-			&stdout.next().unwrap().unwrap(),
-			"{\"pivot_env_var\": Plain { value: \"will be set\" }}?"
-		);
-		assert_eq!(&stdout.next().unwrap().unwrap(), "(y/n)");
-		stdin.write_all("y\n".as_bytes()).expect("Failed to write to stdin");
-
 		// Wait for the command to write the approval and exit
 		assert!(child.wait().unwrap().success());
 
@@ -253,44 +236,6 @@ async fn main() {
 			personal_pair.public_key().to_bytes(),
 		);
 	}
-
-	// -- ENCLAVE start enclave
-	let mut _enclave_child_process: ChildWrapper =
-		Command::new(integration::QOS_CORE_PATH)
-			.args([
-				"--usock",
-				usock.to_str().unwrap(),
-				"--quorum-file",
-				secret_path.to_str().unwrap(),
-				"--pivot-file",
-				pivot_path.to_str().unwrap(),
-				"--ephemeral-file",
-				eph_path.to_str().unwrap(),
-				"--mock",
-				"--manifest-file",
-				manifest_path.to_str().unwrap(),
-			])
-			.spawn()
-			.unwrap()
-			.into();
-
-	// -- HOST start host
-	let mut _host_child_process: ChildWrapper =
-		Command::new(integration::QOS_HOST_PATH)
-			.args([
-				"--host-port",
-				&host_port.to_string(),
-				"--host-ip",
-				LOCAL_HOST,
-				"--usock",
-				usock.to_str().unwrap(),
-			])
-			.spawn()
-			.unwrap()
-			.into();
-
-	// -- Make sure the enclave and host have time to boot
-	qos_test_primitives::wait_until_port_is_bound(host_port);
 
 	// -- CLIENT generate the manifest envelope
 	assert!(
@@ -385,8 +330,6 @@ async fn main() {
 				"--alias",
 				user,
 				"--unsafe-skip-attestation",
-				"--unsafe-eph-path-override",
-				eph_path.to_str().unwrap(),
 			])
 			.stdin(Stdio::piped())
 			.stdout(Stdio::piped())
@@ -464,10 +407,4 @@ async fn main() {
 	assert_eq!(enclave_info.phase, ProtocolPhase::QuorumKeyProvisioned);
 
 	println!("=========ENCLAVE READY WITH PIVOT RUNNING!!==========");
-	println!("press ctrl+c to quit");
-
-	match tokio::signal::ctrl_c().await {
-		Ok(()) => {}
-		Err(err) => panic!("{err}"),
-	}
 }

--- a/src/integration/examples/pivot_download.rs
+++ b/src/integration/examples/pivot_download.rs
@@ -1,7 +1,24 @@
-use std::time::{Duration, SystemTime};
+use std::{
+	net::SocketAddr,
+	time::{Duration, SystemTime},
+};
 
 use sha2::Digest;
+use ureq::Resolver;
 
+struct FixedResolver {
+	ip_addr: SocketAddr,
+}
+
+impl Resolver for FixedResolver {
+	fn resolve(&self, _netloc: &str) -> std::io::Result<Vec<SocketAddr>> {
+		Ok(vec![self.ip_addr])
+	}
+}
+
+// arguments are <url> [ip_override]
+//    url - the url of the file to download (GET)
+//    ip_override - an optional <ip:port> e.g. 127.0.0.1:80 that is used to avoid dns lookup with the given url if given
 fn main() {
 	let mut args = std::env::args();
 	let url = url::Url::parse(&args.nth(1).expect("no url provided"))
@@ -12,31 +29,27 @@ fn main() {
 	std::thread::sleep(std::time::Duration::from_secs(10));
 
 	let client_builder = if let Some(ip) = ip_override {
-		let addr = ip.parse().expect("invalid override ip");
+		let ip_addr = ip.parse().expect("invalid override ip");
 		let base_url = url.host_str().expect("no host in url");
 
 		println!("using override ip of {ip} for base url {base_url}");
 
-		reqwest::blocking::ClientBuilder::new()
-			.resolve_to_addrs(base_url, &[addr])
+		ureq::builder().resolver(FixedResolver { ip_addr })
 	} else {
-		reqwest::blocking::ClientBuilder::new()
+		ureq::builder()
 	};
 
-	let client = client_builder.build().unwrap();
+	let client = client_builder.timeout(Duration::from_mins(1)).build();
 
 	println!("starting download of {url}");
-	let request = client
-		.get(url)
-		.timeout(Duration::from_secs(300))
-		.build()
-		.expect("unable to build request");
+	let request = client.get(url.as_ref());
 
 	let start = SystemTime::now();
-	let dl = client.execute(request).expect("unable to download");
+	let dl = request.call().expect("unable to download");
 
 	let status = dl.status();
-	let bytes = dl.bytes().unwrap();
+	let bytes: Vec<u8> = dl.into_string().unwrap().bytes().collect();
+
 	let size = bytes.len();
 	let ss = sha2::Sha256::digest(bytes);
 

--- a/src/integration/examples/pivot_download.rs
+++ b/src/integration/examples/pivot_download.rs
@@ -1,0 +1,50 @@
+use std::time::{Duration, SystemTime};
+
+use sha2::Digest;
+
+fn main() {
+	let mut args = std::env::args();
+	let url = url::Url::parse(&args.nth(1).expect("no url provided"))
+		.expect("invalid url");
+	let ip_override = args.next(); // provides ip override if we want to avoid dns
+
+	println!("sleeping 10s before download");
+	std::thread::sleep(std::time::Duration::from_secs(10));
+
+	let client_builder = if let Some(ip) = ip_override {
+		let addr = ip.parse().expect("invalid override ip");
+		let base_url = url.host_str().expect("no host in url");
+
+		println!("using override ip of {ip} for base url {base_url}");
+
+		reqwest::blocking::ClientBuilder::new()
+			.resolve_to_addrs(base_url, &[addr])
+	} else {
+		reqwest::blocking::ClientBuilder::new()
+	};
+
+	let client = client_builder.build().unwrap();
+
+	println!("starting download of {url}");
+	let request = client
+		.get(url)
+		.timeout(Duration::from_secs(300))
+		.build()
+		.expect("unable to build request");
+
+	let start = SystemTime::now();
+	let dl = client.execute(request).expect("unable to download");
+
+	let status = dl.status();
+	let bytes = dl.bytes().unwrap();
+	let size = bytes.len();
+	let ss = sha2::Sha256::digest(bytes);
+
+	println!(
+		"download complete\n\tstatus: {}\n\tsize: {}\n\tduration: {:?}\n\tsha256sum:{:x}",
+		status,
+		size,
+		SystemTime::now().duration_since(start).unwrap(),
+		ss,
+	);
+}

--- a/src/integration/src/lib.rs
+++ b/src/integration/src/lib.rs
@@ -54,9 +54,9 @@ pub const PIVOT_SOCKET_STRESS_PATH: &str = concat!(
 /// Path to an enclave app that has routes to fetch app proofs.
 pub const PIVOT_PROOF_PATH: &str =
 	concat!(env!("CARGO_MANIFEST_DIR"), "/../../target/debug/pivot_proof");
-/// Path to `qos_bridge` bin for tests.
+/// Path to `qos_bridge` ingress bin for tests.
 pub const QOS_BRIDGE_PATH: &str =
-	concat!(env!("CARGO_MANIFEST_DIR"), "/../../target/debug/qos_bridge");
+	concat!(env!("CARGO_MANIFEST_DIR"), "/../../target/debug/ingress");
 /// Path to `qos_client` bin for tests.
 pub const QOS_CLIENT_PATH: &str =
 	concat!(env!("CARGO_MANIFEST_DIR"), "/../../target/debug/qos_client");

--- a/src/qos_bridge/Cargo.toml
+++ b/src/qos_bridge/Cargo.toml
@@ -21,4 +21,5 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 ureq = { workspace = true, features = ["json"] }
 
 [features]
+qemu = ["qos_core/qemu"]
 egress = ["qos_core/egress"]

--- a/src/qos_bridge/Cargo.toml
+++ b/src/qos_bridge/Cargo.toml
@@ -13,9 +13,12 @@ qos_host = { workspace = true, default-features = false }
 qos_core = { workspace = true, default-features = false }
 qos_hex = { workspace = true, features = ["serde"], default-features = false }
 qos_nsm = { workspace = true, default-features = false }
-ureq = { workspace = true, features = ["json"] }
 
 # Third party
 serde_json = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+ureq = { workspace = true, features = ["json"] }
+
+[features]
+egress = ["qos_core/egress"]

--- a/src/qos_bridge/src/bin/egress.rs
+++ b/src/qos_bridge/src/bin/egress.rs
@@ -1,0 +1,12 @@
+//! QOS bridge binary entry point for egress bridge.
+
+use qos_bridge::cli;
+
+fn main() {
+	// Development quick start
+	// ```
+	// cargo run --bin egress -- \
+	//      --cid 16
+	// ```
+	cli::Cli::execute_egress();
+}

--- a/src/qos_bridge/src/bin/ingress.rs
+++ b/src/qos_bridge/src/bin/ingress.rs
@@ -1,15 +1,14 @@
-//! QOS bridge binary entry point.
+//! QOS bridge binary entry point for ingress bridge.
 
-mod cli;
-mod host;
+use qos_bridge::cli;
 
 #[tokio::main]
 async fn main() {
 	// Development quick start
 	// ```
-	// cargo run --bin qos_bridge -- \
+	// cargo run --bin ingress -- \
 	//      --usock /tmp/usock.sock \
 	//      --control-url http://localhost:3001/qos
 	// ```
-	cli::Cli::execute().await;
+	cli::Cli::execute_ingress().await;
 }

--- a/src/qos_bridge/src/cli.rs
+++ b/src/qos_bridge/src/cli.rs
@@ -158,7 +158,6 @@ impl Cli {
 	/// # Panics
 	/// panics on socket errors on wrong cli input
 	pub fn execute_egress() {
-		println!("here");
 		let mut args: Vec<String> = env::args().collect();
 		let options = HostOpts::new(&mut args);
 

--- a/src/qos_bridge/src/cli.rs
+++ b/src/qos_bridge/src/cli.rs
@@ -12,6 +12,7 @@ const CONTROL_URL: &str = "control-url";
 const HOST_PORT_OVERRIDE: &str = "host-port-override";
 const VSOCK_TO_HOST: &str = "vsock-to-host";
 const EGRESS_HOST: &str = "egress-host";
+const EGRESS_BIN_PATH: &str = "egress-bin-path";
 
 struct HostParser;
 impl GetParserForOptions for HostParser {
@@ -48,6 +49,10 @@ impl GetParserForOptions for HostParser {
 				Token::new(EGRESS_HOST, "run in enclave egress in host mode")
 					.takes_value(false)
 			)
+			.token(
+				Token::new(EGRESS_BIN_PATH, "path to the egress binary")
+					.takes_value(true)
+			)
 	}
 }
 
@@ -81,6 +86,12 @@ impl HostOpts {
 	#[must_use]
 	pub fn egress_host(&self) -> bool {
 		self.parsed.flag(EGRESS_HOST).unwrap_or(false)
+	}
+
+	/// Wether to run in egress host mode (e.g. in qos bridge on the host)
+	#[must_use]
+	pub fn egress_bin_path(&self) -> Option<String> {
+		self.parsed.single(EGRESS_BIN_PATH).cloned()
 	}
 
 	/// overrides the host portion of the bridge with given port, ignoring the manifest value
@@ -199,6 +210,7 @@ impl Cli {
 					.expect("failed to create enclave socket placeholder"),
 				options.control_url(),
 				options.host_port_override(),
+				options.egress_bin_path(),
 			)
 			.serve()
 			.await;

--- a/src/qos_bridge/src/cli.rs
+++ b/src/qos_bridge/src/cli.rs
@@ -11,7 +11,6 @@ use qos_core::{
 const CONTROL_URL: &str = "control-url";
 const HOST_PORT_OVERRIDE: &str = "host-port-override";
 const VSOCK_TO_HOST: &str = "vsock-to-host";
-const ENCLAVE_EGRESS: &str = "enclave-egress";
 
 struct HostParser;
 impl GetParserForOptions for HostParser {
@@ -44,10 +43,6 @@ impl GetParserForOptions for HostParser {
 					.required(false)
 					.forbids(vec![USOCK])
 			)
-			.token(
-				Token::new(ENCLAVE_EGRESS, "start in enclave egress mode")
-					.takes_value(false)
-			)
 	}
 }
 
@@ -77,15 +72,6 @@ impl HostOpts {
 	/// NOTE: used for localhost testing, since we can't bind the same port twice
 	pub fn host_port_override(&self) -> Option<u16> {
 		self.parsed.single(HOST_PORT_OVERRIDE).and_then(|v| v.parse().ok())
-	}
-
-	/// sets the bridge in "inside enclave" egress mode to be run directly by `Reaper` as a separate binary
-	pub fn enclave_egress(&self) -> bool {
-		self.parsed
-			.single(ENCLAVE_EGRESS)
-			.unwrap_or(&"false".to_string())
-			.parse()
-			.expect("unable to parse enclave-egress bool")
 	}
 
 	/// Create a new `StreamPool` using the list of `SocketAddress` for the qos host.
@@ -143,12 +129,6 @@ impl Cli {
 			println!("version: {}", env!("CARGO_PKG_VERSION"));
 		} else if options.parsed.help() {
 			println!("{}", options.parsed.info());
-		} else if options.enclave_egress() {
-			run_egress_bridge(
-				&options
-					.enclave_socket()
-					.expect("failed to create enclave socket"),
-			);
 		} else {
 			crate::host::BridgeServer::new(
 				options
@@ -164,24 +144,4 @@ impl Cli {
 			let _ = tokio::signal::ctrl_c().await;
 		}
 	}
-}
-// dummy placeholder
-#[cfg(not(feature = "vm"))]
-fn run_egress_bridge(_core_socket: &SocketAddress) {
-	panic!("unable to run egress without vm feature and vsock support");
-}
-
-// run the transparent host egress
-#[cfg(feature = "vm")]
-fn run_egress_bridge(core_socket: &SocketAddress) {
-	let vsock = core_socket.vsock();
-	let cid = vsock.cid();
-	let flags = qos_core::io::vsock_svm_flags(vsock); // ensure we copy the flags as set
-
-	tokio::task::spawn_blocking(move || {
-		use qos_core::egress::EGRESS_VSOCK_PORT;
-
-		println!("reaper: starting transparent egress host side");
-		qos_core::egress::enclave_egress(cid, EGRESS_VSOCK_PORT, flags);
-	});
 }

--- a/src/qos_bridge/src/cli.rs
+++ b/src/qos_bridge/src/cli.rs
@@ -11,6 +11,7 @@ use qos_core::{
 const CONTROL_URL: &str = "control-url";
 const HOST_PORT_OVERRIDE: &str = "host-port-override";
 const VSOCK_TO_HOST: &str = "vsock-to-host";
+const ENCLAVE_EGRESS: &str = "enclave-egress";
 
 struct HostParser;
 impl GetParserForOptions for HostParser {
@@ -21,7 +22,7 @@ impl GetParserForOptions for HostParser {
 				"full url of qos-host to get manifest information from, including the base path, e.g. http://localhost:3001/qos",
 			)
 			.takes_value(true)
-			.required(true),
+			.required(false),
 		)
 			.token(
 				Token::new(CID, "context identifier for the enclave socket (only for VSOCK)")
@@ -42,6 +43,10 @@ impl GetParserForOptions for HostParser {
 					.takes_value(true)
 					.required(false)
 					.forbids(vec![USOCK])
+			)
+			.token(
+				Token::new(ENCLAVE_EGRESS, "run in enclave egress mode (within enclave)")
+					.takes_value(false)
 			)
 	}
 }
@@ -68,6 +73,11 @@ impl HostOpts {
 			.clone()
 	}
 
+	/// Wether to run in enclave-egress mode (e.g. in enclave egress bridge)
+	pub fn enclave_egress(&self) -> bool {
+		self.parsed.flag(ENCLAVE_EGRESS).unwrap_or(false)
+	}
+
 	/// overrides the host portion of the bridge with given port, ignoring the manifest value
 	/// NOTE: used for localhost testing, since we can't bind the same port twice
 	pub fn host_port_override(&self) -> Option<u16> {
@@ -90,6 +100,15 @@ impl HostOpts {
 
 			_ => panic!("Invalid socket opts"),
 		}
+	}
+
+	#[cfg(feature = "egress")]
+	fn cid(&self) -> u32 {
+		self.parsed
+			.single(CID)
+			.expect("no cid provided")
+			.parse()
+			.expect("unable to parse cid")
 	}
 
 	#[cfg(not(target_os = "macos"))]
@@ -129,6 +148,18 @@ impl Cli {
 			println!("version: {}", env!("CARGO_PKG_VERSION"));
 		} else if options.parsed.help() {
 			println!("{}", options.parsed.info());
+		} else if options.enclave_egress() {
+			#[cfg(feature = "egress")]
+			qos_core::egress::enclave_egress(
+				options.cid(),
+				qos_core::egress::EGRESS_VSOCK_PORT,
+				options.to_host_flag(),
+			);
+
+			#[cfg(not(feature = "egress"))]
+			panic!(
+				"unable to run enclave-egress without egress feature enabled"
+			);
 		} else {
 			crate::host::BridgeServer::new(
 				options

--- a/src/qos_bridge/src/cli.rs
+++ b/src/qos_bridge/src/cli.rs
@@ -158,6 +158,7 @@ impl Cli {
 	/// # Panics
 	/// panics on socket errors on wrong cli input
 	pub fn execute_egress() {
+		println!("here");
 		let mut args: Vec<String> = env::args().collect();
 		let options = HostOpts::new(&mut args);
 
@@ -166,6 +167,7 @@ impl Cli {
 		} else if options.parsed.help() {
 			println!("{}", options.parsed.info());
 		} else if options.egress_host() {
+			println!("running in host egress mode");
 			#[cfg(feature = "egress")]
 			qos_core::egress::host_egress(
 				options.cid(),
@@ -178,6 +180,7 @@ impl Cli {
 				"unable to run enclave-egress without egress feature support"
 			);
 		} else {
+			println!("running in enclave egress mode");
 			#[cfg(feature = "egress")]
 			qos_core::egress::enclave_egress(
 				options.cid(),

--- a/src/qos_bridge/src/cli.rs
+++ b/src/qos_bridge/src/cli.rs
@@ -11,7 +11,7 @@ use qos_core::{
 const CONTROL_URL: &str = "control-url";
 const HOST_PORT_OVERRIDE: &str = "host-port-override";
 const VSOCK_TO_HOST: &str = "vsock-to-host";
-const ENCLAVE_EGRESS: &str = "enclave-egress";
+const EGRESS_HOST: &str = "egress-host";
 
 struct HostParser;
 impl GetParserForOptions for HostParser {
@@ -45,7 +45,7 @@ impl GetParserForOptions for HostParser {
 					.forbids(vec![USOCK])
 			)
 			.token(
-				Token::new(ENCLAVE_EGRESS, "run in enclave egress mode (within enclave)")
+				Token::new(EGRESS_HOST, "run in enclave egress in host mode")
 					.takes_value(false)
 			)
 	}
@@ -58,6 +58,7 @@ pub struct HostOpts {
 }
 
 impl HostOpts {
+	#[must_use]
 	fn new(args: &mut Vec<String>) -> Self {
 		let parsed = OptionsParser::<HostParser>::parse(args)
 			.expect("Entered invalid CLI args");
@@ -66,6 +67,9 @@ impl HostOpts {
 	}
 
 	/// The qos-host URL
+	/// # Panics
+	/// Panics if no control-url is provided
+	#[must_use]
 	pub fn control_url(&self) -> String {
 		self.parsed
 			.single(CONTROL_URL)
@@ -73,13 +77,15 @@ impl HostOpts {
 			.clone()
 	}
 
-	/// Wether to run in enclave-egress mode (e.g. in enclave egress bridge)
-	pub fn enclave_egress(&self) -> bool {
-		self.parsed.flag(ENCLAVE_EGRESS).unwrap_or(false)
+	/// Wether to run in egress host mode (e.g. in qos bridge on the host)
+	#[must_use]
+	pub fn egress_host(&self) -> bool {
+		self.parsed.flag(EGRESS_HOST).unwrap_or(false)
 	}
 
 	/// overrides the host portion of the bridge with given port, ignoring the manifest value
 	/// NOTE: used for localhost testing, since we can't bind the same port twice
+	#[must_use]
 	pub fn host_port_override(&self) -> Option<u16> {
 		self.parsed.single(HOST_PORT_OVERRIDE).and_then(|v| v.parse().ok())
 	}
@@ -102,7 +108,7 @@ impl HostOpts {
 		}
 	}
 
-	#[cfg(feature = "egress")]
+	#[allow(unused)]
 	fn cid(&self) -> u32 {
 		self.parsed
 			.single(CID)
@@ -137,10 +143,10 @@ impl HostOpts {
 /// Host server command line interface.
 pub struct Cli;
 impl Cli {
-	/// Execute the command line interface.
+	/// Execute the commandline interface for `qos_bridge` egress
 	/// # Panics
-	/// If pool creation fails
-	pub async fn execute() {
+	/// panics on socket errors on wrong cli input
+	pub fn execute_egress() {
 		let mut args: Vec<String> = env::args().collect();
 		let options = HostOpts::new(&mut args);
 
@@ -148,7 +154,19 @@ impl Cli {
 			println!("version: {}", env!("CARGO_PKG_VERSION"));
 		} else if options.parsed.help() {
 			println!("{}", options.parsed.info());
-		} else if options.enclave_egress() {
+		} else if options.egress_host() {
+			#[cfg(feature = "egress")]
+			qos_core::egress::host_egress(
+				options.cid(),
+				qos_core::egress::EGRESS_VSOCK_PORT,
+				options.to_host_flag(),
+			);
+
+			#[cfg(not(feature = "egress"))]
+			panic!(
+				"unable to run enclave-egress without egress feature support"
+			);
+		} else {
 			#[cfg(feature = "egress")]
 			qos_core::egress::enclave_egress(
 				options.cid(),
@@ -158,8 +176,22 @@ impl Cli {
 
 			#[cfg(not(feature = "egress"))]
 			panic!(
-				"unable to run enclave-egress without egress feature enabled"
+				"unable to run enclave-egress without egress feature support"
 			);
+		}
+	}
+
+	/// Execute the command line interface for `qos_bridge` ingress host
+	/// # Panics
+	/// If pool creation fails, cli errors or if manifest parsing fails
+	pub async fn execute_ingress() {
+		let mut args: Vec<String> = env::args().collect();
+		let options = HostOpts::new(&mut args);
+
+		if options.parsed.version() {
+			println!("version: {}", env!("CARGO_PKG_VERSION"));
+		} else if options.parsed.help() {
+			println!("{}", options.parsed.info());
 		} else {
 			crate::host::BridgeServer::new(
 				options

--- a/src/qos_bridge/src/cli.rs
+++ b/src/qos_bridge/src/cli.rs
@@ -11,6 +11,7 @@ use qos_core::{
 const CONTROL_URL: &str = "control-url";
 const HOST_PORT_OVERRIDE: &str = "host-port-override";
 const VSOCK_TO_HOST: &str = "vsock-to-host";
+const ENCLAVE_EGRESS: &str = "enclave-egress";
 
 struct HostParser;
 impl GetParserForOptions for HostParser {
@@ -43,6 +44,10 @@ impl GetParserForOptions for HostParser {
 					.required(false)
 					.forbids(vec![USOCK])
 			)
+			.token(
+				Token::new(ENCLAVE_EGRESS, "start in enclave egress mode")
+					.takes_value(false)
+			)
 	}
 }
 
@@ -72,6 +77,15 @@ impl HostOpts {
 	/// NOTE: used for localhost testing, since we can't bind the same port twice
 	pub fn host_port_override(&self) -> Option<u16> {
 		self.parsed.single(HOST_PORT_OVERRIDE).and_then(|v| v.parse().ok())
+	}
+
+	/// sets the bridge in "inside enclave" egress mode to be run directly by `Reaper` as a separate binary
+	pub fn enclave_egress(&self) -> bool {
+		self.parsed
+			.single(ENCLAVE_EGRESS)
+			.unwrap_or(&"false".to_string())
+			.parse()
+			.expect("unable to parse enclave-egress bool")
 	}
 
 	/// Create a new `StreamPool` using the list of `SocketAddress` for the qos host.
@@ -129,6 +143,12 @@ impl Cli {
 			println!("version: {}", env!("CARGO_PKG_VERSION"));
 		} else if options.parsed.help() {
 			println!("{}", options.parsed.info());
+		} else if options.enclave_egress() {
+			run_egress_bridge(
+				&options
+					.enclave_socket()
+					.expect("failed to create enclave socket"),
+			);
 		} else {
 			crate::host::BridgeServer::new(
 				options
@@ -144,4 +164,24 @@ impl Cli {
 			let _ = tokio::signal::ctrl_c().await;
 		}
 	}
+}
+// dummy placeholder
+#[cfg(not(feature = "vm"))]
+fn run_egress_bridge(_core_socket: &SocketAddress) {
+	panic!("unable to run egress without vm feature and vsock support");
+}
+
+// run the transparent host egress
+#[cfg(feature = "vm")]
+fn run_egress_bridge(core_socket: &SocketAddress) {
+	let vsock = core_socket.vsock();
+	let cid = vsock.cid();
+	let flags = qos_core::io::vsock_svm_flags(vsock); // ensure we copy the flags as set
+
+	tokio::task::spawn_blocking(move || {
+		use qos_core::egress::EGRESS_VSOCK_PORT;
+
+		println!("reaper: starting transparent egress host side");
+		qos_core::egress::enclave_egress(cid, EGRESS_VSOCK_PORT, flags);
+	});
 }

--- a/src/qos_bridge/src/host.rs
+++ b/src/qos_bridge/src/host.rs
@@ -90,14 +90,14 @@ impl BridgeServer {
 	}
 
 	// dummy placeholder
-	#[cfg(target_os = "macos")]
+	#[cfg(not(feature = "egress"))]
 	#[allow(clippy::unused_self)]
 	fn run_egress_host_bridge(&self) {
 		panic!("unable to run egress without vm feature and vsock support");
 	}
 
 	// run the transparent host egress
-	#[cfg(not(target_os = "macos"))]
+	#[cfg(feature = "egress")]
 	fn run_egress_host_bridge(&self) {
 		let vsock = self.socket_placeholder.vsock();
 		let cid = vsock.cid();

--- a/src/qos_bridge/src/host.rs
+++ b/src/qos_bridge/src/host.rs
@@ -100,19 +100,20 @@ impl BridgeServer {
 		panic!("unable to run egress without vm feature and vsock support");
 	}
 
-	// run the transparent host egress
+	// run the transparent host egress as separate binary, non-blocking
 	#[cfg(feature = "egress")]
 	fn run_egress_host_bridge(&self) {
 		let vsock = self.socket_placeholder.vsock();
 		let cid = vsock.cid();
 		let flags = qos_core::io::vsock_svm_flags(vsock); // ensure we copy the flags as set
+		let vsock_to_host = flags == qos_core::io::VMADDR_FLAG_TO_HOST;
 
-		tokio::task::spawn_blocking(move || {
-			use qos_core::egress::EGRESS_VSOCK_PORT;
-
-			println!("qos_bridge: starting transparent egress host side");
-			qos_core::egress::host_egress(cid, EGRESS_VSOCK_PORT, flags);
-		});
+		qos_core::egress::run_looping(
+			"/qos_egress",
+			&format!(
+				"--egress-host --cid {cid} --vsock-to-host {vsock_to_host}",
+			),
+		);
 	}
 
 	fn run_ingress_bridge(

--- a/src/qos_bridge/src/host.rs
+++ b/src/qos_bridge/src/host.rs
@@ -19,6 +19,8 @@ pub struct BridgeServer {
 }
 
 impl BridgeServer {
+	/// Create a new `BridgeServer` with  the given core socket placeholder, `control_url` and override port for local running
+	#[must_use]
 	pub fn new(
 		socket_placeholder: SocketAddress,
 		control_url: String,
@@ -32,6 +34,8 @@ impl BridgeServer {
 	}
 
 	/// Start the host side of the bridge, taking configuration from the enclave
+	/// # Panics
+	/// Panics if enclave info response fails to parse
 	pub async fn serve(&self) {
 		loop {
 			match tokio::task::block_in_place(|| {

--- a/src/qos_bridge/src/host.rs
+++ b/src/qos_bridge/src/host.rs
@@ -99,14 +99,15 @@ impl BridgeServer {
 	// run the transparent host egress
 	#[cfg(not(target_os = "macos"))]
 	fn run_egress_host_bridge(&self) {
-		const EGRESS_PORT: u32 = 1000; // reserved range so user ports don't interfere
 		let vsock = self.socket_placeholder.vsock();
 		let cid = vsock.cid();
 		let flags = qos_core::io::vsock_svm_flags(vsock); // ensure we copy the flags as set
 
 		tokio::task::spawn_blocking(move || {
+			use qos_core::egress::EGRESS_VSOCK_PORT;
+
 			println!("qos_bridge: starting transparent egress host side");
-			qos_core::egress::host_egress(cid, EGRESS_PORT, flags);
+			qos_core::egress::host_egress(cid, EGRESS_VSOCK_PORT, flags);
 		});
 	}
 

--- a/src/qos_bridge/src/host.rs
+++ b/src/qos_bridge/src/host.rs
@@ -113,13 +113,12 @@ impl BridgeServer {
 		let vsock_to_host = flags == qos_core::io::VMADDR_FLAG_TO_HOST;
 		let egress_bin_path: &str =
 			self.egress_bin_path.as_deref().unwrap_or("/qos_egress");
-
-		qos_core::egress::run_looping(
-			egress_bin_path,
-			&format!(
-				"--egress-host --cid {cid} --vsock-to-host {vsock_to_host}",
-			),
+		let args = &format!(
+			"--egress-host --cid {cid} --vsock-to-host {vsock_to_host}",
 		);
+
+		println!("running egress bridge binary: {egress_bin_path} {args}");
+		qos_core::egress::run_looping(egress_bin_path, &args);
 	}
 
 	fn run_ingress_bridge(

--- a/src/qos_bridge/src/host.rs
+++ b/src/qos_bridge/src/host.rs
@@ -16,6 +16,8 @@ pub struct BridgeServer {
 	socket_placeholder: SocketAddress,
 	info_url: String,
 	host_port_override: Option<u16>,
+	#[allow(unused)]
+	egress_bin_path: Option<String>,
 }
 
 impl BridgeServer {
@@ -25,11 +27,13 @@ impl BridgeServer {
 		socket_placeholder: SocketAddress,
 		control_url: String,
 		host_port_override: Option<u16>,
+		egress_bin_path: Option<String>,
 	) -> Self {
 		Self {
 			socket_placeholder,
 			info_url: control_url + ENCLAVE_INFO,
 			host_port_override,
+			egress_bin_path,
 		}
 	}
 
@@ -107,9 +111,11 @@ impl BridgeServer {
 		let cid = vsock.cid();
 		let flags = qos_core::io::vsock_svm_flags(vsock); // ensure we copy the flags as set
 		let vsock_to_host = flags == qos_core::io::VMADDR_FLAG_TO_HOST;
+		let egress_bin_path: &str =
+			self.egress_bin_path.as_deref().unwrap_or("/qos_egress");
 
 		qos_core::egress::run_looping(
-			"/qos_egress",
+			egress_bin_path,
 			&format!(
 				"--egress-host --cid {cid} --vsock-to-host {vsock_to_host}",
 			),

--- a/src/qos_bridge/src/host.rs
+++ b/src/qos_bridge/src/host.rs
@@ -64,50 +64,88 @@ impl BridgeServer {
 	}
 
 	fn run_bridges(&self, configs: &[BridgeConfig]) {
+		let mut egress_enabled = false;
+
 		for config in configs {
-			let (host_port, host_ip_str) = match config {
+			match config {
 				BridgeConfig::Client { port: _, host: _ } => {
-					unimplemented!("client support pending")
+					// NOTE: we ignore the host and port here as they are meant for firewall rules
+					// TODO: figure out how to actually handle the firewall rules, see TVC-25
+
+					// only run one instance as it covers ALL ports, the others are for firewalls
+					if !egress_enabled {
+						egress_enabled = true;
+						self.run_egress_host_bridge();
+					}
 				}
 				BridgeConfig::Server { port, host } => {
-					(self.host_port(*port), host)
-				}
-			};
-
-			// derive the app socket, for vsock just use the app host port with same CID as the enclave socket,
-			// with usock just add "<port>.appsock" suffix
-			let app_socket = match self
-				.socket_placeholder
-				.with_port(config.port())
-			{
-				Ok(value) => value,
-				Err(err) => {
-					eprintln!(
-						"unable to derive app socket from enclave socket: {err:?}, tcp to vsock bridge will not start"
+					self.run_ingress_bridge(
+						config.port(),
+						self.host_port(*port),
+						host,
 					);
-					return;
 				}
-			};
+			}
+		}
+	}
 
-			let app_pool = match StreamPool::single(app_socket) {
-				Ok(value) => value,
-				Err(err) => {
-					eprintln!(
-						"unable to create new app socket pool: {err:?}, tcp to vsock bridge will not start"
-					);
-					return;
-				}
-			};
+	// dummy placeholder
+	#[cfg(target_os = "macos")]
+	#[allow(clippy::unused_self)]
+	fn run_egress_host_bridge(&self) {
+		panic!("unable to run egress without vm feature and vsock support");
+	}
 
-			let Ok(host_ip) = host_ip_str.parse::<Ipv4Addr>() else {
+	// run the transparent host egress
+	#[cfg(not(target_os = "macos"))]
+	fn run_egress_host_bridge(&self) {
+		const EGRESS_PORT: u32 = 1000; // reserved range so user ports don't interfere
+		let vsock = self.socket_placeholder.vsock();
+		let cid = vsock.cid();
+		let flags = qos_core::io::vsock_svm_flags(vsock); // ensure we copy the flags as set
+
+		tokio::task::spawn_blocking(move || {
+			println!("qos_bridge: starting transparent egress host side");
+			qos_core::egress::host_egress(cid, EGRESS_PORT, flags);
+		});
+	}
+
+	fn run_ingress_bridge(
+		&self,
+		core_port: u16,
+		host_port: u16,
+		host_ip_str: &str,
+	) {
+		// derive the app socket, for vsock just use the app host port with same CID as the enclave socket,
+		// with usock just add "<port>.appsock" suffix
+		let app_socket = match self.socket_placeholder.with_port(core_port) {
+			Ok(value) => value,
+			Err(err) => {
 				eprintln!(
-					"unable to parse host ip for bridge configuration: {host_ip_str}"
+					"unable to derive app socket from enclave socket: {err:?}, tcp to vsock bridge will not start"
 				);
 				return;
-			};
-			let host_addr = SocketAddr::new(host_ip.into(), host_port);
+			}
+		};
 
-			HostBridge::new(app_pool, host_addr).tcp_to_vsock();
-		}
+		let app_pool = match StreamPool::single(app_socket) {
+			Ok(value) => value,
+			Err(err) => {
+				eprintln!(
+					"unable to create new app socket pool: {err:?}, tcp to vsock bridge will not start"
+				);
+				return;
+			}
+		};
+
+		let Ok(host_ip) = host_ip_str.parse::<Ipv4Addr>() else {
+			eprintln!(
+				"unable to parse host ip for bridge configuration: {host_ip_str}"
+			);
+			return;
+		};
+		let host_addr = SocketAddr::new(host_ip.into(), host_port);
+
+		HostBridge::new(app_pool, host_addr).tcp_to_vsock();
 	}
 }

--- a/src/qos_bridge/src/lib.rs
+++ b/src/qos_bridge/src/lib.rs
@@ -1,0 +1,4 @@
+//! QOS bridge ingress and egress library.
+
+pub mod cli;
+pub mod host;

--- a/src/qos_client/src/cli/mod.rs
+++ b/src/qos_client/src/cli/mod.rs
@@ -279,12 +279,6 @@ impl From<String> for Command {
 }
 
 impl Command {
-	fn print_all() {
-		println!(
-			"\thost-health, enclave-status, generate-file-key, generate-manifest-envelope, boot-genesis,\n\tafter-genesis, verify-genesis, generate-manifest, approve-manifest, boot-standard, get-attestation-doc,\n\tget-ephemeral-key-hex, proxy-re-encrypt-share, post-share, dangerous-dev-boot,\n\tprovision-yubikey, advanced-provision-yubikey, pivot-hash, shamir-split, shamir-reconstruct,\n\tyubikey-sign, yubikey-public, yubikey-piv-reset, yubikey-change-pin, display, json-to-borsh,\n\tboot-key-fwd, export-key, inject-key, p256-verify, p256-sign, p256-asymmetric-encrypt, p256-asymmetric-decrypt"
-		);
-	}
-
 	fn namespace_token() -> Token {
 		Token::new(NAMESPACE, "Namespace for the associated manifest.")
 			.takes_value(true)
@@ -1287,15 +1281,13 @@ impl ClientRunner {
 	pub fn new(args: &mut Vec<String>) -> Self {
 		let result = CommandParser::<Command>::parse(args);
 
-		if let Ok((cmd, parsed)) = result {
-			Self { cmd, opts: ClientOpts { parsed } }
-		} else {
-			println!(
-				"Invalid input, try using --help with any of the following commands"
-			);
-			Command::print_all();
+		match result {
+			Ok((cmd, parsed)) => Self { cmd, opts: ClientOpts { parsed } },
+			Err(err) => {
+				println!("Invalid input: {err}");
 
-			std::process::exit(1);
+				std::process::exit(1);
+			}
 		}
 	}
 

--- a/src/qos_core/Cargo.toml
+++ b/src/qos_core/Cargo.toml
@@ -19,6 +19,7 @@ qos_json = { workspace = true }
 qos_p256 = { workspace = true }
 qos_nsm = { workspace = true, default-features = false }
 
+etherparse = { workspace = true, optional = true }
 nix = { workspace = true }
 libc = { workspace = true }
 borsh = { workspace = true }
@@ -43,5 +44,7 @@ rustls = { workspace = true }
 webpki-roots = { workspace = true }
 
 [features]
+# Support for egress
+egress = ["etherparse"]
 # Never use in production - support for mock NSM
 mock = ["qos_nsm/mock"]

--- a/src/qos_core/Cargo.toml
+++ b/src/qos_core/Cargo.toml
@@ -46,5 +46,7 @@ webpki-roots = { workspace = true }
 [features]
 # Support for egress
 egress = ["etherparse"]
+# Support for localhost qemu setup without forcing host to use root
+qemu = []
 # Never use in production - support for mock NSM
 mock = ["qos_nsm/mock"]

--- a/src/qos_core/src/egress.rs
+++ b/src/qos_core/src/egress.rs
@@ -26,6 +26,7 @@ pub const EGRESS_VSOCK_PORT: u32 = 1000; // reserved range so user ports don't i
 /// panics on socket errors of any kind
 #[allow(unsafe_code)]
 pub fn enclave_egress(cid: u32, port: u32, flags: u8) {
+	eprintln!("qos_bridge: enclave egress running");
 	let addr = SocketAddress::new_vsock_raw(cid, port, flags);
 	let core_socket =
 		create_core_socket().expect("unable to create core socket");
@@ -48,6 +49,7 @@ pub fn enclave_egress(cid: u32, port: u32, flags: u8) {
 /// # Panics
 /// panics on socket errors of any kind
 pub fn host_egress(cid: u32, port: u32, flags: u8) {
+	eprintln!("qos_bridge: host egress running");
 	// NOTE: it's important we don't loop just connect here as that seems to cause EPIPE errors after it does connect
 	let proxy_fd = loop {
 		let addr = SocketAddress::new_vsock_raw(cid, port, flags);

--- a/src/qos_core/src/egress.rs
+++ b/src/qos_core/src/egress.rs
@@ -67,14 +67,14 @@ pub fn host_egress(cid: u32, port: u32, flags: u8) {
 	copy_bidirectional(sock_fd, proxy_fd);
 }
 
-/// sets up new tuntap tun interface `enclave_egress` with localhost routing using `10.0.0.1/32` mask and default gw
+/// sets up new tuntap tun interface `enclave_egress` with localhost routing using `172.29.107.65/32` mask and default gw
 /// expects `/usr/sbin/ip` and `/lib/ld-musl-x86` to be present
 /// # Panics
 /// panics if the program executions fail
 pub fn init_egress_tun() {
 	run_ip("tuntap add enclave_egress mode tun", "tuntap add failed");
 	run_ip("link set lo up", "unable to bring up lo");
-	run_ip("address add 10.0.0.1/32 dev lo", "ip assign to lo failed");
+	run_ip("address add 172.29.107.65/32 dev lo", "ip assign to lo failed");
 	run_ip("link set enclave_egress up", "unable to bring up egress");
 	run_ip("route add default dev enclave_egress", "unable to route");
 }

--- a/src/qos_core/src/egress.rs
+++ b/src/qos_core/src/egress.rs
@@ -129,7 +129,7 @@ pub fn create_tun_socket(if_name: &str) -> Result<OwnedFd, Box<dyn Error>> {
 
 		// Set flags to IFF_TUN
 		// Using libc directly for the ioctl is common when nix lacks the specific macro:
-		let ret = nix::libc::ioctl(fd, 0x4004_54ca, &raw const ifr);
+		let ret = nix::libc::ioctl(fd, 0x4004_54ca, &raw mut ifr);
 		if ret < 0 {
 			libc::close(fd);
 			return Err(Box::new(std::io::Error::last_os_error()));
@@ -252,7 +252,7 @@ fn pipe_frames(
 			}
 
 			if let Some(size) = next_frame(&buf[sent..received]) {
-				assert!(sent + size < buf.len(), "frame buffer overflow"); // should be impossible as MTU is 1500
+				assert!(sent + size <= buf.len(), "frame buffer overflow"); // should be impossible as MTU is 1500
 				frame_size = sent + size;
 			} else {
 				let tail_size = received - sent;

--- a/src/qos_core/src/egress.rs
+++ b/src/qos_core/src/egress.rs
@@ -272,7 +272,7 @@ pub fn run_ip(args: &str, fail_str: &str) {
 	assert!(ip_exit.success(), "{}", fail_str);
 }
 
-/// run a statically linked program in a loop
+/// run a statically linked program in a loop in a separate thread (not blocking)
 pub fn run_looping(cmd_path: &str, args: &str) {
 	let cmd_path = cmd_path.to_owned();
 	let args: Vec<String> =

--- a/src/qos_core/src/egress.rs
+++ b/src/qos_core/src/egress.rs
@@ -270,21 +270,15 @@ pub fn run_ip(args: &str, fail_str: &str) {
 	assert!(ip_exit.success(), "{}", fail_str);
 }
 
-/// run a statically linked program and return the `Child` handle
-/// # Errors
-/// returns `std::io::Error` in case of process creation problems
-pub fn run_static(cmd_path: &str, args: &str) -> std::io::Result<Child> {
-	Command::new(cmd_path).env_clear().args(args.split(' ')).spawn()
-}
-
 /// run a statically linked program in a loop
 pub fn run_looping(cmd_path: &str, args: &str) {
 	let cmd_path = cmd_path.to_owned();
-	let args = args.to_owned();
+	let args: Vec<String> =
+		args.split_whitespace().map(str::to_string).collect();
 
 	std::thread::spawn(move || {
 		loop {
-			match run_static(&cmd_path, &args) {
+			match Command::new(&cmd_path).env_clear().args(&args).spawn() {
 				Ok(mut child) => {
 					let exit = child.wait(); // try to wait, restart  in any case
 					eprintln!("process {cmd_path} exit {exit:?}");

--- a/src/qos_core/src/egress.rs
+++ b/src/qos_core/src/egress.rs
@@ -21,7 +21,6 @@ use nix::{
 /// egress vsock port used both in and out of the enclave to provide transparent egress data transfer
 pub const EGRESS_VSOCK_PORT: u32 = 1000; // reserved range so user ports don't interfere
 
-/// sets up required tuntap interfaces using the `ip` binary
 /// opens enclave side egress bridging using given cid and port blocking forever
 /// # Panics
 /// panics on socket errors of any kind

--- a/src/qos_core/src/egress.rs
+++ b/src/qos_core/src/egress.rs
@@ -19,14 +19,21 @@ use nix::{
 };
 
 /// egress vsock port used both in and out of the enclave to provide transparent egress data transfer
+#[cfg(not(feature = "qemu"))]
 pub const EGRESS_VSOCK_PORT: u32 = 1000; // reserved range so user ports don't interfere
+
+/// egress vsock port used both in and out of the enclave to provide transparent egress data transfer
+#[cfg(feature = "qemu")]
+pub const EGRESS_VSOCK_PORT: u32 = 9002; // open range for qemu local debug
 
 /// opens enclave side egress bridging using given cid and port blocking forever
 /// # Panics
 /// panics on socket errors of any kind
 #[allow(unsafe_code)]
 pub fn enclave_egress(cid: u32, port: u32, flags: u8) {
-	eprintln!("qos_bridge: enclave egress running");
+	eprintln!(
+		"qos_bridge: enclave egress running cid: {cid} port: {port} flags: {flags:02x}"
+	);
 	let addr = SocketAddress::new_vsock_raw(cid, port, flags);
 	let core_socket =
 		create_core_socket().expect("unable to create core socket");
@@ -49,7 +56,9 @@ pub fn enclave_egress(cid: u32, port: u32, flags: u8) {
 /// # Panics
 /// panics on socket errors of any kind
 pub fn host_egress(cid: u32, port: u32, flags: u8) {
-	eprintln!("qos_bridge: host egress running");
+	eprintln!(
+		"qos_bridge: host egress running cid: {cid} port: {port} flags: {flags:02x}"
+	);
 	// NOTE: it's important we don't loop just connect here as that seems to cause EPIPE errors after it does connect
 	let proxy_fd = loop {
 		let addr = SocketAddress::new_vsock_raw(cid, port, flags);

--- a/src/qos_core/src/egress.rs
+++ b/src/qos_core/src/egress.rs
@@ -1,0 +1,295 @@
+//! Transparent egress functionality using linux tuntap and basic unix blocking syscalls
+
+use std::{
+	error::Error,
+	ffi::CString,
+	os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd},
+	process::{Child, Command},
+	time::Duration,
+};
+
+use crate::io::SocketAddress;
+use nix::{
+	NixPath, libc,
+	sys::socket::{
+		AddressFamily, Backlog, SockFlag, SockType, accept, bind, connect,
+		listen, socket,
+	},
+	unistd::{read, write},
+};
+
+/// sets up required tuntap interfaces using the `ip` binary
+/// opens enclave side egress bridging using given cid and port blocking forever
+/// # Panics
+/// panics on socket errors of any kind
+#[allow(unsafe_code)]
+pub fn enclave_egress(cid: u32, port: u32, flags: u8) {
+	setup_enclave_tunnel();
+
+	let addr = SocketAddress::new_vsock_raw(cid, port, flags);
+	let core_socket =
+		create_core_socket().expect("unable to create core socket");
+
+	bind(core_socket.as_raw_fd(), &addr).expect("unable to bind core socket");
+
+	// rust stdlib uses a 128 connection backlog
+	listen(&core_socket, Backlog::new(1).expect("unable to set backlog"))
+		.expect("unable to listen on core socket");
+
+	let stream_fd = accept(core_socket.as_raw_fd())
+		.expect("unable to accept on core socket");
+	let stream = unsafe { OwnedFd::from_raw_fd(stream_fd) };
+	let sock_fd = create_tun_socket("enclave_egress")
+		.expect("unable to create raw socket");
+	copy_bidirectional(sock_fd, stream);
+}
+
+/// opens host side egress bridging at the specified address, blocking forever
+/// # Panics
+/// panics on socket errors of any kind
+pub fn host_egress(cid: u32, port: u32, flags: u8) {
+	// NOTE: it's important we don't loop just connect here as that seems to cause EPIPE errors after it does connect
+	let proxy_fd = loop {
+		let addr = SocketAddress::new_vsock_raw(cid, port, flags);
+		let proxy_fd = create_core_socket().expect("unable to create vsock");
+
+		if connect(proxy_fd.as_raw_fd(), &addr).is_ok() {
+			break proxy_fd;
+		}
+		std::thread::sleep(Duration::from_millis(200));
+	};
+
+	let sock_fd =
+		create_tun_socket("host_egress").expect("unable to create raw socket");
+
+	copy_bidirectional(sock_fd, proxy_fd);
+}
+
+// sets up new tuntap tun interface `enclave_egress` with localhost routing using `10.0.0.1/32` mask
+// and default gw
+fn setup_enclave_tunnel() {
+	run_ip("tuntap add enclave_egress mode tun", "tuntap add failed");
+	run_ip("link set lo up", "unable to bring up lo");
+	run_ip("address add 10.0.0.1/32 dev lo", "ip assign to lo failed");
+	run_ip("link set enclave_egress up", "unable to bring up egress");
+	run_ip("route add default dev enclave_egress", "unable to route");
+}
+
+/// Create core vsock socket in streaming mode
+/// # Returns
+/// returns the new `OwnedFd` vsock
+/// # Errors
+/// same as `socket` from `nix`
+pub fn create_core_socket() -> Result<OwnedFd, nix::Error> {
+	socket(AddressFamily::Vsock, SockType::Stream, SockFlag::empty(), None)
+}
+
+/// Create a raw socket connecting to the given linux tun interface
+/// # Returns
+/// returns the new `OwnedFd` raw socket
+/// # Errors
+/// returns `NilError` in case of `CString` failure, or `std::io::Error` from `libc::errno` if `open` or `ioctl` have failed
+#[allow(unsafe_code)]
+#[allow(clippy::cast_possible_truncation)]
+pub fn create_tun_socket(if_name: &str) -> Result<OwnedFd, Box<dyn Error>> {
+	let if_name = CString::new(if_name)?;
+	let name_ptr = if_name.as_ptr();
+	let name_len = if_name.len().min(nix::libc::IFNAMSIZ - 1);
+	let mut ifr = libc::ifreq {
+		ifr_name: [0; nix::libc::IFNAMSIZ],
+		ifr_ifru: unsafe { std::mem::zeroed() },
+	};
+
+	let tun_dev = CString::new("/dev/net/tun")?;
+
+	unsafe {
+		let fd = libc::open(tun_dev.as_ptr(), libc::O_RDWR);
+		if fd < 0 {
+			return Err(Box::new(std::io::Error::last_os_error()));
+		}
+		std::ptr::copy_nonoverlapping(
+			name_ptr,
+			ifr.ifr_name.as_mut_ptr(),
+			name_len,
+		);
+		ifr.ifr_ifru.ifru_flags = libc::IFF_TUN as i16 | libc::IFF_NO_PI as i16;
+
+		// Set flags to IFF_TUN
+		// Using libc directly for the ioctl is common when nix lacks the specific macro:
+		let ret = nix::libc::ioctl(fd, 0x4004_54ca, &raw const ifr);
+		if ret < 0 {
+			libc::close(fd);
+			return Err(Box::new(std::io::Error::last_os_error()));
+		}
+
+		Ok(OwnedFd::from_raw_fd(fd))
+	}
+}
+
+/// Copies traffic in both directions between two sockets using threads, never returns
+/// # Panics
+/// Panics if any read/write operation panics
+fn copy_bidirectional(rsock: OwnedFd, vsock: OwnedFd) {
+	std::thread::scope(|s| {
+		let sfd = rsock.as_fd();
+		let tfd = vsock.as_fd();
+		std::thread::Builder::new()
+			.name("raw_to_vsock".to_owned())
+			.spawn_scoped(s, move || {
+				pipe_all(sfd, tfd).expect("error piping from raw to vsock");
+			})
+			.expect("unable to run scoped thread");
+
+		let sfd = rsock.as_fd();
+		let tfd = vsock.as_fd();
+		std::thread::Builder::new()
+			.name("vsock_to_raw".to_owned())
+			.spawn_scoped(s, move || {
+				// pipe_all(tfd, sfd, TrafficDirection::VsockToRaw(debug))
+				pipe_frames(tfd, sfd).expect("error piping from vsock to raw");
+			})
+			.expect("unable to run scoped thread");
+	});
+
+	// mostly for lint, we want to consume here on purpose as copy_bidirectional is supposed to be a terminal function
+	drop(rsock);
+	drop(vsock);
+}
+
+/// sends all traffic from `fd_from` to `fd_to` byte by byte
+/// # Panics
+/// panics if reads receive 0
+fn pipe_all(fd_from: BorrowedFd, fd_to: BorrowedFd) -> Result<(), nix::Error> {
+	// NOTE: qemu has the same bug as aws nitro
+	#[allow(clippy::large_stack_arrays)]
+	let mut buf = [0u8; 32000];
+
+	loop {
+		let received = read(fd_from, &mut buf)?;
+		assert!(received > 0, "unexpected disconnect from socket");
+
+		let mut sent = 0;
+		while sent < received {
+			sent += write(fd_to, &buf[sent..received])?;
+		}
+	}
+}
+
+// returns Some(size) of the first ip frame present in `buf` or None if no complete frame is found
+// WARNING: assumes `buf` slice starts at frame boundary!
+fn next_frame(buf: &[u8]) -> Option<usize> {
+	let Ok((ip, _)) = etherparse::LaxIpSlice::from_slice(buf) else {
+		return None;
+	};
+
+	let size: usize = if let Some(ip4) = ip.ipv4() {
+		ip4.header().total_len()
+	} else if let Some(ip6) = ip.ipv6() {
+		ip6.header().payload_length() + 40 // ip6 40 bytes header + payload_length
+	} else {
+		panic!("invalid ip version??");
+	}
+	.into();
+
+	if buf.len() < size { None } else { Some(size) }
+}
+
+// sends all traffic from fd_from to fd_to byte by ip frames waiting for completion on reads
+fn pipe_frames(
+	fd_from: BorrowedFd,
+	fd_to: BorrowedFd,
+) -> Result<(), nix::Error> {
+	// NOTE: qemu has the same bug as aws nitro
+	#[allow(clippy::large_stack_arrays)]
+	let mut buf = [0u8; 32000];
+	let mut frame_size;
+	let mut received = 0;
+
+	loop {
+		loop {
+			let r = read(fd_from, &mut buf[received..])?;
+			assert!(r > 0, "unexpected disconnect from socket");
+			received += r;
+
+			if let Some(size) = next_frame(&buf[..received]) {
+				frame_size = size;
+				break;
+			}
+		}
+
+		let mut sent = 0;
+		loop {
+			while sent < frame_size {
+				sent += write(fd_to, &buf[sent..frame_size])?;
+			}
+
+			if let Some(size) = next_frame(&buf[sent..received]) {
+				assert!(sent + size < buf.len(), "frame buffer overflow"); // should be impossible as MTU is 1500
+				frame_size = sent + size;
+			} else {
+				let tail_size = received - sent;
+				// copy tail to start so we can continue on reads
+				if sent < received {
+					buf.rotate_left(sent);
+				}
+				received = tail_size;
+				break;
+			}
+		}
+	}
+}
+
+/// Default path to the `ip` utility program
+pub const IP_PATH: &str = "/usr/sbin/ip";
+
+/// run the `ip` utility via the `run_with_ld`
+/// # Panics
+/// panics on program spawn errors
+pub fn run_ip(args: &str, fail_str: &str) {
+	let ip_exit = run_with_ld(IP_PATH, args)
+		.expect("unable to run ip command")
+		.wait()
+		.expect("ip program failed to finish");
+	assert!(ip_exit.success(), "{}", fail_str);
+}
+
+/// run a statically linked program and return the `Child` handle
+/// # Errors
+/// returns `std::io::Error` in case of process creation problems
+pub fn run_static(cmd_path: &str, args: &str) -> std::io::Result<Child> {
+	Command::new(cmd_path).env_clear().args(args.split(' ')).spawn()
+}
+
+/// run a statically linked program in a loop
+pub fn run_looping(cmd_path: &str, args: &str) {
+	let cmd_path = cmd_path.to_owned();
+	let args = args.to_owned();
+
+	std::thread::spawn(move || {
+		loop {
+			match run_static(&cmd_path, &args) {
+				Ok(mut child) => {
+					let exit = child.wait(); // try to wait, restart  in any case
+					eprintln!("process {cmd_path} exit {exit:?}");
+				}
+				Err(err) => {
+					eprintln!("error spawning process {cmd_path}: {err}");
+				}
+			}
+
+			eprintln!("process {cmd_path} exited, restarting in 200ms");
+			std::thread::sleep(Duration::from_millis(200));
+		}
+	});
+}
+
+/// run a program with `/lib/ld-musl-x86` loader and return the `Child` handle
+/// # Errors
+/// returns `std::io::Error` in case of process creation problems
+pub fn run_with_ld(cmd_path: &str, args: &str) -> std::io::Result<Child> {
+	Command::new("/lib/ld-musl-x86")
+		.env_clear()
+		.arg(cmd_path)
+		.args(args.split(' '))
+		.spawn()
+}

--- a/src/qos_core/src/egress.rs
+++ b/src/qos_core/src/egress.rs
@@ -18,14 +18,15 @@ use nix::{
 	unistd::{read, write},
 };
 
+/// egress vsock port used both in and out of the enclave to provide transparent egress data transfer
+pub const EGRESS_VSOCK_PORT: u32 = 1000; // reserved range so user ports don't interfere
+
 /// sets up required tuntap interfaces using the `ip` binary
 /// opens enclave side egress bridging using given cid and port blocking forever
 /// # Panics
 /// panics on socket errors of any kind
 #[allow(unsafe_code)]
 pub fn enclave_egress(cid: u32, port: u32, flags: u8) {
-	setup_enclave_tunnel();
-
 	let addr = SocketAddress::new_vsock_raw(cid, port, flags);
 	let core_socket =
 		create_core_socket().expect("unable to create core socket");
@@ -65,9 +66,11 @@ pub fn host_egress(cid: u32, port: u32, flags: u8) {
 	copy_bidirectional(sock_fd, proxy_fd);
 }
 
-// sets up new tuntap tun interface `enclave_egress` with localhost routing using `10.0.0.1/32` mask
-// and default gw
-fn setup_enclave_tunnel() {
+/// sets up new tuntap tun interface `enclave_egress` with localhost routing using `10.0.0.1/32` mask and default gw
+/// expects `/usr/sbin/ip` and `/lib/ld-musl-x86` to be present
+/// # Panics
+/// panics if the program executions fail
+pub fn init_egress_tun() {
 	run_ip("tuntap add enclave_egress mode tun", "tuntap add failed");
 	run_ip("link set lo up", "unable to bring up lo");
 	run_ip("address add 10.0.0.1/32 dev lo", "ip assign to lo failed");
@@ -128,12 +131,12 @@ pub fn create_tun_socket(if_name: &str) -> Result<OwnedFd, Box<dyn Error>> {
 
 /// Copies traffic in both directions between two sockets using threads, never returns
 /// # Panics
-/// Panics if any read/write operation panics
+/// Panics if any read/write operation fails
 fn copy_bidirectional(rsock: OwnedFd, vsock: OwnedFd) {
 	std::thread::scope(|s| {
 		let sfd = rsock.as_fd();
 		let tfd = vsock.as_fd();
-		std::thread::Builder::new()
+		let raw_to_vsock = std::thread::Builder::new()
 			.name("raw_to_vsock".to_owned())
 			.spawn_scoped(s, move || {
 				pipe_all(sfd, tfd).expect("error piping from raw to vsock");
@@ -142,13 +145,28 @@ fn copy_bidirectional(rsock: OwnedFd, vsock: OwnedFd) {
 
 		let sfd = rsock.as_fd();
 		let tfd = vsock.as_fd();
-		std::thread::Builder::new()
+		let vsock_to_raw = std::thread::Builder::new()
 			.name("vsock_to_raw".to_owned())
 			.spawn_scoped(s, move || {
 				// pipe_all(tfd, sfd, TrafficDirection::VsockToRaw(debug))
 				pipe_frames(tfd, sfd).expect("error piping from vsock to raw");
 			})
 			.expect("unable to run scoped thread");
+
+		// see if any of the threads have paniced and if so, propagate the error and panic the main process
+		loop {
+			if raw_to_vsock.is_finished() {
+				raw_to_vsock.join().expect("raw_to_vsock worker error");
+				panic!("raw_to_vsock exit");
+			}
+
+			if vsock_to_raw.is_finished() {
+				vsock_to_raw.join().expect("vsock_to_raw worker error");
+				panic!("vsock_to_raw exit");
+			}
+
+			std::thread::sleep(Duration::from_millis(200));
+		}
 	});
 
 	// mostly for lint, we want to consume here on purpose as copy_bidirectional is supposed to be a terminal function

--- a/src/qos_core/src/io/mod.rs
+++ b/src/qos_core/src/io/mod.rs
@@ -208,7 +208,7 @@ impl SocketAddress {
 			Self::Vsock(vsa) => Ok(Self::new_vsock(
 				vsa.cid(),
 				port.into(),
-				vsock_svm_flags(*vsa),
+				vsock_svm_flags(vsa),
 			)),
 			Self::Unix(ua) => {
 				let mut path = ua
@@ -252,29 +252,31 @@ impl std::fmt::Display for SocketAddress {
 
 /// Extract `svm_flags` field value from existing VSOCK.
 #[cfg(not(target_os = "macos"))]
-#[allow(unsafe_code)]
 #[must_use]
-pub fn vsock_svm_flags(vsock: VsockAddr) -> u8 {
-	// SAFETY: `SockAddrVm` is `repr(C)` and laid out identically to the
-	// kernel `sockaddr_vm` structure that backs `nix`'s `VsockAddr`, so the
-	// reinterpret is well-defined for the purpose of reading the
-	// `svm_flags` byte.
+#[allow(unsafe_code)]
+pub fn vsock_svm_flags(vsock: &VsockAddr) -> u8 {
 	unsafe {
-		let cast: SockAddrVm = std::mem::transmute(vsock);
+		let cast: SockAddrVm = std::mem::transmute(*vsock);
 		cast.svm_flags
 	}
 }
 
+/// `sockaddr_vm` representation that contains the new `svm_flags` since `libc` currently still does not
 #[cfg(not(target_os = "macos"))]
 #[repr(C)]
 #[allow(clippy::struct_field_names)]
-struct SockAddrVm {
-	svm_family: libc::sa_family_t,
-	svm_reserved1: libc::c_ushort,
-	svm_port: libc::c_uint,
-	svm_cid: libc::c_uint,
-	// Field added [here](https://github.com/torvalds/linux/commit/3a9c049a81f6bd7c78436d7f85f8a7b97b0821e6)
-	// but not yet in a version of libc we can use.
-	svm_flags: u8,
-	svm_zero: [u8; 3],
+pub(crate) struct SockAddrVm {
+	/// Family
+	pub(crate) svm_family: libc::sa_family_t,
+	/// Kernel reserved
+	pub(crate) svm_reserved1: libc::c_ushort,
+	/// Port
+	pub(crate) svm_port: libc::c_uint,
+	/// Cid
+	pub(crate) svm_cid: libc::c_uint,
+	/// Field added [here](https://github.com/torvalds/linux/commit/3a9c049a81f6bd7c78436d7f85f8a7b97b0821e6)
+	/// but not yet in a version of libc we can use.
+	pub(crate) svm_flags: u8,
+	/// Zero padding
+	pub(crate) svm_zero: [u8; 3],
 }

--- a/src/qos_core/src/io/pool.rs
+++ b/src/qos_core/src/io/pool.rs
@@ -286,7 +286,7 @@ impl SocketAddress {
 			Self::Vsock(vsock) => Ok(Self::new_vsock(
 				vsock.cid(),
 				vsock.port() + 1,
-				super::vsock_svm_flags(*vsock),
+				super::vsock_svm_flags(vsock),
 			)),
 		}
 	}

--- a/src/qos_core/src/io/stream.rs
+++ b/src/qos_core/src/io/stream.rs
@@ -150,6 +150,9 @@ impl Stream {
 		// first time? connect
 		if self.inner.is_none() {
 			self.connect().await?;
+
+			#[cfg(feature = "qemu")]
+			tokio::time::sleep(std::time::Duration::from_millis(50)).await; // see https://github.com/rust-vmm/vhost-device/issues/963
 		} else {
 			eprintln!("SocketStream already connected, call proceeding");
 		}

--- a/src/qos_core/src/lib.rs
+++ b/src/qos_core/src/lib.rs
@@ -7,15 +7,17 @@
 //! This crate should have as minimal dependencies as possible to decrease
 //! supply chain attack vectors and audit burden
 
-pub mod client;
-pub mod server;
-
 pub mod cli;
+pub mod client;
 pub mod handles;
 pub mod io;
 pub mod parser;
 pub mod protocol;
 pub mod reaper;
+pub mod server;
+
+#[cfg(feature = "egress")]
+pub mod egress;
 
 /// Path to Quorum Key secret.
 pub const QUORUM_FILE: &str = "/qos.quorum.key";

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -117,10 +117,7 @@ fn run_egress_bridge(_core_socket: &SocketAddress) {
 fn run_egress_bridge(core_socket: &SocketAddress) {
 	let cid = core_socket.vsock().cid();
 
-	crate::egress::run_looping(
-		"/qos_bridge",
-		&format!("--cid {cid} --enclave-egress"),
-	);
+	crate::egress::run_looping("/egress", &format!("--cid {cid}"));
 }
 
 fn reprint_pivot_output(child: &mut Child) {

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -121,7 +121,7 @@ fn run_egress_bridge(core_socket: &SocketAddress) {
 	let flags = crate::io::vsock_svm_flags(vsock); // ensure we copy the flags as set
 
 	tokio::task::spawn_blocking(move || {
-		println!("reaper: starting transparent egress host side");
+		println!("reaper: starting transparent egress enclave side");
 		crate::egress::enclave_egress(cid, EGRESS_PORT, flags);
 	});
 }

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -66,18 +66,21 @@ async fn run_server(
 	println!("Reaper::server shutdown");
 }
 
-// runs the VSOCK -> TCP bridge so that apps can use any TCP based protocol without worrying about VSOCK
+// runs configured bridges based on `BridgeConfig` so that apps can use any TCP based protocol without worrying about VSOCK
 // communication. This is started if `PivotConfig::bridge_config` has any members defined.
-// uses the enclave core socket and given pivot host port to constuct the VSOCK to TCP bridge.
-fn run_vsock_to_tcp_bridge(
+// uses the enclave core socket and given pivot host port to construct the VSOCK to TCP bridge for server side
+// and opens a fully transparent egress if client side is set.
+fn run_bridges(
 	core_socket: &SocketAddress,
-	bridges: &Vec<BridgeConfig>,
+	bridges: &[BridgeConfig],
 ) -> Result<(), IOError> {
 	// do nothing if we're not asked to provide bridging
 	if bridges.is_empty() {
 		println!("skipping host bridge, not configured");
 		return Ok(());
 	}
+
+	let mut egress_enabled = false;
 
 	for bc in bridges {
 		match bc {
@@ -91,12 +94,36 @@ fn run_vsock_to_tcp_bridge(
 				bridge.vsock_to_tcp();
 			}
 			BridgeConfig::Client { port: _, host: _ } => {
-				panic!("client bridge unimplemented")
-			} // TODO: implement
+				// only run one instance as it covers ALL ports, the others are for firewalls
+				if !egress_enabled {
+					egress_enabled = true;
+					run_egress_bridge(core_socket);
+				}
+			}
 		}
 	}
 
 	Ok(())
+}
+
+// dummy placeholder
+#[cfg(target_os = "macos")]
+fn run_egress_bridge(_core_socket: &SocketAddress) {
+	panic!("unable to run egress without vm feature and vsock support");
+}
+
+// run the transparent host egress
+#[cfg(not(target_os = "macos"))]
+fn run_egress_bridge(core_socket: &SocketAddress) {
+	const EGRESS_PORT: u32 = 1000; // reserved range so user ports don't interfere
+	let vsock = core_socket.vsock();
+	let cid = vsock.cid();
+	let flags = crate::io::vsock_svm_flags(vsock); // ensure we copy the flags as set
+
+	tokio::task::spawn_blocking(move || {
+		println!("reaper: starting transparent egress host side");
+		crate::egress::enclave_egress(cid, EGRESS_PORT, flags);
+	});
 }
 
 fn reprint_pivot_output(child: &mut Child) {
@@ -194,8 +221,8 @@ impl Reaper {
 		let host_config = manifest.bridge_config().to_vec();
 
 		// if the app indicates the need for the VSOCK -> TCP bridge, run it as another task
-		run_vsock_to_tcp_bridge(&core_socket, &host_config)
-			.expect("failed to run VSOCK -> TCP socket bridge");
+		run_bridges(&core_socket, &host_config)
+			.expect("failed to run ingress/egress bridges");
 
 		let mut pivot = Command::new(handles.pivot_path());
 		pivot.env_clear();

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -107,39 +107,20 @@ fn run_bridges(
 }
 
 // dummy placeholder
-#[cfg(target_os = "macos")]
+#[cfg(not(feature = "egress"))]
 fn run_egress_bridge(_core_socket: &SocketAddress) {
-	panic!("unable to run egress without vm feature and vsock support");
+	panic!("unable to run egress without vsock support");
 }
 
 // run the transparent host egress
-#[cfg(not(target_os = "macos"))]
+#[cfg(feature = "egress")]
 fn run_egress_bridge(core_socket: &SocketAddress) {
-	let vsock = core_socket.vsock();
-	let cid = vsock.cid();
-	let flags = crate::io::vsock_svm_flags(vsock); // ensure we copy the flags as set
+	let cid = core_socket.vsock().cid();
 
-	tokio::task::spawn_blocking(move || {
-		use crate::egress::EGRESS_VSOCK_PORT;
-
-		loop {
-			let egress_worker = std::thread::spawn(move || {
-				println!("reaper: starting transparent egress enclave side");
-				crate::egress::enclave_egress(cid, EGRESS_VSOCK_PORT, flags);
-			});
-
-			match egress_worker.join() {
-				Ok(_) => {
-					eprintln!("egress worker stopped without error, restarting")
-				}
-				Err(err) => {
-					eprintln!("egress worker error: {err:?}, restarting")
-				}
-			}
-
-			std::thread::sleep(Duration::from_millis(200));
-		}
-	});
+	crate::egress::run_looping(
+		"/qos_bridge",
+		&format!("--cid {cid} --enclave-egress"),
+	);
 }
 
 fn reprint_pivot_output(child: &mut Child) {

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -117,7 +117,10 @@ fn run_egress_bridge(_core_socket: &SocketAddress) {
 fn run_egress_bridge(core_socket: &SocketAddress) {
 	let cid = core_socket.vsock().cid();
 
-	crate::egress::run_looping("/egress", &format!("--cid {cid}"));
+	crate::egress::run_looping(
+		"/egress",
+		&format!("--cid {cid} --vsock-to-host false"),
+	);
 }
 
 fn reprint_pivot_output(child: &mut Child) {

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -122,8 +122,23 @@ fn run_egress_bridge(core_socket: &SocketAddress) {
 	tokio::task::spawn_blocking(move || {
 		use crate::egress::EGRESS_VSOCK_PORT;
 
-		println!("reaper: starting transparent egress enclave side");
-		crate::egress::enclave_egress(cid, EGRESS_VSOCK_PORT, flags);
+		loop {
+			let egress_worker = std::thread::spawn(move || {
+				println!("reaper: starting transparent egress enclave side");
+				crate::egress::enclave_egress(cid, EGRESS_VSOCK_PORT, flags);
+			});
+
+			match egress_worker.join() {
+				Ok(_) => {
+					eprintln!("egress worker stopped without error, restarting")
+				}
+				Err(err) => {
+					eprintln!("egress worker error: {err:?}, restarting")
+				}
+			}
+
+			std::thread::sleep(Duration::from_millis(200));
+		}
 	});
 }
 

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -115,14 +115,15 @@ fn run_egress_bridge(_core_socket: &SocketAddress) {
 // run the transparent host egress
 #[cfg(not(target_os = "macos"))]
 fn run_egress_bridge(core_socket: &SocketAddress) {
-	const EGRESS_PORT: u32 = 1000; // reserved range so user ports don't interfere
 	let vsock = core_socket.vsock();
 	let cid = vsock.cid();
 	let flags = crate::io::vsock_svm_flags(vsock); // ensure we copy the flags as set
 
 	tokio::task::spawn_blocking(move || {
+		use crate::egress::EGRESS_VSOCK_PORT;
+
 		println!("reaper: starting transparent egress enclave side");
-		crate::egress::enclave_egress(cid, EGRESS_PORT, flags);
+		crate::egress::enclave_egress(cid, EGRESS_VSOCK_PORT, flags);
 	});
 }
 

--- a/src/qos_host/Cargo.toml
+++ b/src/qos_host/Cargo.toml
@@ -19,3 +19,7 @@ borsh = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[features]
+# Support for localhost qemu setup without forcing host to use root
+qemu = ["qos_core/qemu"]

--- a/src/scripts/enclave_egress_interfaces.sh
+++ b/src/scripts/enclave_egress_interfaces.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+
+set -e
+
+DEFINT="${1:-eth0}"
+
+# create egress from host tun interface
+sudo ip tuntap add host_egress mode tun
+
+# assign 10.0.0.2/28 to host_egress to mask the martians
+sudo ip address add 172.29.107.66/28 dev host_egress
+
+# bring the interface up
+sudo ip link set host_egress up
+
+# ensure forwarding is going to go through
+echo 1 | sudo tee /proc/sys/net/ipv4/ip_forward > /dev/null
+sudo iptables -P FORWARD ACCEPT
+
+# masquerade nat for egress
+sudo iptables -t nat -I POSTROUTING -s 172.29.107.65 -j MASQUERADE -o "$DEFINT"
+
+# check it
+ip a show dev host_egress


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

qos_core: add new transparent egress support
qos_bridge: implement host side of the transparent egress

new dependency: etherparse and arrayvec as indirect dependency of that

There are also new dev dependencies for the `pivot_download` example in integration. I'm not sure if there's a better way to isolate those.

## How I Tested These Changes

Locally so far

## Pre merge check list

No breaking changes, fully key-forward and Manifest compatible, previous versions would just panic if we configured the client type in `BridgeConfig`