### PR TITLE
qos_bridge: add egress setup POC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-trait"
 version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,6 +666,15 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "etherparse"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ac016aaf11dfe643edcd088a166234bfcb72e7f06691abfcf21e9af524037f4"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "ff"
@@ -1940,6 +1955,7 @@ version = "0.8.0"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "borsh",
+ "etherparse",
  "futures",
  "libc",
  "nix 0.30.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ aws-nitro-enclaves-nsm-api = { version = "0.4", default-features = false }
 axum = { version = "0.6.20", features = ["http1", "tokio", "json"], default-features = false }
 borsh = { version = "1.0", features = ["std", "derive"], default-features = false }
 chunked_transfer = { version = "1.5.0", default-features = false }
+etherparse = { version = "0.20.1", default-features = false }
 futures = { version = "0.3.30" }
 der = { version = "0.7", default-features = false }
 hex-literal = "0.4.0"

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,8 @@ out/qos_bridge/index.json: \
 	out/common/index.json \
 	$(CARGO_WORKSPACE_FILES) \
 	src/images/qos_bridge/Containerfile \
+	src/images/qos_bridge/enclave_egress_interfaces.sh \
+	src/images/qos_bridge/entrypoint.sh \
 	$(shell git ls-files \
 		src/qos_bridge \
 		src/qos_host \

--- a/src/images/qos_bridge/Containerfile
+++ b/src/images/qos_bridge/Containerfile
@@ -1,3 +1,8 @@
+FROM stagex/busybox:sx2024.11.0@sha256:3d128909dbc8e7b6c4b8c3c31f4583f01a307907ea179934bb42c4ef056c7efd AS busybox
+FROM stagex/iproute2:sx2024.11.0@sha256:65da03aa94d17dd6310b022f426a6cc8b3c55bb267e4bac1697bc57d6c850570 AS iproute2
+FROM stagex/iptables:sx2024.11.0@sha256:185773114afa78f26e77a88b452894b805200594fe7d3d0e08b804bc7beb7517 AS iptables
+FROM stagex/musl:sx2024.11.0@sha256:d7f6c365f5724c65cadb2b96d9f594e46132ceb366174c89dbf7554897f2bc53 AS musl
+
 FROM common AS base
 ADD . /src
 
@@ -11,9 +16,22 @@ EOF
 
 FROM base AS install
 WORKDIR /rootfs
+COPY --from=busybox . .
+COPY --from=iproute2 . .
+COPY --from=iptables . .
+COPY --from=musl . .
 COPY --from=build /qos_bridge .
-RUN find . -exec touch -hcd "@0" "{}" +
+COPY --chmod=755 src/images/qos_bridge/enclave_egress_interfaces.sh .
+COPY --chmod=755 src/images/qos_bridge/entrypoint.sh .
+RUN <<-EOF
+	set -eu
+	mkdir -p dev/net run tmp
+	chmod 1777 tmp
+	find . -exec touch -hcd "@0" "{}" +
+EOF
 
 FROM scratch AS package
 COPY --from=install /rootfs .
-ENTRYPOINT ["/qos_bridge"]
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+USER 0:0
+ENTRYPOINT ["/entrypoint.sh"]

--- a/src/images/qos_bridge/enclave_egress_interfaces.sh
+++ b/src/images/qos_bridge/enclave_egress_interfaces.sh
@@ -19,9 +19,9 @@ if ! ip link show dev host_egress >/dev/null 2>&1; then
 	ip tuntap add host_egress mode tun
 fi
 
-# assign 10.0.0.2/28 to host_egress to mask the martians
-if ! ip address show dev host_egress | grep -q "10.0.0.2/28"; then
-	ip address add 10.0.0.2/28 dev host_egress
+# assign 172.29.107.66/28 to host_egress to mask the martians
+if ! ip address show dev host_egress | grep -q "172.29.107.66/28"; then
+	ip address add 172.29.107.66/28 dev host_egress
 fi
 
 # bring the interface up
@@ -29,11 +29,10 @@ ip link set host_egress up
 
 # ensure forwarding is going to go through
 printf '1\n' > /proc/sys/net/ipv4/ip_forward
-iptables -P FORWARD ACCEPT
 
 # masquerade nat for egress
-if ! iptables -t nat -C POSTROUTING -s 10.0.0.1 -o "$DEFINT" -j MASQUERADE 2>/dev/null; then
-	iptables -t nat -I POSTROUTING -s 10.0.0.1 -o "$DEFINT" -j MASQUERADE
+if ! iptables -t nat -C POSTROUTING -s 172.29.107.65 -o eth0 -j MASQUERADE 2>/dev/null; then
+	iptables -t nat -I POSTROUTING -s 172.29.107.65 -o eth0 -j MASQUERADE
 fi
 
 # check it

--- a/src/images/qos_bridge/enclave_egress_interfaces.sh
+++ b/src/images/qos_bridge/enclave_egress_interfaces.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+set -eu
+
+DEFINT="${1:-${QOS_BRIDGE_EGRESS_INTERFACE:-eth0}}"
+
+if [ "$(id -u)" != "0" ]; then
+	echo "enclave_egress_interfaces.sh must run as root" >&2
+	exit 1
+fi
+
+if [ ! -c /dev/net/tun ]; then
+	echo "/dev/net/tun is not available; provide the TUN device to this container" >&2
+	exit 1
+fi
+
+# create egress from host tun interface
+if ! ip link show dev host_egress >/dev/null 2>&1; then
+	ip tuntap add host_egress mode tun
+fi
+
+# assign 10.0.0.2/28 to host_egress to mask the martians
+if ! ip address show dev host_egress | grep -q "10.0.0.2/28"; then
+	ip address add 10.0.0.2/28 dev host_egress
+fi
+
+# bring the interface up
+ip link set host_egress up
+
+# ensure forwarding is going to go through
+printf '1\n' > /proc/sys/net/ipv4/ip_forward
+iptables -P FORWARD ACCEPT
+
+# masquerade nat for egress
+if ! iptables -t nat -C POSTROUTING -s 10.0.0.1 -o "$DEFINT" -j MASQUERADE 2>/dev/null; then
+	iptables -t nat -I POSTROUTING -s 10.0.0.1 -o "$DEFINT" -j MASQUERADE
+fi
+
+# check it
+ip a show dev host_egress

--- a/src/images/qos_bridge/entrypoint.sh
+++ b/src/images/qos_bridge/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -eu
+
+if [ "${QOS_BRIDGE_SKIP_EGRESS_SETUP:-0}" != "1" ]; then
+	/enclave_egress_interfaces.sh "${QOS_BRIDGE_EGRESS_INTERFACE:-eth0}"
+fi
+
+exec /qos_bridge "$@"

--- a/src/images/qos_enclave/Containerfile
+++ b/src/images/qos_enclave/Containerfile
@@ -3,6 +3,8 @@ FROM stagex/gen_initramfs:6.8@sha256:f5b9271cca6003e952cbbb9ef041ffa92ba328894f5
 FROM stagex/linux-nitro:sx2024.03.0@sha256:073c4603686e3bdc0ed6755fee3203f6f6f1512e0ded09eaea8866b002b04264 AS linux-nitro
 FROM stagex/core-gcc:15.2.0@sha256:ceae6035d43fe3653e142e638fd78d72950cd51e7a5dba4755d1db081c54de77 AS gcc
 FROM stagex/core-libunwind:1.7.2@sha256:eb66122d8fc543f5e2f335bb1616f8c3a471604383e2c0a9df4a8e278505d3bc AS libunwind
+FROM stagex/iproute2:sx2024.11.0@sha256:65da03aa94d17dd6310b022f426a6cc8b3c55bb267e4bac1697bc57d6c850570 AS iproute2
+FROM stagex/musl:sx2024.11.0@sha256:d7f6c365f5724c65cadb2b96d9f594e46132ceb366174c89dbf7554897f2bc53 AS musl
 
 FROM common AS base
 
@@ -50,10 +52,14 @@ COPY <<-EOF initramfs.list
 	dir  /usr              0755 0 0
 	dir  /usr/bin          0755 0 0
 	dir  /usr/sbin         0755 0 0
+	dir  /usr/lib          0755 0 0
 	dir  /dev              0755 0 0
 	dir  /dev/shm          0755 0 0
 	dir  /dev/pts          0755 0 0
 	nod  /dev/console      0600 0 0 c 5 1
+	file /usr/sbin/ip      /usr/sbin/ip     0700 0 0
+	file /lib/ld-musl-x86  /usr/lib/ld-musl-x86_64.so.1                   0700 0 0
+	file /usr/lib/libc.musl-x86_64.so.1 /usr/lib/libc.musl-x86_64.so.1    0644 0 0
 EOF
 ENV CPIO_TIMESTAMP=1
 ENV KBUILD_BUILD_TIMESTAMP=1

--- a/src/init/Cargo.lock
+++ b/src/init/Cargo.lock
@@ -86,6 +86,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +464,15 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "etherparse"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ac016aaf11dfe643edcd088a166234bfcb72e7f06691abfcf21e9af524037f4"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "ff"
@@ -1160,15 +1175,17 @@ dependencies = [
 
 [[package]]
 name = "qos_core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "borsh",
+ "etherparse",
  "futures",
  "libc",
  "nix 0.30.1",
  "qos_crypto",
  "qos_hex",
+ "qos_json",
  "qos_nsm",
  "qos_p256",
  "serde",
@@ -1180,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "qos_crypto"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "rand 0.9.4",
  "sha2",
@@ -1190,20 +1207,32 @@ dependencies = [
 
 [[package]]
 name = "qos_hex"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
+name = "qos_json"
+version = "0.8.0"
+dependencies = [
+ "qos_hex",
+ "serde",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
 name = "qos_nsm"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "aws-nitro-enclaves-nsm-api",
  "borsh",
  "p384",
  "qos_hex",
+ "qos_json",
+ "serde",
  "serde_bytes",
  "sha2",
  "webpki",
@@ -1212,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "qos_p256"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "aes-gcm",
  "borsh",
@@ -1220,6 +1249,7 @@ dependencies = [
  "hmac",
  "p256",
  "qos_hex",
+ "serde",
  "sha2",
  "zeroize",
 ]

--- a/src/init/init.rs
+++ b/src/init/init.rs
@@ -1,8 +1,9 @@
 use qos_core::{
-	EPHEMERAL_KEY_FILE, MANIFEST_FILE, PIVOT_FILE, QUORUM_FILE,
+	egress::init_egress_tun,
 	handles::Handles,
 	io::{SocketAddress, VMADDR_NO_FLAGS},
 	reaper::Reaper,
+	EPHEMERAL_KEY_FILE, MANIFEST_FILE, PIVOT_FILE, QUORUM_FILE,
 };
 use qos_nsm::Nsm;
 use qos_system::{dmesg, freopen, get_local_cid, mount, reboot};
@@ -56,6 +57,7 @@ fn boot() {
 	init_console();
 	init_platform();
 	init_localhost();
+	init_egress_tun();
 }
 
 #[tokio::main]

--- a/src/qos_bridge/Cargo.toml
+++ b/src/qos_bridge/Cargo.toml
@@ -13,12 +13,12 @@ qos_host = { workspace = true, default-features = false }
 qos_core = { workspace = true, default-features = false }
 qos_hex = { workspace = true, features = ["serde"], default-features = false }
 qos_nsm = { workspace = true, default-features = false }
-ureq = { workspace = true, features = ["json"] }
 
 # Third party
 serde_json = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+ureq = { workspace = true, features = ["json"] }
 
 [features]
 vm = ["qos_core/vm"]

--- a/src/qos_bridge/README.md
+++ b/src/qos_bridge/README.md
@@ -21,3 +21,34 @@ Provided a bridge configuration of
 `cargo run -- --control-url http://localhost:3001/qos --usock /tmp/enclave-example/example.sock --host-port-override 4000`
 
 The pivot app will be available on `localhost:4000` via the bridge, and `localhost:3000` directly.
+
+## Transparent Egress POC
+
+The `qos_bridge` image runs `/enclave_egress_interfaces.sh` before starting the
+bridge binary. The script is intentionally POSIX `sh`, not `bash`, so it can run
+in the minimal Stagex-based image used on Talos Kubernetes.
+
+For a Kubernetes proof of concept, the container must run as root with network
+administration privileges and access to `/dev/net/tun`. The exact pod shape may
+vary by cluster policy, but the relevant settings are:
+
+```yaml
+securityContext:
+  runAsUser: 0
+  runAsGroup: 0
+  readOnlyRootFilesystem: false
+  capabilities:
+    add:
+      - NET_ADMIN
+volumeMounts:
+  - name: dev-net-tun
+    mountPath: /dev/net/tun
+volumes:
+  - name: dev-net-tun
+    hostPath:
+      path: /dev/net/tun
+      type: CharDevice
+```
+
+Set `QOS_BRIDGE_EGRESS_INTERFACE` if the outbound interface is not `eth0`. Set
+`QOS_BRIDGE_SKIP_EGRESS_SETUP=1` to bypass the setup script for local testing.

--- a/src/qos_bridge/src/cli.rs
+++ b/src/qos_bridge/src/cli.rs
@@ -99,12 +99,11 @@ impl HostOpts {
 			.single(VSOCK_TO_HOST)
 			.as_ref()
 			.map(|s| s.parse())
-			.map(|r| {
+			.is_none_or(|r| {
 				r.expect(
 					"could not parse `--vsock-to-host`. Valid args are true or false",
 				)
-			})
-			.unwrap_or(true);
+			});
 
 		if include {
 			println!("Configuring vsock with VMADDR_FLAG_TO_HOST.");

--- a/src/qos_bridge/src/cli.rs
+++ b/src/qos_bridge/src/cli.rs
@@ -11,7 +11,6 @@ use qos_core::{
 const CONTROL_URL: &str = "control-url";
 const HOST_PORT_OVERRIDE: &str = "host-port-override";
 const VSOCK_TO_HOST: &str = "vsock-to-host";
-const ENCLAVE_EGRESS: &str = "enclave-egress";
 
 struct HostParser;
 impl GetParserForOptions for HostParser {
@@ -44,10 +43,6 @@ impl GetParserForOptions for HostParser {
 					.required(false)
 					.forbids(vec![USOCK])
 			)
-			.token(
-				Token::new(ENCLAVE_EGRESS, "start in enclave egress mode")
-					.takes_value(false)
-			)
 	}
 }
 
@@ -77,15 +72,6 @@ impl HostOpts {
 	/// NOTE: used for localhost testing, since we can't bind the same port twice
 	pub fn host_port_override(&self) -> Option<u16> {
 		self.parsed.single(HOST_PORT_OVERRIDE).and_then(|v| v.parse().ok())
-	}
-
-	/// sets the bridge in "inside enclave" egress mode to be run directly by `Reaper` as a separate binary
-	pub fn enclave_egress(&self) -> bool {
-		self.parsed
-			.single(ENCLAVE_EGRESS)
-			.unwrap_or(&"false".to_string())
-			.parse()
-			.expect("unable to parse enclave-egress bool")
 	}
 
 	/// Create a new `StreamPool` using the list of `SocketAddress` for the qos host.
@@ -143,12 +129,6 @@ impl Cli {
 			println!("version: {}", env!("CARGO_PKG_VERSION"));
 		} else if options.parsed.help() {
 			println!("{}", options.parsed.info());
-		} else if options.enclave_egress() {
-			run_egress_bridge(
-				&options
-					.enclave_socket()
-					.expect("failed to create enclave socket"),
-			);
 		} else {
 			crate::host::BridgeServer::new(
 				options
@@ -164,24 +144,4 @@ impl Cli {
 			let _ = tokio::signal::ctrl_c().await;
 		}
 	}
-}
-// dummy placeholder
-#[cfg(not(feature = "vm"))]
-fn run_egress_bridge(_core_socket: &SocketAddress) {
-	panic!("unable to run egress without vm feature and vsock support");
-}
-
-// run the transparent host egress
-#[cfg(feature = "vm")]
-fn run_egress_bridge(core_socket: &SocketAddress) {
-	let vsock = core_socket.vsock();
-	let cid = vsock.cid();
-	let flags = qos_core::io::vsock_svm_flags(vsock); // ensure we copy the flags as set
-
-	tokio::task::spawn_blocking(move || {
-		use qos_core::egress::EGRESS_VSOCK_PORT;
-
-		println!("reaper: starting transparent egress host side");
-		qos_core::egress::enclave_egress(cid, EGRESS_VSOCK_PORT, flags);
-	});
 }

--- a/src/qos_bridge/src/cli.rs
+++ b/src/qos_bridge/src/cli.rs
@@ -11,6 +11,7 @@ use qos_core::{
 const CONTROL_URL: &str = "control-url";
 const HOST_PORT_OVERRIDE: &str = "host-port-override";
 const VSOCK_TO_HOST: &str = "vsock-to-host";
+const ENCLAVE_EGRESS: &str = "enclave-egress";
 
 struct HostParser;
 impl GetParserForOptions for HostParser {
@@ -43,6 +44,10 @@ impl GetParserForOptions for HostParser {
 					.required(false)
 					.forbids(vec![USOCK])
 			)
+			.token(
+				Token::new(ENCLAVE_EGRESS, "start in enclave egress mode")
+					.takes_value(false)
+			)
 	}
 }
 
@@ -72,6 +77,15 @@ impl HostOpts {
 	/// NOTE: used for localhost testing, since we can't bind the same port twice
 	pub fn host_port_override(&self) -> Option<u16> {
 		self.parsed.single(HOST_PORT_OVERRIDE).and_then(|v| v.parse().ok())
+	}
+
+	/// sets the bridge in "inside enclave" egress mode to be run directly by `Reaper` as a separate binary
+	pub fn enclave_egress(&self) -> bool {
+		self.parsed
+			.single(ENCLAVE_EGRESS)
+			.unwrap_or(&"false".to_string())
+			.parse()
+			.expect("unable to parse enclave-egress bool")
 	}
 
 	/// Create a new `StreamPool` using the list of `SocketAddress` for the qos host.
@@ -129,6 +143,12 @@ impl Cli {
 			println!("version: {}", env!("CARGO_PKG_VERSION"));
 		} else if options.parsed.help() {
 			println!("{}", options.parsed.info());
+		} else if options.enclave_egress() {
+			run_egress_bridge(
+				&options
+					.enclave_socket()
+					.expect("failed to create enclave socket"),
+			);
 		} else {
 			crate::host::BridgeServer::new(
 				options
@@ -144,4 +164,24 @@ impl Cli {
 			let _ = tokio::signal::ctrl_c().await;
 		}
 	}
+}
+// dummy placeholder
+#[cfg(not(feature = "vm"))]
+fn run_egress_bridge(_core_socket: &SocketAddress) {
+	panic!("unable to run egress without vm feature and vsock support");
+}
+
+// run the transparent host egress
+#[cfg(feature = "vm")]
+fn run_egress_bridge(core_socket: &SocketAddress) {
+	let vsock = core_socket.vsock();
+	let cid = vsock.cid();
+	let flags = qos_core::io::vsock_svm_flags(vsock); // ensure we copy the flags as set
+
+	tokio::task::spawn_blocking(move || {
+		use qos_core::egress::EGRESS_VSOCK_PORT;
+
+		println!("reaper: starting transparent egress host side");
+		qos_core::egress::enclave_egress(cid, EGRESS_VSOCK_PORT, flags);
+	});
 }

--- a/src/qos_bridge/src/host.rs
+++ b/src/qos_bridge/src/host.rs
@@ -64,50 +64,88 @@ impl BridgeServer {
 	}
 
 	fn run_bridges(&self, configs: &[BridgeConfig]) {
+		let mut egress_enabled = false;
+
 		for config in configs {
-			let (host_port, host_ip_str) = match config {
+			match config {
 				BridgeConfig::Client { port: _, host: _ } => {
-					unimplemented!("client support pending")
+					// NOTE: we ignore the host and port here as they are meant for firewall rules
+					// TODO: figure out how to actually handle the firewall rules, see TVC-25
+
+					// only run one instance as it covers ALL ports, the others are for firewalls
+					if !egress_enabled {
+						egress_enabled = true;
+						self.run_egress_host_bridge();
+					}
 				}
 				BridgeConfig::Server { port, host } => {
-					(self.host_port(*port), host)
-				}
-			};
-
-			// derive the app socket, for vsock just use the app host port with same CID as the enclave socket,
-			// with usock just add "<port>.appsock" suffix
-			let app_socket = match self
-				.socket_placeholder
-				.with_port(config.port())
-			{
-				Ok(value) => value,
-				Err(err) => {
-					eprintln!(
-						"unable to derive app socket from enclave socket: {err:?}, tcp to vsock bridge will not start"
+					self.run_ingress_bridge(
+						config.port(),
+						self.host_port(*port),
+						host,
 					);
-					return;
 				}
-			};
+			}
+		}
+	}
 
-			let app_pool = match StreamPool::single(app_socket) {
-				Ok(value) => value,
-				Err(err) => {
-					eprintln!(
-						"unable to create new app socket pool: {err:?}, tcp to vsock bridge will not start"
-					);
-					return;
-				}
-			};
+	// dummy placeholder
+	#[cfg(not(feature = "vm"))]
+	#[allow(clippy::unused_self)]
+	fn run_egress_host_bridge(&self) {
+		panic!("unable to run egress without vm feature and vsock support");
+	}
 
-			let Ok(host_ip) = host_ip_str.parse::<Ipv4Addr>() else {
+	// run the transparent host egress
+	#[cfg(feature = "vm")]
+	fn run_egress_host_bridge(&self) {
+		const EGRESS_PORT: u32 = 1000; // reserved range so user ports don't interfere
+		let vsock = self.socket_placeholder.vsock();
+		let cid = vsock.cid();
+		let flags = qos_core::io::vsock_svm_flags(vsock); // ensure we copy the flags as set
+
+		tokio::task::spawn_blocking(move || {
+			println!("qos_bridge: starting transparent egress host side");
+			qos_core::egress::host_egress(cid, EGRESS_PORT, flags);
+		});
+	}
+
+	fn run_ingress_bridge(
+		&self,
+		core_port: u16,
+		host_port: u16,
+		host_ip_str: &str,
+	) {
+		// derive the app socket, for vsock just use the app host port with same CID as the enclave socket,
+		// with usock just add "<port>.appsock" suffix
+		let app_socket = match self.socket_placeholder.with_port(core_port) {
+			Ok(value) => value,
+			Err(err) => {
 				eprintln!(
-					"unable to parse host ip for bridge configuration: {host_ip_str}"
+					"unable to derive app socket from enclave socket: {err:?}, tcp to vsock bridge will not start"
 				);
 				return;
-			};
-			let host_addr = SocketAddr::new(host_ip.into(), host_port);
+			}
+		};
 
-			HostBridge::new(app_pool, host_addr).tcp_to_vsock();
-		}
+		let app_pool = match StreamPool::single(app_socket) {
+			Ok(value) => value,
+			Err(err) => {
+				eprintln!(
+					"unable to create new app socket pool: {err:?}, tcp to vsock bridge will not start"
+				);
+				return;
+			}
+		};
+
+		let Ok(host_ip) = host_ip_str.parse::<Ipv4Addr>() else {
+			eprintln!(
+				"unable to parse host ip for bridge configuration: {host_ip_str}"
+			);
+			return;
+		};
+		let host_addr = SocketAddr::new(host_ip.into(), host_port);
+
+		HostBridge::new(app_pool, host_addr).tcp_to_vsock();
 	}
 }

--- a/src/qos_bridge/src/host.rs
+++ b/src/qos_bridge/src/host.rs
@@ -99,14 +99,15 @@ impl BridgeServer {
 	// run the transparent host egress
 	#[cfg(feature = "vm")]
 	fn run_egress_host_bridge(&self) {
-		const EGRESS_PORT: u32 = 1000; // reserved range so user ports don't interfere
 		let vsock = self.socket_placeholder.vsock();
 		let cid = vsock.cid();
 		let flags = qos_core::io::vsock_svm_flags(vsock); // ensure we copy the flags as set
 
 		tokio::task::spawn_blocking(move || {
+			use qos_core::egress::EGRESS_VSOCK_PORT;
+
 			println!("qos_bridge: starting transparent egress host side");
-			qos_core::egress::host_egress(cid, EGRESS_PORT, flags);
+			qos_core::egress::host_egress(cid, EGRESS_VSOCK_PORT, flags);
 		});
 	}
 

--- a/src/qos_core/Cargo.toml
+++ b/src/qos_core/Cargo.toml
@@ -19,6 +19,7 @@ qos_json = { workspace = true }
 qos_p256 = { workspace = true }
 qos_nsm = { workspace = true, default-features = false }
 
+etherparse = { workspace = true, optional = true }
 nix = { workspace = true }
 libc = { workspace = true }
 borsh = { workspace = true }
@@ -43,6 +44,6 @@ webpki-roots = { workspace = true }
 
 [features]
 # Support for VSOCK
-vm = []
+vm = ["etherparse"]
 # Never use in production - support for mock NSM
 mock = ["qos_nsm/mock"]

--- a/src/qos_core/src/egress.rs
+++ b/src/qos_core/src/egress.rs
@@ -66,14 +66,14 @@ pub fn host_egress(cid: u32, port: u32, flags: u8) {
 	copy_bidirectional(sock_fd, proxy_fd);
 }
 
-/// sets up new tuntap tun interface `enclave_egress` with localhost routing using `10.0.0.1/32` mask and default gw
+/// sets up new tuntap tun interface `enclave_egress` with localhost routing using `172.29.107.65/32` mask and default gw
 /// expects `/usr/sbin/ip` and `/lib/ld-musl-x86` to be present
 /// # Panics
 /// panics if the program executions fail
 pub fn init_egress_tun() {
 	run_ip("tuntap add enclave_egress mode tun", "tuntap add failed");
 	run_ip("link set lo up", "unable to bring up lo");
-	run_ip("address add 10.0.0.1/32 dev lo", "ip assign to lo failed");
+	run_ip("address add 172.29.107.65/32 dev lo", "ip assign to lo failed");
 	run_ip("link set enclave_egress up", "unable to bring up egress");
 	run_ip("route add default dev enclave_egress", "unable to route");
 }

--- a/src/qos_core/src/egress.rs
+++ b/src/qos_core/src/egress.rs
@@ -1,0 +1,295 @@
+//! Transparent egress functionality using linux tuntap and basic unix blocking syscalls
+
+use std::{
+	error::Error,
+	ffi::CString,
+	os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd},
+	process::{Child, Command},
+	time::Duration,
+};
+
+use crate::io::SocketAddress;
+use nix::{
+	NixPath, libc,
+	sys::socket::{
+		AddressFamily, Backlog, SockFlag, SockType, accept, bind, connect,
+		listen, socket,
+	},
+	unistd::{read, write},
+};
+
+/// sets up required tuntap interfaces using the `ip` binary
+/// opens enclave side egress bridging using given cid and port blocking forever
+/// # Panics
+/// panics on socket errors of any kind
+#[allow(unsafe_code)]
+pub fn enclave_egress(cid: u32, port: u32, flags: u8) {
+	setup_enclave_tunnel();
+
+	let addr = SocketAddress::new_vsock_raw(cid, port, flags);
+	let core_socket =
+		create_core_socket().expect("unable to create core socket");
+
+	bind(core_socket.as_raw_fd(), &addr).expect("unable to bind core socket");
+
+	// rust stdlib uses a 128 connection backlog
+	listen(&core_socket, Backlog::new(1).expect("unable to set backlog"))
+		.expect("unable to listen on core socket");
+
+	let stream_fd = accept(core_socket.as_raw_fd())
+		.expect("unable to accept on core socket");
+	let stream = unsafe { OwnedFd::from_raw_fd(stream_fd) };
+	let sock_fd = create_tun_socket("enclave_egress")
+		.expect("unable to create raw socket");
+	copy_bidirectional(sock_fd, stream);
+}
+
+/// opens host side egress bridging at the specified address, blocking forever
+/// # Panics
+/// panics on socket errors of any kind
+pub fn host_egress(cid: u32, port: u32, flags: u8) {
+	// NOTE: it's important we don't loop just connect here as that seems to cause EPIPE errors after it does connect
+	let proxy_fd = loop {
+		let addr = SocketAddress::new_vsock_raw(cid, port, flags);
+		let proxy_fd = create_core_socket().expect("unable to create vsock");
+
+		if connect(proxy_fd.as_raw_fd(), &addr).is_ok() {
+			break proxy_fd;
+		}
+		std::thread::sleep(Duration::from_millis(200));
+	};
+
+	let sock_fd =
+		create_tun_socket("host_egress").expect("unable to create raw socket");
+
+	copy_bidirectional(sock_fd, proxy_fd);
+}
+
+// sets up new tuntap tun interface `enclave_egress` with localhost routing using `10.0.0.1/32` mask
+// and default gw
+fn setup_enclave_tunnel() {
+	run_ip("tuntap add enclave_egress mode tun", "tuntap add failed");
+	run_ip("link set lo up", "unable to bring up lo");
+	run_ip("address add 10.0.0.1/32 dev lo", "ip assign to lo failed");
+	run_ip("link set enclave_egress up", "unable to bring up egress");
+	run_ip("route add default dev enclave_egress", "unable to route");
+}
+
+/// Create core vsock socket in streaming mode
+/// # Returns
+/// returns the new `OwnedFd` vsock
+/// # Errors
+/// same as `socket` from `nix`
+pub fn create_core_socket() -> Result<OwnedFd, nix::Error> {
+	socket(AddressFamily::Vsock, SockType::Stream, SockFlag::empty(), None)
+}
+
+/// Create a raw socket connecting to the given linux tun interface
+/// # Returns
+/// returns the new `OwnedFd` raw socket
+/// # Errors
+/// returns `NilError` in case of `CString` failure, or `std::io::Error` from `libc::errno` if `open` or `ioctl` have failed
+#[allow(unsafe_code)]
+#[allow(clippy::cast_possible_truncation)]
+pub fn create_tun_socket(if_name: &str) -> Result<OwnedFd, Box<dyn Error>> {
+	let if_name = CString::new(if_name)?;
+	let name_ptr = if_name.as_ptr();
+	let name_len = if_name.len().min(nix::libc::IFNAMSIZ - 1);
+	let mut ifr = libc::ifreq {
+		ifr_name: [0; nix::libc::IFNAMSIZ],
+		ifr_ifru: unsafe { std::mem::zeroed() },
+	};
+
+	let tun_dev = CString::new("/dev/net/tun")?;
+
+	unsafe {
+		let fd = libc::open(tun_dev.as_ptr(), libc::O_RDWR);
+		if fd < 0 {
+			return Err(Box::new(std::io::Error::last_os_error()));
+		}
+		std::ptr::copy_nonoverlapping(
+			name_ptr,
+			ifr.ifr_name.as_mut_ptr(),
+			name_len,
+		);
+		ifr.ifr_ifru.ifru_flags = libc::IFF_TUN as i16 | libc::IFF_NO_PI as i16;
+
+		// Set flags to IFF_TUN
+		// Using libc directly for the ioctl is common when nix lacks the specific macro:
+		let ret = nix::libc::ioctl(fd, 0x4004_54ca, &raw const ifr);
+		if ret < 0 {
+			libc::close(fd);
+			return Err(Box::new(std::io::Error::last_os_error()));
+		}
+
+		Ok(OwnedFd::from_raw_fd(fd))
+	}
+}
+
+/// Copies traffic in both directions between two sockets using threads, never returns
+/// # Panics
+/// Panics if any read/write operation panics
+fn copy_bidirectional(rsock: OwnedFd, vsock: OwnedFd) {
+	std::thread::scope(|s| {
+		let sfd = rsock.as_fd();
+		let tfd = vsock.as_fd();
+		std::thread::Builder::new()
+			.name("raw_to_vsock".to_owned())
+			.spawn_scoped(s, move || {
+				pipe_all(sfd, tfd).expect("error piping from raw to vsock");
+			})
+			.expect("unable to run scoped thread");
+
+		let sfd = rsock.as_fd();
+		let tfd = vsock.as_fd();
+		std::thread::Builder::new()
+			.name("vsock_to_raw".to_owned())
+			.spawn_scoped(s, move || {
+				// pipe_all(tfd, sfd, TrafficDirection::VsockToRaw(debug))
+				pipe_frames(tfd, sfd).expect("error piping from vsock to raw");
+			})
+			.expect("unable to run scoped thread");
+	});
+
+	// mostly for lint, we want to consume here on purpose as copy_bidirectional is supposed to be a terminal function
+	drop(rsock);
+	drop(vsock);
+}
+
+/// sends all traffic from `fd_from` to `fd_to` byte by byte
+/// # Panics
+/// panics if reads receive 0
+fn pipe_all(fd_from: BorrowedFd, fd_to: BorrowedFd) -> Result<(), nix::Error> {
+	// NOTE: qemu has the same bug as aws nitro
+	#[allow(clippy::large_stack_arrays)]
+	let mut buf = [0u8; 32000];
+
+	loop {
+		let received = read(fd_from, &mut buf)?;
+		assert!(received > 0, "unexpected disconnect from socket");
+
+		let mut sent = 0;
+		while sent < received {
+			sent += write(fd_to, &buf[sent..received])?;
+		}
+	}
+}
+
+// returns Some(size) of the first ip frame present in `buf` or None if no complete frame is found
+// WARNING: assumes `buf` slice starts at frame boundary!
+fn next_frame(buf: &[u8]) -> Option<usize> {
+	let Ok((ip, _)) = etherparse::LaxIpSlice::from_slice(buf) else {
+		return None;
+	};
+
+	let size: usize = if let Some(ip4) = ip.ipv4() {
+		ip4.header().total_len()
+	} else if let Some(ip6) = ip.ipv6() {
+		ip6.header().payload_length() + 40 // ip6 40 bytes header + payload_length
+	} else {
+		panic!("invalid ip version??");
+	}
+	.into();
+
+	if buf.len() < size { None } else { Some(size) }
+}
+
+// sends all traffic from fd_from to fd_to byte by ip frames waiting for completion on reads
+fn pipe_frames(
+	fd_from: BorrowedFd,
+	fd_to: BorrowedFd,
+) -> Result<(), nix::Error> {
+	// NOTE: qemu has the same bug as aws nitro
+	#[allow(clippy::large_stack_arrays)]
+	let mut buf = [0u8; 32000];
+	let mut frame_size;
+	let mut received = 0;
+
+	loop {
+		loop {
+			let r = read(fd_from, &mut buf[received..])?;
+			assert!(r > 0, "unexpected disconnect from socket");
+			received += r;
+
+			if let Some(size) = next_frame(&buf[..received]) {
+				frame_size = size;
+				break;
+			}
+		}
+
+		let mut sent = 0;
+		loop {
+			while sent < frame_size {
+				sent += write(fd_to, &buf[sent..frame_size])?;
+			}
+
+			if let Some(size) = next_frame(&buf[sent..received]) {
+				assert!(sent + size < buf.len(), "frame buffer overflow"); // should be impossible as MTU is 1500
+				frame_size = sent + size;
+			} else {
+				let tail_size = received - sent;
+				// copy tail to start so we can continue on reads
+				if sent < received {
+					buf.rotate_left(sent);
+				}
+				received = tail_size;
+				break;
+			}
+		}
+	}
+}
+
+/// Default path to the `ip` utility program
+pub const IP_PATH: &str = "/usr/sbin/ip";
+
+/// run the `ip` utility via the `run_with_ld`
+/// # Panics
+/// panics on program spawn errors
+pub fn run_ip(args: &str, fail_str: &str) {
+	let ip_exit = run_with_ld(IP_PATH, args)
+		.expect("unable to run ip command")
+		.wait()
+		.expect("ip program failed to finish");
+	assert!(ip_exit.success(), "{}", fail_str);
+}
+
+/// run a statically linked program and return the `Child` handle
+/// # Errors
+/// returns `std::io::Error` in case of process creation problems
+pub fn run_static(cmd_path: &str, args: &str) -> std::io::Result<Child> {
+	Command::new(cmd_path).env_clear().args(args.split(' ')).spawn()
+}
+
+/// run a statically linked program in a loop
+pub fn run_looping(cmd_path: &str, args: &str) {
+	let cmd_path = cmd_path.to_owned();
+	let args = args.to_owned();
+
+	std::thread::spawn(move || {
+		loop {
+			match run_static(&cmd_path, &args) {
+				Ok(mut child) => {
+					let exit = child.wait(); // try to wait, restart  in any case
+					eprintln!("process {cmd_path} exit {exit:?}");
+				}
+				Err(err) => {
+					eprintln!("error spawning process {cmd_path}: {err}");
+				}
+			}
+
+			eprintln!("process {cmd_path} exited, restarting in 200ms");
+			std::thread::sleep(Duration::from_millis(200));
+		}
+	});
+}
+
+/// run a program with `/lib/ld-musl-x86` loader and return the `Child` handle
+/// # Errors
+/// returns `std::io::Error` in case of process creation problems
+pub fn run_with_ld(cmd_path: &str, args: &str) -> std::io::Result<Child> {
+	Command::new("/lib/ld-musl-x86")
+		.env_clear()
+		.arg(cmd_path)
+		.args(args.split(' '))
+		.spawn()
+}

--- a/src/qos_core/src/egress.rs
+++ b/src/qos_core/src/egress.rs
@@ -18,14 +18,15 @@ use nix::{
 	unistd::{read, write},
 };
 
+/// egress vsock port used both in and out of the enclave to provide transparent egress data transfer
+pub const EGRESS_VSOCK_PORT: u32 = 1000; // reserved range so user ports don't interfere
+
 /// sets up required tuntap interfaces using the `ip` binary
 /// opens enclave side egress bridging using given cid and port blocking forever
 /// # Panics
 /// panics on socket errors of any kind
 #[allow(unsafe_code)]
 pub fn enclave_egress(cid: u32, port: u32, flags: u8) {
-	setup_enclave_tunnel();
-
 	let addr = SocketAddress::new_vsock_raw(cid, port, flags);
 	let core_socket =
 		create_core_socket().expect("unable to create core socket");
@@ -65,9 +66,11 @@ pub fn host_egress(cid: u32, port: u32, flags: u8) {
 	copy_bidirectional(sock_fd, proxy_fd);
 }
 
-// sets up new tuntap tun interface `enclave_egress` with localhost routing using `10.0.0.1/32` mask
-// and default gw
-fn setup_enclave_tunnel() {
+/// sets up new tuntap tun interface `enclave_egress` with localhost routing using `10.0.0.1/32` mask and default gw
+/// expects `/usr/sbin/ip` and `/lib/ld-musl-x86` to be present
+/// # Panics
+/// panics if the program executions fail
+pub fn init_egress_tun() {
 	run_ip("tuntap add enclave_egress mode tun", "tuntap add failed");
 	run_ip("link set lo up", "unable to bring up lo");
 	run_ip("address add 10.0.0.1/32 dev lo", "ip assign to lo failed");
@@ -128,12 +131,12 @@ pub fn create_tun_socket(if_name: &str) -> Result<OwnedFd, Box<dyn Error>> {
 
 /// Copies traffic in both directions between two sockets using threads, never returns
 /// # Panics
-/// Panics if any read/write operation panics
+/// Panics if any read/write operation fails
 fn copy_bidirectional(rsock: OwnedFd, vsock: OwnedFd) {
 	std::thread::scope(|s| {
 		let sfd = rsock.as_fd();
 		let tfd = vsock.as_fd();
-		std::thread::Builder::new()
+		let raw_to_vsock = std::thread::Builder::new()
 			.name("raw_to_vsock".to_owned())
 			.spawn_scoped(s, move || {
 				pipe_all(sfd, tfd).expect("error piping from raw to vsock");
@@ -142,13 +145,28 @@ fn copy_bidirectional(rsock: OwnedFd, vsock: OwnedFd) {
 
 		let sfd = rsock.as_fd();
 		let tfd = vsock.as_fd();
-		std::thread::Builder::new()
+		let vsock_to_raw = std::thread::Builder::new()
 			.name("vsock_to_raw".to_owned())
 			.spawn_scoped(s, move || {
 				// pipe_all(tfd, sfd, TrafficDirection::VsockToRaw(debug))
 				pipe_frames(tfd, sfd).expect("error piping from vsock to raw");
 			})
 			.expect("unable to run scoped thread");
+
+		// see if any of the threads have paniced and if so, propagate the error and panic the main process
+		loop {
+			if raw_to_vsock.is_finished() {
+				raw_to_vsock.join().expect("raw_to_vsock worker error");
+				panic!("raw_to_vsock exit");
+			}
+
+			if vsock_to_raw.is_finished() {
+				vsock_to_raw.join().expect("vsock_to_raw worker error");
+				panic!("vsock_to_raw exit");
+			}
+
+			std::thread::sleep(Duration::from_millis(200));
+		}
 	});
 
 	// mostly for lint, we want to consume here on purpose as copy_bidirectional is supposed to be a terminal function

--- a/src/qos_core/src/io/mod.rs
+++ b/src/qos_core/src/io/mod.rs
@@ -104,15 +104,19 @@ impl SocketAddress {
 	///
 	/// For flags see: [Add flags field in the vsock address](<https://lkml.org/lkml/2020/12/11/249>).
 	#[cfg(feature = "vm")]
+	#[must_use]
 	pub fn new_vsock(cid: u32, port: u32, flags: u8) -> Self {
 		Self::Vsock(Self::new_vsock_raw(cid, port, flags))
 	}
 
-	/// Create a new raw VsockAddr.
+	/// Create a new raw `VsockAddr`.
 	///
 	/// For flags see: [Add flags field in the vsock address](<https://lkml.org/lkml/2020/12/11/249>).
+	/// # Panics
+	/// Panics if addr length mismatches
 	#[cfg(feature = "vm")]
-	#[allow(unsafe_code)]
+	#[must_use]
+	#[allow(unsafe_code, clippy::cast_possible_truncation)]
 	pub fn new_vsock_raw(cid: u32, port: u32, flags: u8) -> VsockAddr {
 		let vsock_addr = SockAddrVm {
 			svm_family: AddressFamily::Vsock as libc::sa_family_t,
@@ -123,14 +127,13 @@ impl SocketAddress {
 			svm_zero: [0; 3],
 		};
 		let vsock_addr_len = size_of::<SockAddrVm>() as libc::socklen_t;
-		let addr = unsafe {
+		unsafe {
 			VsockAddr::from_raw(
-				&vsock_addr as *const SockAddrVm as *const libc::sockaddr,
+				(&raw const vsock_addr).cast::<libc::sockaddr>(),
 				Some(vsock_addr_len),
 			)
 			.unwrap()
-		};
-		addr
+		}
 	}
 
 	/// Get the `AddressFamily` of the socket.
@@ -154,22 +157,26 @@ impl SocketAddress {
 	}
 
 	/// Returns the `UnixAddr` if this is a USOCK `SocketAddress`, panics otherwise
+	/// # Panics
+	/// Panics if this is a vsock
 	#[must_use]
 	pub fn usock(&self) -> &UnixAddr {
 		match self {
 			Self::Unix(usock) => usock,
 			#[cfg(feature = "vm")]
-			_ => panic!("invalid socket address requested"),
+			Self::Vsock(_) => panic!("invalid socket address requested"),
 		}
 	}
 
 	/// Returns the `UnixAddr` if this is a USOCK `SocketAddress`, panics otherwise
+	/// # Panics
+	/// Panics if this is a unix socket
 	#[must_use]
 	#[cfg(feature = "vm")]
 	pub fn vsock(&self) -> &VsockAddr {
 		match self {
 			Self::Vsock(vsock) => vsock,
-			_ => panic!("invalid socket address requested"),
+			Self::Unix(_) => panic!("invalid socket address requested"),
 		}
 	}
 
@@ -188,7 +195,7 @@ impl SocketAddress {
 			Self::Vsock(vsa) => Ok(Self::new_vsock(
 				vsa.cid(),
 				port.into(),
-				vsock_svm_flags(*vsa),
+				vsock_svm_flags(vsa),
 			)),
 			Self::Unix(ua) => {
 				let mut path = ua
@@ -230,25 +237,33 @@ impl std::fmt::Display for SocketAddress {
 	}
 }
 
-/// Extract svm_flags field value from existing VSOCK.
+/// Extract `svm_flags` field value from existing VSOCK.
 #[cfg(feature = "vm")]
+#[must_use]
 #[allow(unsafe_code)]
-pub fn vsock_svm_flags(vsock: VsockAddr) -> u8 {
+pub fn vsock_svm_flags(vsock: &VsockAddr) -> u8 {
 	unsafe {
-		let cast: SockAddrVm = std::mem::transmute(vsock);
+		let cast: SockAddrVm = std::mem::transmute(*vsock);
 		cast.svm_flags
 	}
 }
 
+/// `sockaddr_vm` representation that contains the new `svm_flags` since `libc` currently still does not
 #[cfg(feature = "vm")]
 #[repr(C)]
-struct SockAddrVm {
-	svm_family: libc::sa_family_t,
-	svm_reserved1: libc::c_ushort,
-	svm_port: libc::c_uint,
-	svm_cid: libc::c_uint,
-	// Field added [here](https://github.com/torvalds/linux/commit/3a9c049a81f6bd7c78436d7f85f8a7b97b0821e6)
-	// but not yet in a version of libc we can use.
-	svm_flags: u8,
-	svm_zero: [u8; 3],
+#[allow(clippy::struct_field_names)]
+pub(crate) struct SockAddrVm {
+	/// Family
+	pub(crate) svm_family: libc::sa_family_t,
+	/// Kernel reserved
+	pub(crate) svm_reserved1: libc::c_ushort,
+	/// Port
+	pub(crate) svm_port: libc::c_uint,
+	/// Cid
+	pub(crate) svm_cid: libc::c_uint,
+	/// Field added [here](https://github.com/torvalds/linux/commit/3a9c049a81f6bd7c78436d7f85f8a7b97b0821e6)
+	/// but not yet in a version of libc we can use.
+	pub(crate) svm_flags: u8,
+	/// Zero padding
+	pub(crate) svm_zero: [u8; 3],
 }

--- a/src/qos_core/src/io/pool.rs
+++ b/src/qos_core/src/io/pool.rs
@@ -286,7 +286,7 @@ impl SocketAddress {
 			Self::Vsock(vsock) => Ok(Self::new_vsock(
 				vsock.cid(),
 				vsock.port() + 1,
-				super::vsock_svm_flags(*vsock),
+				super::vsock_svm_flags(vsock),
 			)),
 		}
 	}

--- a/src/qos_core/src/io/stream.rs
+++ b/src/qos_core/src/io/stream.rs
@@ -82,7 +82,7 @@ impl Stream {
 			}
 			#[cfg(feature = "vm")]
 			SocketAddress::Vsock(_vaddr) => {
-				let inner = vsock_connect(&addr).await?;
+				let inner = vsock_connect(addr).await?;
 
 				self.inner = Some(InnerStream::Vsock(inner));
 			}

--- a/src/qos_core/src/lib.rs
+++ b/src/qos_core/src/lib.rs
@@ -13,15 +13,17 @@ compile_error!(
 	"feature \"vm\" and feature \"mock\" cannot be enabled at the same time"
 );
 
-pub mod client;
-pub mod server;
-
 pub mod cli;
+pub mod client;
 pub mod handles;
 pub mod io;
 pub mod parser;
 pub mod protocol;
 pub mod reaper;
+pub mod server;
+
+#[cfg(feature = "vm")]
+pub mod egress;
 
 /// Path to Quorum Key secret.
 #[cfg(not(feature = "vm"))]

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -121,7 +121,7 @@ fn run_egress_bridge(core_socket: &SocketAddress) {
 	let flags = crate::io::vsock_svm_flags(vsock); // ensure we copy the flags as set
 
 	tokio::task::spawn_blocking(move || {
-		println!("reaper: starting transparent egress host side");
+		println!("reaper: starting transparent egress enclave side");
 		crate::egress::enclave_egress(cid, EGRESS_PORT, flags);
 	});
 }

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -122,8 +122,23 @@ fn run_egress_bridge(core_socket: &SocketAddress) {
 	tokio::task::spawn_blocking(move || {
 		use crate::egress::EGRESS_VSOCK_PORT;
 
-		println!("reaper: starting transparent egress enclave side");
-		crate::egress::enclave_egress(cid, EGRESS_VSOCK_PORT, flags);
+		loop {
+			let egress_worker = std::thread::spawn(move || {
+				println!("reaper: starting transparent egress enclave side");
+				crate::egress::enclave_egress(cid, EGRESS_VSOCK_PORT, flags);
+			});
+
+			match egress_worker.join() {
+				Ok(_) => {
+					eprintln!("egress worker stopped without error, restarting")
+				}
+				Err(err) => {
+					eprintln!("egress worker error: {err:?}, restarting")
+				}
+			}
+
+			std::thread::sleep(Duration::from_millis(200));
+		}
 	});
 }
 

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -115,14 +115,15 @@ fn run_egress_bridge(_core_socket: &SocketAddress) {
 // run the transparent host egress
 #[cfg(feature = "vm")]
 fn run_egress_bridge(core_socket: &SocketAddress) {
-	const EGRESS_PORT: u32 = 1000; // reserved range so user ports don't interfere
 	let vsock = core_socket.vsock();
 	let cid = vsock.cid();
 	let flags = crate::io::vsock_svm_flags(vsock); // ensure we copy the flags as set
 
 	tokio::task::spawn_blocking(move || {
+		use crate::egress::EGRESS_VSOCK_PORT;
+
 		println!("reaper: starting transparent egress enclave side");
-		crate::egress::enclave_egress(cid, EGRESS_PORT, flags);
+		crate::egress::enclave_egress(cid, EGRESS_VSOCK_PORT, flags);
 	});
 }
 

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -66,18 +66,21 @@ async fn run_server(
 	println!("Reaper::server shutdown");
 }
 
-// runs the VSOCK -> TCP bridge so that apps can use any TCP based protocol without worrying about VSOCK
+// runs configured bridges based on `BridgeConfig` so that apps can use any TCP based protocol without worrying about VSOCK
 // communication. This is started if `PivotConfig::bridge_config` has any members defined.
-// uses the enclave core socket and given pivot host port to constuct the VSOCK to TCP bridge.
-fn run_vsock_to_tcp_bridge(
+// uses the enclave core socket and given pivot host port to construct the VSOCK to TCP bridge for server side
+// and opens a fully transparent egress if client side is set.
+fn run_bridges(
 	core_socket: &SocketAddress,
-	bridges: &Vec<BridgeConfig>,
+	bridges: &[BridgeConfig],
 ) -> Result<(), IOError> {
 	// do nothing if we're not asked to provide bridging
 	if bridges.is_empty() {
 		println!("skipping host bridge, not configured");
 		return Ok(());
 	}
+
+	let mut egress_enabled = false;
 
 	for bc in bridges {
 		match bc {
@@ -91,12 +94,36 @@ fn run_vsock_to_tcp_bridge(
 				bridge.vsock_to_tcp();
 			}
 			BridgeConfig::Client { port: _, host: _ } => {
-				panic!("client bridge unimplemented")
-			} // TODO: implement
+				// only run one instance as it covers ALL ports, the others are for firewalls
+				if !egress_enabled {
+					egress_enabled = true;
+					run_egress_bridge(core_socket);
+				}
+			}
 		}
 	}
 
 	Ok(())
+}
+
+// dummy placeholder
+#[cfg(not(feature = "vm"))]
+fn run_egress_bridge(_core_socket: &SocketAddress) {
+	panic!("unable to run egress without vm feature and vsock support");
+}
+
+// run the transparent host egress
+#[cfg(feature = "vm")]
+fn run_egress_bridge(core_socket: &SocketAddress) {
+	const EGRESS_PORT: u32 = 1000; // reserved range so user ports don't interfere
+	let vsock = core_socket.vsock();
+	let cid = vsock.cid();
+	let flags = crate::io::vsock_svm_flags(vsock); // ensure we copy the flags as set
+
+	tokio::task::spawn_blocking(move || {
+		println!("reaper: starting transparent egress host side");
+		crate::egress::enclave_egress(cid, EGRESS_PORT, flags);
+	});
 }
 
 fn reprint_pivot_output(child: &mut Child) {
@@ -194,8 +221,8 @@ impl Reaper {
 		let host_config = manifest.bridge_config().to_vec();
 
 		// if the app indicates the need for the VSOCK -> TCP bridge, run it as another task
-		run_vsock_to_tcp_bridge(&core_socket, &host_config)
-			.expect("failed to run VSOCK -> TCP socket bridge");
+		run_bridges(&core_socket, &host_config)
+			.expect("failed to run ingress/egress bridges");
 
 		let mut pivot = Command::new(handles.pivot_path());
 		pivot.env_clear();


### PR DESCRIPTION
Draft POC for running the enclave egress setup inside the qos_bridge image.

Changes:
- add a small sh entrypoint that runs the egress setup before qos_bridge
- include the Stagex busybox, iproute2, iptables, and musl bits needed by the script
- document the Talos/Kubernetes settings needed for this test

Related:
- mono: https://github.com/tkhq/mono/pull/6607
- gitops: https://github.com/tkhq/gitops/pull/4251