### PR TITLE
Make egress bridge restart cooperatively

### DIFF
--- a/src/qos_bridge/src/host.rs
+++ b/src/qos_bridge/src/host.rs
@@ -9,7 +9,7 @@ use qos_core::{
 	io::{HostBridge, SocketAddress, StreamPool},
 	protocol::services::boot::BridgeConfig,
 };
-use qos_host::{EnclaveInfo, ENCLAVE_INFO};
+use qos_host::{ENCLAVE_INFO, EnclaveInfo};
 
 /// Host server implementation using `HostBridge::tcp_to_vsock`
 pub struct BridgeServer {

--- a/src/qos_bridge/src/host.rs
+++ b/src/qos_bridge/src/host.rs
@@ -9,7 +9,7 @@ use qos_core::{
 	io::{HostBridge, SocketAddress, StreamPool},
 	protocol::services::boot::BridgeConfig,
 };
-use qos_host::{ENCLAVE_INFO, EnclaveInfo};
+use qos_host::{EnclaveInfo, ENCLAVE_INFO};
 
 /// Host server implementation using `HostBridge::tcp_to_vsock`
 pub struct BridgeServer {
@@ -106,8 +106,25 @@ impl BridgeServer {
 		tokio::task::spawn_blocking(move || {
 			use qos_core::egress::EGRESS_VSOCK_PORT;
 
-			println!("qos_bridge: starting transparent egress host side");
-			qos_core::egress::host_egress(cid, EGRESS_VSOCK_PORT, flags);
+			loop {
+				// Restart from the top of host_egress so errors drop the entire
+				// session and recreate the vsock fd before reconnecting.
+				println!("qos_bridge: starting transparent egress host side");
+				match qos_core::egress::host_egress(
+					cid,
+					EGRESS_VSOCK_PORT,
+					flags,
+				) {
+					Ok(()) => eprintln!(
+						"qos_bridge: egress host side stopped without error, restarting"
+					),
+					Err(err) => eprintln!(
+						"qos_bridge: egress host side error: {err:?}, restarting"
+					),
+				}
+
+				std::thread::sleep(Duration::from_millis(200));
+			}
 		});
 	}
 

--- a/src/qos_core/src/egress.rs
+++ b/src/qos_core/src/egress.rs
@@ -10,60 +10,110 @@ use std::{
 
 use crate::io::SocketAddress;
 use nix::{
-	NixPath, libc,
+	errno::Errno,
+	libc,
 	sys::socket::{
-		AddressFamily, Backlog, SockFlag, SockType, accept, bind, connect,
-		listen, socket,
+		accept, bind, connect, listen, socket, AddressFamily, Backlog,
+		SockFlag, SockType,
 	},
 	unistd::{read, write},
+	NixPath,
 };
 
 /// egress vsock port used both in and out of the enclave to provide transparent egress data transfer
 pub const EGRESS_VSOCK_PORT: u32 = 1000; // reserved range so user ports don't interfere
 
-/// sets up required tuntap interfaces using the `ip` binary
-/// opens enclave side egress bridging using given cid and port blocking forever
-/// # Panics
-/// panics on socket errors of any kind
-#[allow(unsafe_code)]
-pub fn enclave_egress(cid: u32, port: u32, flags: u8) {
-	let addr = SocketAddress::new_vsock_raw(cid, port, flags);
-	let core_socket =
-		create_core_socket().expect("unable to create core socket");
-
-	bind(core_socket.as_raw_fd(), &addr).expect("unable to bind core socket");
-
-	// rust stdlib uses a 128 connection backlog
-	listen(&core_socket, Backlog::new(1).expect("unable to set backlog"))
-		.expect("unable to listen on core socket");
-
-	let stream_fd = accept(core_socket.as_raw_fd())
-		.expect("unable to accept on core socket");
-	let stream = unsafe { OwnedFd::from_raw_fd(stream_fd) };
-	let sock_fd = create_tun_socket("enclave_egress")
-		.expect("unable to create raw socket");
-	copy_bidirectional(sock_fd, stream);
+/// Egress bridge errors.
+#[derive(Debug)]
+pub enum EgressError {
+	/// `nix` syscall error.
+	Nix(nix::Error),
+	/// Standard I/O error.
+	Io(std::io::Error),
+	/// TUN socket setup failed.
+	TunSocket(String),
+	/// A pipe worker panicked.
+	WorkerPanic(&'static str),
+	/// Peer disconnected unexpectedly.
+	UnexpectedDisconnect,
+	/// A write returned zero bytes.
+	WriteZero,
+	/// Invalid IP frame.
+	InvalidIpFrame,
 }
 
-/// opens host side egress bridging at the specified address, blocking forever
-/// # Panics
-/// panics on socket errors of any kind
-pub fn host_egress(cid: u32, port: u32, flags: u8) {
-	// NOTE: it's important we don't loop just connect here as that seems to cause EPIPE errors after it does connect
-	let proxy_fd = loop {
+impl From<nix::Error> for EgressError {
+	fn from(value: nix::Error) -> Self {
+		Self::Nix(value)
+	}
+}
+
+impl From<std::io::Error> for EgressError {
+	fn from(value: std::io::Error) -> Self {
+		Self::Io(value)
+	}
+}
+
+/// sets up required tuntap interfaces using the `ip` binary
+/// opens one enclave side egress bridging session using given cid and port.
+///
+/// Returning from this function is the restart boundary. Callers should retry
+/// by calling it again so all session fds, including the vsock fd, are
+/// recreated from scratch.
+/// # Errors
+/// returns on socket errors of any kind
+#[allow(unsafe_code)]
+pub fn enclave_egress(
+	cid: u32,
+	port: u32,
+	flags: u8,
+) -> Result<(), EgressError> {
+	let addr = SocketAddress::new_vsock_raw(cid, port, flags);
+	let core_socket = create_core_socket()?;
+
+	bind(core_socket.as_raw_fd(), &addr)?;
+
+	// rust stdlib uses a 128 connection backlog
+	listen(&core_socket, Backlog::new(1)?)?;
+
+	let stream_fd = accept(core_socket.as_raw_fd())?;
+	let stream = unsafe { OwnedFd::from_raw_fd(stream_fd) };
+	let sock_fd = create_tun_socket("enclave_egress")
+		.map_err(|err| EgressError::TunSocket(err.to_string()))?;
+	copy_bidirectional(sock_fd, stream)
+}
+
+/// opens one host side egress bridging session at the specified address.
+///
+/// Returning from this function is the restart boundary. Callers should retry
+/// by calling it again so all session fds, including the vsock fd, are
+/// recreated from scratch.
+/// # Errors
+/// returns on socket errors of any kind
+pub fn host_egress(cid: u32, port: u32, flags: u8) -> Result<(), EgressError> {
+	let proxy_fd = connect_vsock_with_retry(cid, port, flags)?;
+	let sock_fd = create_tun_socket("host_egress")
+		.map_err(|err| EgressError::TunSocket(err.to_string()))?;
+
+	copy_bidirectional(sock_fd, proxy_fd)
+}
+
+fn connect_vsock_with_retry(
+	cid: u32,
+	port: u32,
+	flags: u8,
+) -> Result<OwnedFd, EgressError> {
+	loop {
 		let addr = SocketAddress::new_vsock_raw(cid, port, flags);
-		let proxy_fd = create_core_socket().expect("unable to create vsock");
+		// Create a fresh vsock fd for every attempt. Reusing a vsock fd after a
+		// failed pre-listener connect can poison the later connection.
+		let proxy_fd = create_core_socket()?;
 
 		if connect(proxy_fd.as_raw_fd(), &addr).is_ok() {
-			break proxy_fd;
+			return Ok(proxy_fd);
 		}
 		std::thread::sleep(Duration::from_millis(200));
-	};
-
-	let sock_fd =
-		create_tun_socket("host_egress").expect("unable to create raw socket");
-
-	copy_bidirectional(sock_fd, proxy_fd);
+	}
 }
 
 /// sets up new tuntap tun interface `enclave_egress` with localhost routing using `10.0.0.1/32` mask and default gw
@@ -129,75 +179,111 @@ pub fn create_tun_socket(if_name: &str) -> Result<OwnedFd, Box<dyn Error>> {
 	}
 }
 
-/// Copies traffic in both directions between two sockets using threads, never returns
-/// # Panics
-/// Panics if any read/write operation fails
-fn copy_bidirectional(rsock: OwnedFd, vsock: OwnedFd) {
-	std::thread::scope(|s| {
+/// Copies traffic in both directions between two sockets using threads.
+///
+/// Returns when either direction fails or disconnects, after cancelling and
+/// joining the sibling worker.
+fn copy_bidirectional(
+	rsock: OwnedFd,
+	vsock: OwnedFd,
+) -> Result<(), EgressError> {
+	set_nonblocking(rsock.as_fd())?;
+	set_nonblocking(vsock.as_fd())?;
+	let (cancel_read, cancel_write) = cancellation_pipe()?;
+
+	let result = std::thread::scope(|s| {
 		let sfd = rsock.as_fd();
 		let tfd = vsock.as_fd();
-		let raw_to_vsock = std::thread::Builder::new()
-			.name("raw_to_vsock".to_owned())
-			.spawn_scoped(s, move || {
-				pipe_all(sfd, tfd).expect("error piping from raw to vsock");
-			})
-			.expect("unable to run scoped thread");
+		let cancel = cancel_read.as_fd();
+		let mut raw_to_vsock = Some(
+			std::thread::Builder::new()
+				.name("raw_to_vsock".to_owned())
+				.spawn_scoped(s, move || pipe_all(sfd, tfd, cancel))?,
+		);
 
 		let sfd = rsock.as_fd();
 		let tfd = vsock.as_fd();
-		let vsock_to_raw = std::thread::Builder::new()
+		let cancel = cancel_read.as_fd();
+		let mut vsock_to_raw = match std::thread::Builder::new()
 			.name("vsock_to_raw".to_owned())
-			.spawn_scoped(s, move || {
-				// pipe_all(tfd, sfd, TrafficDirection::VsockToRaw(debug))
-				pipe_frames(tfd, sfd).expect("error piping from vsock to raw");
-			})
-			.expect("unable to run scoped thread");
+			.spawn_scoped(s, move || pipe_frames(tfd, sfd, cancel))
+		{
+			Ok(worker) => Some(worker),
+			Err(err) => {
+				signal_cancel(cancel_write.as_fd());
+				if let Some(worker) = raw_to_vsock {
+					join_pipe_worker("raw_to_vsock", worker)?;
+				}
+				return Err(err.into());
+			}
+		};
 
-		// see if any of the threads have paniced and if so, propagate the error and panic the main process
+		let first_result;
 		loop {
-			if raw_to_vsock.is_finished() {
-				raw_to_vsock.join().expect("raw_to_vsock worker error");
-				panic!("raw_to_vsock exit");
+			if raw_to_vsock.as_ref().is_some_and(|worker| worker.is_finished())
+			{
+				first_result = join_pipe_worker(
+					"raw_to_vsock",
+					raw_to_vsock.take().expect("worker exists"),
+				);
+				break;
 			}
 
-			if vsock_to_raw.is_finished() {
-				vsock_to_raw.join().expect("vsock_to_raw worker error");
-				panic!("vsock_to_raw exit");
+			if vsock_to_raw.as_ref().is_some_and(|worker| worker.is_finished())
+			{
+				first_result = join_pipe_worker(
+					"vsock_to_raw",
+					vsock_to_raw.take().expect("worker exists"),
+				);
+				break;
 			}
 
 			std::thread::sleep(Duration::from_millis(200));
 		}
+
+		signal_cancel(cancel_write.as_fd());
+
+		if let Some(worker) = raw_to_vsock {
+			join_pipe_worker("raw_to_vsock", worker)?;
+		}
+		if let Some(worker) = vsock_to_raw {
+			join_pipe_worker("vsock_to_raw", worker)?;
+		}
+
+		first_result
 	});
 
-	// mostly for lint, we want to consume here on purpose as copy_bidirectional is supposed to be a terminal function
 	drop(rsock);
 	drop(vsock);
+
+	result
 }
 
 /// sends all traffic from `fd_from` to `fd_to` byte by byte
-/// # Panics
-/// panics if reads receive 0
-fn pipe_all(fd_from: BorrowedFd, fd_to: BorrowedFd) -> Result<(), nix::Error> {
+fn pipe_all(
+	fd_from: BorrowedFd,
+	fd_to: BorrowedFd,
+	cancel: BorrowedFd,
+) -> Result<(), EgressError> {
 	// NOTE: qemu has the same bug as aws nitro
 	#[allow(clippy::large_stack_arrays)]
 	let mut buf = [0u8; 32000];
 
 	loop {
-		let received = read(fd_from, &mut buf)?;
-		assert!(received > 0, "unexpected disconnect from socket");
+		let Some(received) = read_with_cancel(fd_from, &mut buf, cancel)?
+		else {
+			return Ok(());
+		};
 
-		let mut sent = 0;
-		while sent < received {
-			sent += write(fd_to, &buf[sent..received])?;
-		}
+		write_all_with_cancel(fd_to, &buf[..received], cancel)?;
 	}
 }
 
 // returns Some(size) of the first ip frame present in `buf` or None if no complete frame is found
 // WARNING: assumes `buf` slice starts at frame boundary!
-fn next_frame(buf: &[u8]) -> Option<usize> {
+fn next_frame(buf: &[u8]) -> Result<Option<usize>, EgressError> {
 	let Ok((ip, _)) = etherparse::LaxIpSlice::from_slice(buf) else {
-		return None;
+		return Ok(None);
 	};
 
 	let size: usize = if let Some(ip4) = ip.ipv4() {
@@ -205,18 +291,23 @@ fn next_frame(buf: &[u8]) -> Option<usize> {
 	} else if let Some(ip6) = ip.ipv6() {
 		ip6.header().payload_length() + 40 // ip6 40 bytes header + payload_length
 	} else {
-		panic!("invalid ip version??");
+		return Err(EgressError::InvalidIpFrame);
 	}
 	.into();
 
-	if buf.len() < size { None } else { Some(size) }
+	if buf.len() < size {
+		Ok(None)
+	} else {
+		Ok(Some(size))
+	}
 }
 
 // sends all traffic from fd_from to fd_to byte by ip frames waiting for completion on reads
 fn pipe_frames(
 	fd_from: BorrowedFd,
 	fd_to: BorrowedFd,
-) -> Result<(), nix::Error> {
+	cancel: BorrowedFd,
+) -> Result<(), EgressError> {
 	// NOTE: qemu has the same bug as aws nitro
 	#[allow(clippy::large_stack_arrays)]
 	let mut buf = [0u8; 32000];
@@ -225,11 +316,18 @@ fn pipe_frames(
 
 	loop {
 		loop {
-			let r = read(fd_from, &mut buf[received..])?;
-			assert!(r > 0, "unexpected disconnect from socket");
+			if received == buf.len() {
+				return Err(EgressError::InvalidIpFrame);
+			}
+
+			let Some(r) =
+				read_with_cancel(fd_from, &mut buf[received..], cancel)?
+			else {
+				return Ok(());
+			};
 			received += r;
 
-			if let Some(size) = next_frame(&buf[..received]) {
+			if let Some(size) = next_frame(&buf[..received])? {
 				frame_size = size;
 				break;
 			}
@@ -238,11 +336,16 @@ fn pipe_frames(
 		let mut sent = 0;
 		loop {
 			while sent < frame_size {
-				sent += write(fd_to, &buf[sent..frame_size])?;
+				let written =
+					write_with_cancel(fd_to, &buf[sent..frame_size], cancel)?;
+				if written == 0 {
+					return Ok(());
+				}
+				sent += written;
 			}
 
-			if let Some(size) = next_frame(&buf[sent..received]) {
-				assert!(sent + size < buf.len(), "frame buffer overflow"); // should be impossible as MTU is 1500
+			if let Some(size) = next_frame(&buf[sent..received])? {
+				assert!(sent + size <= buf.len(), "frame buffer overflow"); // should be impossible as MTU is 1500
 				frame_size = sent + size;
 			} else {
 				let tail_size = received - sent;
@@ -255,6 +358,157 @@ fn pipe_frames(
 			}
 		}
 	}
+}
+
+fn join_pipe_worker(
+	name: &'static str,
+	worker: std::thread::ScopedJoinHandle<'_, Result<(), EgressError>>,
+) -> Result<(), EgressError> {
+	worker.join().map_err(|_| EgressError::WorkerPanic(name))?
+}
+
+#[allow(unsafe_code)]
+fn cancellation_pipe() -> Result<(OwnedFd, OwnedFd), EgressError> {
+	let mut fds = [0; 2];
+	let result = unsafe { libc::pipe(fds.as_mut_ptr()) };
+	if result < 0 {
+		return Err(std::io::Error::last_os_error().into());
+	}
+
+	Ok(unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) })
+}
+
+#[allow(unsafe_code)]
+fn signal_cancel(fd: BorrowedFd) {
+	let byte = [1_u8];
+	_ = unsafe {
+		libc::write(fd.as_raw_fd(), byte.as_ptr().cast::<libc::c_void>(), 1)
+	};
+}
+
+#[allow(unsafe_code)]
+fn set_nonblocking(fd: BorrowedFd) -> Result<(), EgressError> {
+	let flags = unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_GETFL) };
+	if flags < 0 {
+		return Err(std::io::Error::last_os_error().into());
+	}
+
+	let result = unsafe {
+		libc::fcntl(fd.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK)
+	};
+	if result < 0 {
+		return Err(std::io::Error::last_os_error().into());
+	}
+
+	Ok(())
+}
+
+enum WaitResult {
+	Ready,
+	Cancelled,
+}
+
+fn wait_fd(
+	fd: BorrowedFd,
+	events: libc::c_short,
+	cancel: BorrowedFd,
+) -> Result<WaitResult, EgressError> {
+	const POLL_FD_COUNT: libc::nfds_t = 2;
+
+	let mut poll_fds = [
+		libc::pollfd { fd: fd.as_raw_fd(), events, revents: 0 },
+		libc::pollfd {
+			fd: cancel.as_raw_fd(),
+			events: libc::POLLIN,
+			revents: 0,
+		},
+	];
+
+	loop {
+		for poll_fd in &mut poll_fds {
+			poll_fd.revents = 0;
+		}
+
+		#[allow(unsafe_code)]
+		let result = unsafe { libc::poll(poll_fds.as_mut_ptr(), POLL_FD_COUNT, -1) };
+
+		if result < 0 {
+			let errno = Errno::last();
+			if errno == Errno::EINTR {
+				continue;
+			}
+			return Err(EgressError::Nix(errno));
+		}
+
+		if poll_fds[1].revents != 0 {
+			return Ok(WaitResult::Cancelled);
+		}
+
+		if poll_fds[0].revents & libc::POLLNVAL != 0 {
+			return Err(EgressError::Io(std::io::Error::from_raw_os_error(
+				libc::EBADF,
+			)));
+		}
+
+		if poll_fds[0].revents != 0 {
+			return Ok(WaitResult::Ready);
+		}
+	}
+}
+
+fn read_with_cancel(
+	fd: BorrowedFd,
+	buf: &mut [u8],
+	cancel: BorrowedFd,
+) -> Result<Option<usize>, EgressError> {
+	loop {
+		if matches!(wait_fd(fd, libc::POLLIN, cancel)?, WaitResult::Cancelled) {
+			return Ok(None);
+		}
+
+		match read(fd, buf) {
+			Ok(0) => return Err(EgressError::UnexpectedDisconnect),
+			Ok(size) => return Ok(Some(size)),
+			Err(err) if err == Errno::EINTR || err == Errno::EAGAIN => {}
+			Err(err) => return Err(EgressError::Nix(err)),
+		}
+	}
+}
+
+fn write_with_cancel(
+	fd: BorrowedFd,
+	buf: &[u8],
+	cancel: BorrowedFd,
+) -> Result<usize, EgressError> {
+	loop {
+		if matches!(wait_fd(fd, libc::POLLOUT, cancel)?, WaitResult::Cancelled)
+		{
+			return Ok(0);
+		}
+
+		match write(fd, buf) {
+			Ok(0) => return Err(EgressError::WriteZero),
+			Ok(size) => return Ok(size),
+			Err(err) if err == Errno::EINTR || err == Errno::EAGAIN => {}
+			Err(err) => return Err(EgressError::Nix(err)),
+		}
+	}
+}
+
+fn write_all_with_cancel(
+	fd: BorrowedFd,
+	buf: &[u8],
+	cancel: BorrowedFd,
+) -> Result<(), EgressError> {
+	let mut sent = 0;
+	while sent < buf.len() {
+		let written = write_with_cancel(fd, &buf[sent..], cancel)?;
+		if written == 0 {
+			return Ok(());
+		}
+		sent += written;
+	}
+	Ok(())
 }
 
 /// Default path to the `ip` utility program
@@ -310,4 +564,55 @@ pub fn run_with_ld(cmd_path: &str, args: &str) -> std::io::Result<Child> {
 		.arg(cmd_path)
 		.args(args.split(' '))
 		.spawn()
+}
+
+#[cfg(test)]
+mod tests {
+	use std::{
+		os::fd::OwnedFd,
+		os::unix::net::UnixStream,
+		sync::{
+			atomic::{AtomicBool, Ordering},
+			Arc,
+		},
+		time::{Duration, Instant},
+	};
+
+	use super::{copy_bidirectional, EgressError};
+
+	#[test]
+	fn copy_bidirectional_returns_when_one_side_disconnects() {
+		let (raw, _raw_peer) = UnixStream::pair().unwrap();
+		let (vsock, vsock_peer) = UnixStream::pair().unwrap();
+		let raw_fd: OwnedFd = raw.into();
+		let vsock_fd: OwnedFd = vsock.into();
+		let finished = Arc::new(AtomicBool::new(false));
+		let finished_clone = Arc::clone(&finished);
+
+		let worker = std::thread::spawn(move || {
+			let result = copy_bidirectional(raw_fd, vsock_fd);
+			finished_clone.store(true, Ordering::SeqCst);
+			result
+		});
+
+		drop(vsock_peer);
+
+		let start = Instant::now();
+		while !finished.load(Ordering::SeqCst)
+			&& start.elapsed() < Duration::from_secs(1)
+		{
+			std::thread::sleep(Duration::from_millis(10));
+		}
+
+		assert!(
+			finished.load(Ordering::SeqCst),
+			"copy_bidirectional did not wake the sibling pipe worker"
+		);
+
+		let result = match worker.join() {
+			Ok(result) => result,
+			Err(_) => panic!("worker panicked"),
+		};
+		assert!(matches!(result, Err(EgressError::UnexpectedDisconnect)));
+	}
 }

--- a/src/qos_core/src/egress.rs
+++ b/src/qos_core/src/egress.rs
@@ -10,14 +10,14 @@ use std::{
 
 use crate::io::SocketAddress;
 use nix::{
+	NixPath,
 	errno::Errno,
 	libc,
 	sys::socket::{
-		accept, bind, connect, listen, socket, AddressFamily, Backlog,
-		SockFlag, SockType,
+		AddressFamily, Backlog, SockFlag, SockType, accept, bind, connect,
+		listen, socket,
 	},
 	unistd::{read, write},
-	NixPath,
 };
 
 /// egress vsock port used both in and out of the enclave to provide transparent egress data transfer
@@ -295,11 +295,7 @@ fn next_frame(buf: &[u8]) -> Result<Option<usize>, EgressError> {
 	}
 	.into();
 
-	if buf.len() < size {
-		Ok(None)
-	} else {
-		Ok(Some(size))
-	}
+	if buf.len() < size { Ok(None) } else { Ok(Some(size)) }
 }
 
 // sends all traffic from fd_from to fd_to byte by ip frames waiting for completion on reads
@@ -572,13 +568,13 @@ mod tests {
 		os::fd::OwnedFd,
 		os::unix::net::UnixStream,
 		sync::{
-			atomic::{AtomicBool, Ordering},
 			Arc,
+			atomic::{AtomicBool, Ordering},
 		},
 		time::{Duration, Instant},
 	};
 
-	use super::{copy_bidirectional, EgressError};
+	use super::{EgressError, copy_bidirectional};
 
 	#[test]
 	fn copy_bidirectional_returns_when_one_side_disconnects() {

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -21,9 +21,9 @@ use crate::{
 	handles::Handles,
 	io::{HostBridge, IOError, SocketAddress, StreamPool},
 	protocol::{
-		ProtocolPhase, ProtocolState,
 		processor::ProtocolProcessor,
 		services::boot::{BridgeConfig, RestartPolicy},
+		ProtocolPhase, ProtocolState,
 	},
 	server::SocketServer,
 };
@@ -123,13 +123,11 @@ fn run_egress_bridge(core_socket: &SocketAddress) {
 		use crate::egress::EGRESS_VSOCK_PORT;
 
 		loop {
-			let egress_worker = std::thread::spawn(move || {
-				println!("reaper: starting transparent egress enclave side");
-				crate::egress::enclave_egress(cid, EGRESS_VSOCK_PORT, flags);
-			});
-
-			match egress_worker.join() {
-				Ok(_) => {
+			// Restart from the top of enclave_egress so errors drop the entire
+			// session and recreate the vsock fd before accepting again.
+			println!("reaper: starting transparent egress enclave side");
+			match crate::egress::enclave_egress(cid, EGRESS_VSOCK_PORT, flags) {
+				Ok(()) => {
 					eprintln!("egress worker stopped without error, restarting")
 				}
 				Err(err) => {

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -21,9 +21,9 @@ use crate::{
 	handles::Handles,
 	io::{HostBridge, IOError, SocketAddress, StreamPool},
 	protocol::{
+		ProtocolPhase, ProtocolState,
 		processor::ProtocolProcessor,
 		services::boot::{BridgeConfig, RestartPolicy},
-		ProtocolPhase, ProtocolState,
 	},
 	server::SocketServer,
 };


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

## How I Tested These Changes

## Pre merge check list

- [ ] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
