### PR TITLE
Add: signed echo app for testing

### DIFF
--- a/.github/workflows/signed-echo-image.yml
+++ b/.github/workflows/signed-echo-image.yml
@@ -1,0 +1,53 @@
+name: signed-echo image publish
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/signed-echo-image.yml"
+      - "src/images/signed_echo/**"
+      - "src/signed_echo/**"
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: publish signed_echo image
+    runs-on: ubicloud-standard-16
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Docker
+        uses: ./.github/actions/docker-setup
+
+      - name: Login to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 #v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build signed_echo image
+        shell: 'script -q -e -c "bash {0}"'
+        run: make out/signed_echo/index.json
+
+      - name: Push signed_echo image to GHCR
+        run: |
+          image="ghcr.io/tkhq/qos/examples/signed_echo"
+          sha_tag="sha-${GITHUB_SHA}"
+
+          env -C out/signed_echo tar -cf - . | docker load
+          docker tag "qos-local/signed_echo:latest" "${image}:${sha_tag}"
+          docker push "${image}:${sha_tag}"
+
+          current_main="$(git ls-remote origin refs/heads/main | awk '{print $1}')"
+          if [ "${current_main}" = "${GITHUB_SHA}" ]; then
+            docker tag "qos-local/signed_echo:latest" "${image}:main"
+            docker push "${image}:main"
+          else
+            echo "Skipping ${image}:main because ${GITHUB_SHA} is no longer main"
+          fi

--- a/.github/workflows/signed-echo-image.yml
+++ b/.github/workflows/signed-echo-image.yml
@@ -6,7 +6,14 @@ on:
       - main
     paths:
       - ".github/workflows/signed-echo-image.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "Makefile"
+      - "src/macros.mk"
+      - "src/images/common/**"
       - "src/images/signed_echo/**"
+      - "src/qos_hex/**"
+      - "src/qos_p256/**"
       - "src/signed_echo/**"
   workflow_dispatch:
 

--- a/.github/workflows/stagex-release.yml
+++ b/.github/workflows/stagex-release.yml
@@ -60,11 +60,15 @@ jobs:
           # Extract version from tag (e.g. "qos_core-v0.5.0" -> "v0.5.0")
           version="${release_tag#qos_core-}"
           for name in qos_client qos_host qos_enclave qos_enclave_egress qos_bridge qos_bridge_egress signed_echo; do
+            image="ghcr.io/tkhq/${name}"
+            if [ "${name}" = "signed_echo" ]; then
+              image="ghcr.io/tkhq/qos/examples/signed_echo"
+            fi
             env -C out/${name} tar -cf - . | docker load
-            docker tag "qos-local/${name}:latest" "ghcr.io/tkhq/${name}:${version}"
-            docker tag "qos-local/${name}:latest" "ghcr.io/tkhq/${name}:latest"
-            docker push "ghcr.io/tkhq/${name}:${version}"
-            docker push "ghcr.io/tkhq/${name}:latest"
+            docker tag "qos-local/${name}:latest" "${image}:${version}"
+            docker tag "qos-local/${name}:latest" "${image}:latest"
+            docker push "${image}:${version}"
+            docker push "${image}:latest"
           done
 
       - name: Extract PCRs (qos_enclave)

--- a/.github/workflows/stagex-release.yml
+++ b/.github/workflows/stagex-release.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           # Extract version from tag (e.g. "qos_core-v0.5.0" -> "v0.5.0")
           version="${release_tag#qos_core-}"
-          for name in qos_client qos_host qos_enclave qos_enclave_egress qos_bridge qos_bridge_egress; do
+          for name in qos_client qos_host qos_enclave qos_enclave_egress qos_bridge qos_bridge_egress signed_echo; do
             env -C out/${name} tar -cf - . | docker load
             docker tag "qos-local/${name}:latest" "ghcr.io/tkhq/${name}:${version}"
             docker tag "qos-local/${name}:latest" "ghcr.io/tkhq/${name}:latest"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,12 +2663,12 @@ dependencies = [
 
 [[package]]
 name = "signed_echo"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "axum",
- "qos_hex 0.10.0",
+ "qos_hex 0.10.1",
  "qos_json",
- "qos_p256 0.10.0",
+ "qos_p256 0.10.1",
  "serde",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2662,6 +2662,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "signed_echo"
+version = "0.9.0"
+dependencies = [
+ "axum",
+ "qos_hex 0.9.0",
+ "qos_p256 0.9.0",
+ "serde",
+ "tokio",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,11 +2663,11 @@ dependencies = [
 
 [[package]]
 name = "signed_echo"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "axum",
- "qos_hex 0.9.0",
- "qos_p256 0.9.0",
+ "qos_hex 0.10.0",
+ "qos_p256 0.10.0",
  "serde",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2667,6 +2667,7 @@ version = "0.10.0"
 dependencies = [
  "axum",
  "qos_hex 0.10.0",
+ "qos_json",
  "qos_p256 0.10.0",
  "serde",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "src/qos_test_primitives",
   "src/qos_p256",
   "src/qos_nsm",
+  "src/signed_echo",
   # special members that are not default-members
   "src/qos_crypto/fuzz",
   "src/qos_net/fuzz",
@@ -31,6 +32,7 @@ default-members = [
   "src/qos_test_primitives",
   "src/qos_p256",
   "src/qos_nsm",
+  "src/signed_echo",
 ]
 exclude = [
   "src/init",

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ default: \
 	out/qos_enclave/index.json \
 	out/qos_bridge/index.json \
 	out/qos_enclave_egress/index.json \
-	out/qos_bridge_egress/index.json
+	out/qos_bridge_egress/index.json \
+	out/signed_echo/index.json
 
 .PHONY: test
 test: out/.common-loaded
@@ -176,6 +177,17 @@ out/qos_bridge_egress/index.json: \
 		src/qos_nsm \
 	)
 	$(call build,qos_bridge_egress)
+
+out/signed_echo/index.json: \
+	out/common/index.json \
+	$(CARGO_WORKSPACE_FILES) \
+	src/images/signed_echo/Containerfile \
+	$(shell git ls-files \
+		src/signed_echo \
+		src/qos_p256 \
+		src/qos_hex \
+	)
+	$(call build,signed_echo)
 
 out/common/index.json: \
 	src/images/common/Containerfile

--- a/src/images/signed_echo/Containerfile
+++ b/src/images/signed_echo/Containerfile
@@ -1,0 +1,30 @@
+FROM common AS base
+
+# Directory for Rust artifacts.
+ENV RELEASE_DIR=/src/target/${TARGET}/release
+
+# Name of the crate containing the pivot app binary.
+ENV APPLICATION_CRATE_NAME=signed_echo
+
+ADD . /src
+
+# Pre-fetch workspace dependencies so the release build can run offline.
+WORKDIR /src
+RUN cd /src && cargo fetch
+
+FROM base AS build
+WORKDIR /src/src/${APPLICATION_CRATE_NAME}
+RUN --network=none <<-EOF
+	set -eux
+	cargo build ${CARGOFLAGS}
+	mkdir -p /rootfs
+	mv ${RELEASE_DIR}/${APPLICATION_CRATE_NAME} /rootfs/tvc_app
+	file /rootfs/tvc_app | grep "static-pie"
+	sha256sum /rootfs/tvc_app | awk '{print "SHA256=" $1}'
+	find /rootfs -exec touch -hcd "@0" "{}" +
+EOF
+
+FROM stagex/core-busybox:1.36.1@sha256:cac5d773db1c69b832d022c469ccf5f52daf223b91166e6866d42d6983a3b374 AS package
+COPY --from=build /rootfs/. .
+RUN echo "TVC application binary is available within the container image at /tvc_app"
+RUN sha256sum /tvc_app | awk '{print "SHA256=" $1}'

--- a/src/signed_echo/Cargo.toml
+++ b/src/signed_echo/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "signed_echo"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[lints.rust]
+missing_docs = "warn"
+unsafe_code = "deny"
+
+[lints.clippy]
+pedantic = "deny"
+missing_errors_doc = "allow"
+module_name_repetitions = "allow"
+
+[dependencies]
+axum = { workspace = true, features = ["http1", "tokio", "json"], default-features = false }
+qos_hex = { workspace = true }
+qos_p256 = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "signal"] }

--- a/src/signed_echo/Cargo.toml
+++ b/src/signed_echo/Cargo.toml
@@ -6,18 +6,13 @@ rust-version.workspace = true
 license.workspace = true
 publish = false
 
-[lints.rust]
-missing_docs = "warn"
-unsafe_code = "deny"
-
-[lints.clippy]
-pedantic = "deny"
-missing_errors_doc = "allow"
-module_name_repetitions = "allow"
+[lints]
+workspace = true
 
 [dependencies]
 axum = { workspace = true, features = ["http1", "tokio", "json"], default-features = false }
 qos_hex = { workspace = true }
+qos_json = { workspace = true }
 qos_p256 = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "signal"] }

--- a/src/signed_echo/README.md
+++ b/src/signed_echo/README.md
@@ -1,0 +1,31 @@
+# Signed Echo
+
+`signed_echo` is a simple Axum pivot app for QOS bridge-based ingress. It
+listens on localhost TCP, accepts UTF-8 POST bodies, and returns the body with
+a quorum-key signature over:
+
+```text
+b"echo app signed at" || unix_time_seconds_u64_be || message_utf8_bytes
+```
+
+## Run Locally
+
+```sh
+cargo run -p signed_echo -- \
+  --host 127.0.0.1 \
+  --port 3000 \
+  --quorum-file /path/to/qos.quorum.key
+```
+
+```sh
+curl -X POST --data-binary 'hello' http://127.0.0.1:3000/echo
+```
+
+## Defaults
+
+- host: `127.0.0.1`
+- port: `3000`
+- quorum key file: `/qos.quorum.key`
+- domain separator: `echo app signed at`
+
+The POST handler is available at `/echo`, `/signed-echo`, and `/signed_echo`.

--- a/src/signed_echo/README.md
+++ b/src/signed_echo/README.md
@@ -2,10 +2,10 @@
 
 `signed_echo` is a simple Axum pivot app for QOS bridge-based ingress. It
 listens on localhost TCP, accepts UTF-8 POST bodies, and returns the body with
-a quorum-key signature over:
+a quorum-key signature over the QOS JSON bytes of `signed_payload_json`:
 
-```text
-b"echo app signed at" || unix_time_seconds_u64_be || message_utf8_bytes
+```json
+{"domain":"echo app signed","message":"hello","time":"1700000000"}
 ```
 
 ## Run Locally
@@ -26,6 +26,5 @@ curl -X POST --data-binary 'hello' http://127.0.0.1:3000/echo
 - host: `127.0.0.1`
 - port: `3000`
 - quorum key file: `/qos.quorum.key`
-- domain separator: `echo app signed at`
 
-The POST handler is available at `/echo`, `/signed-echo`, and `/signed_echo`.
+The POST handler is available at `/echo`.

--- a/src/signed_echo/src/lib.rs
+++ b/src/signed_echo/src/lib.rs
@@ -1,7 +1,6 @@
 //! Axum-based signed echo pivot application.
 
 use std::{
-	mem::size_of,
 	path::{Path, PathBuf},
 	time::{SystemTime, SystemTimeError, UNIX_EPOCH},
 };
@@ -18,8 +17,8 @@ use serde::{Deserialize, Serialize};
 
 /// Default path where QOS writes the quorum-key secret for pivot apps.
 pub const DEFAULT_QUORUM_KEY_PATH: &str = "/qos.quorum.key";
-/// Domain separator for signed echo proofs.
-pub const DOMAIN_SEPARATOR: &str = "echo app signed at";
+/// Application domain included in the signed QOS JSON payload.
+const SIGNED_PAYLOAD_DOMAIN: &str = "echo app signed";
 
 /// Runtime configuration for the signed echo app.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -49,18 +48,21 @@ impl Config {
 
 /// Response returned by the signed echo endpoint.
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
-pub struct SignedEchoResponse {
-	/// Unix timestamp, in seconds, included in the signed payload.
-	pub time: u64,
-	/// Request body echoed back as UTF-8 text.
-	pub message: String,
-	/// Hex-encoded quorum-key signature preimage.
-	pub signed_payload_hex: String,
-	/// Hex-encoded quorum-key signature over the bytes represented by
-	/// `signed_payload_hex`.
+pub struct EchoResponse {
+	/// Exact QOS JSON string covered by `signature_hex`.
+	pub signed_payload_json: String,
+	/// Hex-encoded quorum-key signature over `signed_payload_json` bytes.
 	pub signature_hex: String,
 	/// Hex-encoded quorum public key.
 	pub public_key_hex: String,
+}
+
+/// Payload signed by the quorum key.
+#[derive(Serialize)]
+struct SignedPayload {
+	domain: &'static str,
+	message: String,
+	time: u64,
 }
 
 /// Build the Axum router for signed echo.
@@ -68,8 +70,6 @@ pub fn router(config: Config) -> Router {
 	Router::new()
 		.route("/health", get(health))
 		.route("/echo", post(signed_echo))
-		.route("/signed-echo", post(signed_echo))
-		.route("/signed_echo", post(signed_echo))
 		.with_state(config)
 }
 
@@ -80,7 +80,7 @@ async fn health() -> impl IntoResponse {
 async fn signed_echo(
 	State(config): State<Config>,
 	body: String,
-) -> Result<Json<SignedEchoResponse>, AppError> {
+) -> Result<Json<EchoResponse>, AppError> {
 	let time = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
 	let response = sign_payload(&config, time, body)?;
 	Ok(Json(response))
@@ -90,36 +90,29 @@ fn sign_payload(
 	config: &Config,
 	time: u64,
 	message: String,
-) -> Result<SignedEchoResponse, AppError> {
+) -> Result<EchoResponse, AppError> {
 	let quorum_key = P256Pair::from_hex_file(config.quorum_key_path())
 		.map_err(|_| AppError::QuorumKey)?;
-	let signed_payload = signature_preimage(time, &message);
-	let signature =
-		quorum_key.sign(&signed_payload).map_err(|_| AppError::Sign)?;
+	let signed_payload =
+		SignedPayload { domain: SIGNED_PAYLOAD_DOMAIN, message, time };
+	let signed_payload_json = qos_json::to_string(&signed_payload)
+		.map_err(|_| AppError::Serialize)?;
+	let signature = quorum_key
+		.sign(signed_payload_json.as_bytes())
+		.map_err(|_| AppError::Sign)?;
 
-	Ok(SignedEchoResponse {
-		time,
-		message,
-		signed_payload_hex: qos_hex::encode(&signed_payload),
+	Ok(EchoResponse {
+		signed_payload_json,
 		signature_hex: qos_hex::encode(&signature),
 		public_key_hex: qos_hex::encode(&quorum_key.public_key().to_bytes()),
 	})
-}
-
-fn signature_preimage(time: u64, message: &str) -> Vec<u8> {
-	let mut signed_payload = Vec::with_capacity(
-		DOMAIN_SEPARATOR.len() + size_of::<u64>() + message.len(),
-	);
-	signed_payload.extend_from_slice(DOMAIN_SEPARATOR.as_bytes());
-	signed_payload.extend_from_slice(&time.to_be_bytes());
-	signed_payload.extend_from_slice(message.as_bytes());
-	signed_payload
 }
 
 #[derive(Debug)]
 enum AppError {
 	SystemTime,
 	QuorumKey,
+	Serialize,
 	Sign,
 }
 
@@ -134,6 +127,7 @@ impl IntoResponse for AppError {
 		let error = match self {
 			Self::SystemTime => "system time is before the Unix epoch",
 			Self::QuorumKey => "failed to read quorum key",
+			Self::Serialize => "failed to serialize signed payload",
 			Self::Sign => "failed to sign payload",
 		};
 		(StatusCode::INTERNAL_SERVER_ERROR, Json(ErrorResponse { error }))

--- a/src/signed_echo/src/lib.rs
+++ b/src/signed_echo/src/lib.rs
@@ -1,0 +1,152 @@
+//! Axum-based signed echo pivot application.
+
+use std::{
+	mem::size_of,
+	path::{Path, PathBuf},
+	time::{SystemTime, SystemTimeError, UNIX_EPOCH},
+};
+
+use axum::{
+	Json, Router,
+	extract::State,
+	http::StatusCode,
+	response::{IntoResponse, Response},
+	routing::{get, post},
+};
+use qos_p256::P256Pair;
+use serde::{Deserialize, Serialize};
+
+/// Default path where QOS writes the quorum-key secret for pivot apps.
+pub const DEFAULT_QUORUM_KEY_PATH: &str = "/qos.quorum.key";
+/// Domain separator for signed echo proofs.
+pub const DOMAIN_SEPARATOR: &str = "echo app signed at";
+
+/// Runtime configuration for the signed echo app.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Config {
+	quorum_key_path: PathBuf,
+}
+
+impl Config {
+	/// Create a runtime config.
+	#[must_use]
+	pub fn new(quorum_key_path: impl Into<PathBuf>) -> Self {
+		Self { quorum_key_path: quorum_key_path.into() }
+	}
+
+	/// Create a config using the default QOS quorum-key path.
+	#[must_use]
+	pub fn with_qos_defaults() -> Self {
+		Self::new(DEFAULT_QUORUM_KEY_PATH)
+	}
+
+	/// Return the configured quorum-key path.
+	#[must_use]
+	pub fn quorum_key_path(&self) -> &Path {
+		&self.quorum_key_path
+	}
+}
+
+/// Response returned by the signed echo endpoint.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct SignedEchoResponse {
+	/// Unix timestamp, in seconds, included in the signed payload.
+	pub time: u64,
+	/// Request body echoed back as UTF-8 text.
+	pub message: String,
+	/// Hex-encoded quorum-key signature preimage.
+	pub signed_payload_hex: String,
+	/// Hex-encoded quorum-key signature over the bytes represented by
+	/// `signed_payload_hex`.
+	pub signature_hex: String,
+	/// Hex-encoded quorum public key.
+	pub public_key_hex: String,
+}
+
+/// Build the Axum router for signed echo.
+pub fn router(config: Config) -> Router {
+	Router::new()
+		.route("/health", get(health))
+		.route("/echo", post(signed_echo))
+		.route("/signed-echo", post(signed_echo))
+		.route("/signed_echo", post(signed_echo))
+		.with_state(config)
+}
+
+async fn health() -> impl IntoResponse {
+	(StatusCode::OK, Json(HealthResponse { status: "healthy" }))
+}
+
+async fn signed_echo(
+	State(config): State<Config>,
+	body: String,
+) -> Result<Json<SignedEchoResponse>, AppError> {
+	let time = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+	let response = sign_payload(&config, time, body)?;
+	Ok(Json(response))
+}
+
+fn sign_payload(
+	config: &Config,
+	time: u64,
+	message: String,
+) -> Result<SignedEchoResponse, AppError> {
+	let quorum_key = P256Pair::from_hex_file(config.quorum_key_path())
+		.map_err(|_| AppError::QuorumKey)?;
+	let signed_payload = signature_preimage(time, &message);
+	let signature =
+		quorum_key.sign(&signed_payload).map_err(|_| AppError::Sign)?;
+
+	Ok(SignedEchoResponse {
+		time,
+		message,
+		signed_payload_hex: qos_hex::encode(&signed_payload),
+		signature_hex: qos_hex::encode(&signature),
+		public_key_hex: qos_hex::encode(&quorum_key.public_key().to_bytes()),
+	})
+}
+
+fn signature_preimage(time: u64, message: &str) -> Vec<u8> {
+	let mut signed_payload = Vec::with_capacity(
+		DOMAIN_SEPARATOR.len() + size_of::<u64>() + message.len(),
+	);
+	signed_payload.extend_from_slice(DOMAIN_SEPARATOR.as_bytes());
+	signed_payload.extend_from_slice(&time.to_be_bytes());
+	signed_payload.extend_from_slice(message.as_bytes());
+	signed_payload
+}
+
+#[derive(Debug)]
+enum AppError {
+	SystemTime,
+	QuorumKey,
+	Sign,
+}
+
+impl From<SystemTimeError> for AppError {
+	fn from(_err: SystemTimeError) -> Self {
+		Self::SystemTime
+	}
+}
+
+impl IntoResponse for AppError {
+	fn into_response(self) -> Response {
+		let error = match self {
+			Self::SystemTime => "system time is before the Unix epoch",
+			Self::QuorumKey => "failed to read quorum key",
+			Self::Sign => "failed to sign payload",
+		};
+		(StatusCode::INTERNAL_SERVER_ERROR, Json(ErrorResponse { error }))
+			.into_response()
+	}
+}
+
+#[derive(Serialize)]
+struct ErrorResponse {
+	error: &'static str,
+}
+
+#[derive(Serialize)]
+struct HealthResponse {
+	status: &'static str,
+}

--- a/src/signed_echo/src/main.rs
+++ b/src/signed_echo/src/main.rs
@@ -1,0 +1,82 @@
+//! Signed echo pivot application binary.
+
+use std::net::SocketAddr;
+
+use signed_echo::{Config, DEFAULT_QUORUM_KEY_PATH};
+
+const DEFAULT_HOST: &str = "127.0.0.1";
+const DEFAULT_PORT: u16 = 3000;
+
+#[derive(Debug, PartialEq, Eq)]
+struct Cli {
+	host: String,
+	port: u16,
+	quorum_key_path: String,
+}
+
+impl Default for Cli {
+	fn default() -> Self {
+		Self {
+			host: DEFAULT_HOST.to_string(),
+			port: DEFAULT_PORT,
+			quorum_key_path: DEFAULT_QUORUM_KEY_PATH.to_string(),
+		}
+	}
+}
+
+impl Cli {
+	fn parse(args: impl IntoIterator<Item = String>) -> Result<Self, String> {
+		let mut cli = Self::default();
+		let mut args = args.into_iter();
+
+		while let Some(arg) = args.next() {
+			match arg.as_str() {
+				"--host" => {
+					cli.host = next_value(&mut args, "--host")?;
+				}
+				"--port" => {
+					cli.port =
+						next_value(&mut args, "--port")?.parse().map_err(
+							|err| format!("invalid --port value: {err}"),
+						)?;
+				}
+				"--quorum-file" => {
+					cli.quorum_key_path =
+						next_value(&mut args, "--quorum-file")?;
+				}
+				_ => {
+					return Err(format!("unknown argument: {arg}"));
+				}
+			}
+		}
+
+		Ok(cli)
+	}
+
+	fn addr(&self) -> Result<SocketAddr, std::net::AddrParseError> {
+		format!("{}:{}", self.host, self.port).parse()
+	}
+
+	fn config(&self) -> Config {
+		Config::new(&self.quorum_key_path)
+	}
+}
+
+fn next_value(
+	args: &mut impl Iterator<Item = String>,
+	name: &str,
+) -> Result<String, String> {
+	args.next().ok_or_else(|| format!("missing value for {name}"))
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+	let cli = Cli::parse(std::env::args().skip(1)).map_err(|err| {
+		std::io::Error::new(std::io::ErrorKind::InvalidInput, err)
+	})?;
+	let addr = cli.addr()?;
+	let app = signed_echo::router(cli.config());
+
+	axum::Server::bind(&addr).serve(app.into_make_service()).await?;
+	Ok(())
+}


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

This app is a really simple tvc style app meant to test egress
I have made it so it's always built to make life easy and so we just have an app with an image that I can use here and elsewhere in tests

## How I Tested These Changes

This is to enable testing

## Pre merge check list

- [x] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
