### PR TITLE
Bump vsss-rs to 5.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,18 @@ checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array 0.14.7",
  "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96272c2ff28b807e09250b180ad1fb7889a3258f7455759b5c3c58b719467130"
+dependencies = [
+ "num-traits",
+ "rand_core 0.6.4",
  "serdect",
  "subtle",
  "zeroize",
@@ -614,7 +626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
- "crypto-bigint",
+ "crypto-bigint 0.5.5",
  "digest",
  "ff",
  "generic-array 0.14.7",
@@ -631,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve-tools"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48843edfbd0a370b3dd14cdbb4e446e9a8855311e6b2b57bf9a1fd1367bc317"
+checksum = "1de2b6fae800f08032a6ea32995b52925b1d451bff9d445c8ab2932323277faf"
 dependencies = [
  "elliptic-curve",
  "heapless",
@@ -827,10 +839,11 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "1.1.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96512db27971c2c3eece70a1e106fbe6c87760234e31e8f7e5634912fe52794a"
+checksum = "c2e55f16dcf0e9c00efbe2e655ffe45fc98e7066b52bc92f8a79e64060a79351"
 dependencies = [
+ "rustversion",
  "typenum",
 ]
 
@@ -1047,6 +1060,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2547,9 +2569,9 @@ dependencies = [
 
 [[package]]
 name = "serdect"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
 dependencies = [
  "base16ct",
  "serde",
@@ -3020,9 +3042,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -3111,15 +3133,16 @@ dependencies = [
 
 [[package]]
 name = "vsss-rs"
-version = "5.1.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec4ebcc5594130c31b49594d55c0583fe80621f252f570b222ca4845cafd3cf"
+checksum = "6ec751bdcc8bda099e269b24cc6b4ad14f9ce8b0490c1599174070e792ecd70c"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.6.1",
  "elliptic-curve",
  "elliptic-curve-tools",
- "generic-array 1.1.0",
+ "generic-array 1.4.3",
  "hex",
+ "hybrid-array",
  "num",
  "rand_core 0.6.4",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"], default-
 tokio-rustls = { version = "0.26.2" }
 tokio-vsock = { version = "0.7.2" }
 ureq = { version = "2.9", default-features = false }
-vsss-rs = { version = "5.1", default-features = false, features = ["std", "zeroize"] }
+vsss-rs = { version = "5.4", default-features = false, features = ["std", "zeroize"] }
 webpki = { version = "0.22.4", default-features = false }
 webpki-roots = { version = "1.0.2" }
 x509-cert = { version = "0.2.5", features = ["pem"], default-features = false }

--- a/src/init/Cargo.lock
+++ b/src/init/Cargo.lock
@@ -299,6 +299,18 @@ checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array 0.14.7",
  "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96272c2ff28b807e09250b180ad1fb7889a3258f7455759b5c3c58b719467130"
+dependencies = [
+ "num-traits",
+ "rand_core 0.6.4",
  "serdect",
  "subtle",
  "zeroize",
@@ -425,7 +437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
- "crypto-bigint",
+ "crypto-bigint 0.5.5",
  "digest",
  "ff",
  "generic-array 0.14.7",
@@ -441,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve-tools"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48843edfbd0a370b3dd14cdbb4e446e9a8855311e6b2b57bf9a1fd1367bc317"
+checksum = "1de2b6fae800f08032a6ea32995b52925b1d451bff9d445c8ab2932323277faf"
 dependencies = [
  "elliptic-curve",
  "heapless",
@@ -596,10 +608,11 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "1.1.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96512db27971c2c3eece70a1e106fbe6c87760234e31e8f7e5634912fe52794a"
+checksum = "c2e55f16dcf0e9c00efbe2e655ffe45fc98e7066b52bc92f8a79e64060a79351"
 dependencies = [
+ "rustversion",
  "typenum",
 ]
 
@@ -722,6 +735,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -1160,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "qos_core"
-version = "0.7.0"
+version = "0.10.0"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "borsh",
@@ -1169,6 +1191,7 @@ dependencies = [
  "nix 0.30.1",
  "qos_crypto",
  "qos_hex",
+ "qos_json",
  "qos_nsm",
  "qos_p256",
  "serde",
@@ -1176,34 +1199,48 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-vsock",
+ "zeroize",
 ]
 
 [[package]]
 name = "qos_crypto"
-version = "0.7.0"
+version = "0.10.0"
 dependencies = [
  "rand 0.9.4",
  "sha2",
  "thiserror",
  "vsss-rs",
+ "zeroize",
 ]
 
 [[package]]
 name = "qos_hex"
-version = "0.7.0"
+version = "0.10.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
+name = "qos_json"
+version = "0.10.0"
+dependencies = [
+ "qos_hex",
+ "serde",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
 name = "qos_nsm"
-version = "0.7.0"
+version = "0.10.0"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "aws-nitro-enclaves-nsm-api",
  "borsh",
  "p384",
  "qos_hex",
+ "qos_json",
+ "serde",
  "serde_bytes",
  "sha2",
  "webpki",
@@ -1212,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "qos_p256"
-version = "0.7.0"
+version = "0.10.0"
 dependencies = [
  "aes-gcm",
  "borsh",
@@ -1220,6 +1257,7 @@ dependencies = [
  "hmac",
  "p256",
  "qos_hex",
+ "serde",
  "sha2",
  "zeroize",
 ]
@@ -1465,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "serdect"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
 dependencies = [
  "base16ct",
  "serde",
@@ -1712,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -1756,15 +1794,16 @@ dependencies = [
 
 [[package]]
 name = "vsss-rs"
-version = "5.1.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec4ebcc5594130c31b49594d55c0583fe80621f252f570b222ca4845cafd3cf"
+checksum = "6ec751bdcc8bda099e269b24cc6b4ad14f9ce8b0490c1599174070e792ecd70c"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.6.1",
  "elliptic-curve",
  "elliptic-curve-tools",
- "generic-array 1.1.0",
+ "generic-array 1.4.3",
  "hex",
+ "hybrid-array",
  "num",
  "rand_core 0.6.4",
  "serde",


### PR DESCRIPTION
Bumps the workspace `vsss-rs` dependency from `5.1` to `5.4.0`.

## Changes
- `Cargo.toml`: workspace spec `version = "5.1"` -> `version = "5.4"` (features/default-features unchanged: `default-features = false, features = ["std", "zeroize"]`).
- `Cargo.lock`: `vsss-rs` pinned to `5.4.0` via `cargo update -p vsss-rs --precise 5.4.0`. Transitive bumps: `elliptic-curve-tools 0.1.2->0.2.0`, `serdect 0.2.0->0.3.0`, `generic-array 1.1.0->1.4.3`, `typenum 1.18.0->1.20.1`, plus new `crypto-bigint 0.6.1` and `hybrid-array`.
- `src/init/Cargo.lock`: same `vsss-rs` 5.4.0 pin. This lockfile also picked up pre-existing drift as a side effect of running cargo update — local crate versions `0.7.0 -> 0.10.0` and the previously-missing `qos_json` entry are now in sync with the current workspace version.

## Verification
- `cargo build -p qos_crypto` — clean, no API changes required.
- `cargo test -p qos_crypto` — 7 unit tests + 1 doctest pass.
