### PR TITLE
fix(qos_client): use borsh by default when key forwarding with v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## `qos_client` - [0.8.1](https://github.com/tkhq/qos/compare/qos_client-v0.8.0...qos_client-v0.8.1) - 2026-05-27
+
+### Fixed
+- Prefer legacy Borsh wire encoding for key-forwarding and key-export requests with v0/v1 manifest envelopes, falling back to JSON while keeping v2 manifest envelopes JSON-only.
+
+## `qos_core` - [0.8.1](https://github.com/tkhq/qos/compare/qos_core-v0.8.0...qos_core-v0.8.1) - 2026-05-27
+
+### Fixed
+- Preserved the legacy Borsh discriminant for `ProtocolError::ProtocolMsgDeserialization` by moving the newer `InvalidPivotEnv` variant to the end of the enum.
+
 ## `qos_client` - [0.8.0](https://github.com/tkhq/qos/compare/qos_client-v0.7.0...qos_client-v0.8.0) - 2026-05-17
 
 ### Added

--- a/src/integration/tests/protocol_legacy_decode.rs
+++ b/src/integration/tests/protocol_legacy_decode.rs
@@ -14,6 +14,7 @@ use qos_core::protocol::{
 	},
 };
 use qos_core_legacy::protocol::{
+	ProtocolError as LegacyProtocolError,
 	msg::ProtocolMsg as LegacyProtocolMsg,
 	services::boot::{
 		Manifest as LegacyManifest, ManifestEnvelope as LegacyManifestEnvelope,
@@ -139,6 +140,22 @@ fn legacy_protocol_error_response_decodes() {
 		ProtocolError::InvalidMsg,
 	));
 	assert!(matches!(decoded, LegacyProtocolMsg::ProtocolErrorResponse(_)));
+}
+
+#[test]
+fn legacy_protocol_msg_deserialization_discriminant_is_stable() {
+	let legacy = LegacyProtocolMsg::ProtocolErrorResponse(
+		LegacyProtocolError::ProtocolMsgDeserialization,
+	);
+	let bytes = borsh::to_vec(&legacy).unwrap();
+	let decoded = CurrentProtocolMsg::try_from_slice(&bytes).unwrap();
+
+	assert!(matches!(
+		decoded,
+		CurrentProtocolMsg::ProtocolErrorResponse(
+			ProtocolError::ProtocolMsgDeserialization
+		)
+	));
 }
 
 #[test]

--- a/src/qos_client/src/cli/services.rs
+++ b/src/qos_client/src/cli/services.rs
@@ -9,7 +9,7 @@ use aws_nitro_enclaves_nsm_api::api::AttestationDoc;
 use borsh::BorshDeserialize;
 use qos_core::protocol::{
 	QosHash,
-	msg::{JsonBytes, ProtocolMsg},
+	msg::{JsonBytes, ProtocolMsg, ProtocolMsgEncoding},
 	services::{
 		boot::{
 			Approval, BridgeConfig, Manifest as ManifestV1,
@@ -1193,19 +1193,22 @@ pub(crate) fn boot_key_fwd<P: AsRef<Path>>(
 		fs::read(pivot_path.as_ref()).map_err(Error::FailedToReadPivot)?;
 	let manifest_envelope =
 		read_manifest_envelope_compat(manifest_envelope_path)?;
+	let encodings = manifest_envelope_protocol_encodings(&manifest_envelope);
 
 	let req = ProtocolMsg::BootKeyForwardRequest {
 		manifest_envelope: Box::new(manifest_envelope),
 		pivot,
 	};
-	let cose_sign1 = match request::post(uri, &req).unwrap() {
-		ProtocolMsg::BootKeyForwardResponse {
-			nsm_response: NsmResponse::Attestation { document },
-		} => document,
-		r => {
-			return Err(Error::UnexpectedProtocolMsgResponse(format!("{r:?}")));
-		}
-	};
+	let cose_sign1 =
+		post_request_with_encoding_fallback(uri, &req, encodings, |resp| {
+			match resp {
+				ProtocolMsg::BootKeyForwardResponse {
+					nsm_response: NsmResponse::Attestation { document },
+				} => Ok(document),
+				r => Err(format!("{r:?}")),
+			}
+		})
+		.map_err(Error::UnexpectedProtocolMsgResponse)?;
 
 	write_with_msg(
 		attestation_doc_path.as_ref(),
@@ -1224,6 +1227,7 @@ pub(crate) fn export_key<P: AsRef<Path>>(
 ) -> Result<(), Error> {
 	let manifest_envelope =
 		read_manifest_envelope_compat(manifest_envelope_path)?;
+	let encodings = manifest_envelope_protocol_encodings(&manifest_envelope);
 	let cose_sign1_attestation_doc = fs::read(attestation_doc_path.as_ref())
 		.map_err(Error::FailedToReadAttestationDoc)?;
 
@@ -1232,14 +1236,17 @@ pub(crate) fn export_key<P: AsRef<Path>>(
 		cose_sign1_attestation_doc,
 	};
 
-	let encrypted_quorum_key = match request::post(uri, &req).unwrap() {
-		ProtocolMsg::ExportKeyResponse { encrypted_quorum_key, signature } => {
-			EncryptedQuorumKey { encrypted_quorum_key, signature }
-		}
-		r => {
-			return Err(Error::UnexpectedProtocolMsgResponse(format!("{r:?}")));
-		}
-	};
+	let encrypted_quorum_key =
+		post_request_with_encoding_fallback(uri, &req, encodings, |resp| {
+			match resp {
+				ProtocolMsg::ExportKeyResponse {
+					encrypted_quorum_key,
+					signature,
+				} => Ok(EncryptedQuorumKey { encrypted_quorum_key, signature }),
+				r => Err(format!("{r:?}")),
+			}
+		})
+		.map_err(Error::UnexpectedProtocolMsgResponse)?;
 
 	write_with_msg(
 		encrypted_quorum_key_path.as_ref(),
@@ -1248,6 +1255,53 @@ pub(crate) fn export_key<P: AsRef<Path>>(
 	);
 
 	Ok(())
+}
+
+fn post_request_with_encoding_fallback<T, F>(
+	uri: &str,
+	req: &ProtocolMsg,
+	encodings: &[ProtocolMsgEncoding],
+	parse: F,
+) -> Result<T, String>
+where
+	F: Fn(ProtocolMsg) -> Result<T, String>,
+{
+	let mut errors = vec![];
+
+	for &encoding in encodings {
+		match post_request_with_encoding(uri, req, encoding) {
+			Ok(resp) => match parse(resp) {
+				Ok(value) => return Ok(value),
+				Err(err) => errors
+					.push(format!("{encoding:?}: unexpected response {err}")),
+			},
+			Err(err) => errors.push(format!("{encoding:?}: {err}")),
+		}
+	}
+
+	Err(errors.join("; "))
+}
+
+fn post_request_with_encoding(
+	uri: &str,
+	req: &ProtocolMsg,
+	encoding: ProtocolMsgEncoding,
+) -> Result<ProtocolMsg, String> {
+	match encoding {
+		ProtocolMsgEncoding::Borsh => request::post_borsh(uri, req),
+		ProtocolMsgEncoding::Json => request::post(uri, req),
+	}
+}
+
+fn manifest_envelope_protocol_encodings(
+	manifest_envelope: &VersionedManifestEnvelope,
+) -> &'static [ProtocolMsgEncoding] {
+	match manifest_envelope {
+		VersionedManifestEnvelope::V2(_) => &[ProtocolMsgEncoding::Json],
+		VersionedManifestEnvelope::V1(_) | VersionedManifestEnvelope::V0(_) => {
+			&[ProtocolMsgEncoding::Borsh, ProtocolMsgEncoding::Json]
+		}
+	}
 }
 
 pub(crate) fn inject_key<P: AsRef<Path>>(
@@ -2519,10 +2573,12 @@ mod tests {
 
 	use qos_core::protocol::{
 		QosHash,
+		msg::ProtocolMsgEncoding,
 		services::boot::{
-			Approval, Manifest, ManifestEnvelope, ManifestSet, MemberPubKey,
-			Namespace, NitroConfig, PatchSet, PivotConfig, QuorumMember,
-			RestartPolicy, ShareSet, VersionedManifest,
+			Approval, Manifest, ManifestEnvelope, ManifestEnvelopeV2,
+			ManifestSet, ManifestV2, ManifestVersion, MemberPubKey, Namespace,
+			NitroConfig, PatchSet, PivotConfig, PivotConfigV2, PivotEnv,
+			QuorumMember, RestartPolicy, ShareSet, VersionedManifest,
 			VersionedManifestEnvelope,
 		},
 	};
@@ -2668,6 +2724,43 @@ mod tests {
 			VersionedManifestEnvelope::V1(envelope) => envelope,
 			_ => panic!("expected v1 manifest envelope in test setup"),
 		}
+	}
+
+	#[test]
+	fn manifest_envelope_protocol_encodings_try_v1_borsh_first() {
+		let Setup { manifest_envelope, .. } = setup();
+		let manifest =
+			v1_manifest_envelope(&manifest_envelope).manifest.clone();
+
+		assert_eq!(
+			super::manifest_envelope_protocol_encodings(&manifest_envelope),
+			[ProtocolMsgEncoding::Borsh, ProtocolMsgEncoding::Json]
+		);
+
+		let v2_envelope = VersionedManifestEnvelope::V2(ManifestEnvelopeV2 {
+			manifest: ManifestV2 {
+				version: ManifestVersion::V2,
+				namespace: manifest.namespace,
+				pivot: PivotConfigV2 {
+					hash: manifest.pivot.hash,
+					restart: manifest.pivot.restart,
+					bridge_config: manifest.pivot.bridge_config,
+					debug_mode: manifest.pivot.debug_mode,
+					args: manifest.pivot.args,
+					env: PivotEnv::new(),
+				},
+				manifest_set: manifest.manifest_set,
+				share_set: manifest.share_set,
+				enclave: manifest.enclave,
+			},
+			manifest_set_approvals: vec![],
+			share_set_approvals: vec![],
+		});
+
+		assert_eq!(
+			super::manifest_envelope_protocol_encodings(&v2_envelope),
+			[ProtocolMsgEncoding::Json]
+		);
 	}
 
 	mod approve_manifest_programmatic_verifications {

--- a/src/qos_core/src/protocol/error.rs
+++ b/src/qos_core/src/protocol/error.rs
@@ -44,8 +44,6 @@ pub enum ProtocolError {
 		/// Actual hash as hex string.
 		actual: String,
 	},
-	/// Pivot environment variables are invalid.
-	InvalidPivotEnv(String),
 	/// The message is too large.
 	OversizeMsg,
 	/// Message could not be deserialized
@@ -191,6 +189,8 @@ pub enum ProtocolError {
 	QosCrypto(String),
 	/// Error during expanding the `StreamPool`.
 	PoolExpandError,
+	/// Pivot environment variables are invalid.
+	InvalidPivotEnv(String),
 }
 
 impl From<std::io::Error> for ProtocolError {


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

Fix broken keyforwarding. 

## How I Tested These Changes

## Pre merge check list

- [ ] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
