### PR TITLE
ci: add --locked to catch Cargo.lock drift (mirrors rust-sdk#148)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Run tests
         run: make -C src test
       - name: Run legacy protocol compat tests
-        run: cargo test -p integration --features legacy-protocol-compat --test protocol_legacy_decode
+        run: cargo test --locked -p integration --features legacy-protocol-compat --test protocol_legacy_decode
 
   lint:
     name: lint
@@ -64,7 +64,7 @@ jobs:
       - name: Check publishable crates standalone
         # Check one selected package at a time so unrelated workspace members
         # cannot hide missing direct dependency features through unification.
-        run: cargo check -p ${{ matrix.package }}
+        run: cargo check --locked -p ${{ matrix.package }}
 
   build-linux-only-crates:
     name: build-linux-only-crates

--- a/src/Makefile
+++ b/src/Makefile
@@ -150,7 +150,7 @@ lint:
 
 .PHONY: clippy
 clippy:
-	cargo clippy --all-targets -- -D warnings
+	cargo clippy --locked --all-targets -- -D warnings
 
 .PHONY: clippy-fix
 clippy-fix:
@@ -164,13 +164,18 @@ fmt:
 test:
 	@# The integration tests rely on binaries from other crates being built, so
 	@# we build all the workspace targets.
-	cargo build --all
+	@# --locked makes Cargo.lock drift fail the build instead of being silently
+	@# auto-repaired in the workspace (so CI cannot pass green on a broken
+	@# lockfile). --locked (not --frozen) still allows registry/network access,
+	@# so CI does not need a pre-warmed offline crate cache. Mirrors
+	@# tkhq/rust-sdk#148.
+	cargo build --locked --all
 	@# Run tests
-	cargo test
+	cargo test --locked
 	@# When we build the workspace it resolves with the qos_core mock feature
 	@# enabled. However some tests require it disable, so we test just qos_core
 	@# by itself.
-	cargo test -p qos_core
+	cargo test --locked -p qos_core
 
 .PHONY: build-linux-only
 build-linux-only: qos_system qos_aws init qos_enclave qos_bridge

--- a/src/Makefile
+++ b/src/Makefile
@@ -166,9 +166,7 @@ test:
 	@# we build all the workspace targets.
 	@# --locked makes Cargo.lock drift fail the build instead of being silently
 	@# auto-repaired in the workspace (so CI cannot pass green on a broken
-	@# lockfile). --locked (not --frozen) still allows registry/network access,
-	@# so CI does not need a pre-warmed offline crate cache. Mirrors
-	@# tkhq/rust-sdk#148.
+	@# lockfile).
 	cargo build --locked --all
 	@# Run tests
 	cargo test --locked


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

**Problem:** CI builds Rust via `make -C src test` / `make -C src lint` (in `.github/workflows/pr.yml`), plus a standalone `cargo check -p <pkg>` matrix and a legacy-protocol `cargo test`. None of these pass `--locked`. When a checkout's `Cargo.lock` is out of sync with the dependency graph, cargo silently repairs the lockfile in the workspace and proceeds — so a broken/drifted lockfile passes CI green and the repair is never committed. This exact failure mode bit tkhq/rust-sdk: a rebase dropped a `[[package]]` stanza, CI didn't catch it, and it had to be fixed manually later. The preventive fix landed in tkhq/rust-sdk#148.

**Solution:** Add `--locked` to the cargo invocations that resolve the workspace `Cargo.lock` in CI:
- `src/Makefile` `test`: `cargo build --locked --all`, `cargo test --locked`, `cargo test --locked -p qos_core`
- `src/Makefile` `clippy`: `cargo clippy --locked --all-targets`
- `.github/workflows/pr.yml`: `cargo check --locked -p <pkg>` and `cargo test --locked -p integration ...`

With `--locked`, lockfile drift now fails the build instead of being silently auto-repaired. `--locked` (not `--frozen`) is intentional: it catches drift while still allowing registry/network access, so CI doesn't need a pre-warmed offline crate cache. Mirrors tkhq/rust-sdk#148.

## How I Tested These Changes

- Verified the affected Make targets with dry-runs: `make -C src -n test` and `make -C src -n clippy` — `--locked` lands in the correct position on every workspace-resolving cargo command.
- Validated `.github/workflows/pr.yml` parses as valid YAML.
- Did not run a full `cargo build`/`test` locally (no Rust toolchain in the authoring environment); CI on this PR validates the live build. The change is CI-only — no library/runtime code is touched.

## Pre merge check list

- [x] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version? **Yes**
    - Can previous versions of QOS verify attestations from this new version? **Yes**
    - Can manifests generated by a previous version still be parsed by this one? **Yes**
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)? **Yes**
    - Can a previous version of QOS still perform a boot standard on an enclave of this version? **Yes**

_This is a CI-only change (build flags in `src/Makefile` and `.github/workflows/pr.yml`). It touches no runtime, protocol, manifest, attestation, or signing code, so all verification-flow answers are unaffected._