### PR TITLE
egress: add DNS support using /etc/resolv.conf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include src/macros.mk
 
 PIVOT_BIN ?= pivot_download
-PIVOT_ARGS ?= [http://objdump.katona.me/program.bin,109.123.250.238:80]
+PIVOT_ARGS ?= [http://objdump.katona.me/program.bin]
 REGISTRY := local
 CARGO_WORKSPACE_FILES := Cargo.toml Cargo.lock
 .DEFAULT_GOAL :=

--- a/in/resolv.conf
+++ b/in/resolv.conf
@@ -1,0 +1,3 @@
+nameserver 8.8.4.4
+options edns0 trust-ad
+search lan

--- a/src/images/qemu/Containerfile
+++ b/src/images/qemu/Containerfile
@@ -38,6 +38,7 @@ COPY --from=linux-nitro /nsm.ko .
 COPY --from=iproute2 . /
 COPY --from=musl . /
 COPY --from=build-egress /egress .
+COPY in/resolv.conf resolv.conf
 COPY <<-EOF initramfs.list
 	file /init     init    0700 0 0
 	file /nsm.ko   nsm.ko  0600 0 0
@@ -60,6 +61,7 @@ COPY <<-EOF initramfs.list
 	file /egress   egress 0700 0 0
 	file /usr/sbin/ip      /usr/sbin/ip     0700 0 0
 	file /lib/ld-musl-x86  /usr/lib/ld-musl-x86_64.so.1                   0700 0 0
+	file /etc/resolv.conf  resolv.conf      0644 0 0
 EOF
 ENV CPIO_TIMESTAMP=1
 ENV KBUILD_BUILD_TIMESTAMP=1

--- a/src/images/qos_enclave_egress/Containerfile
+++ b/src/images/qos_enclave_egress/Containerfile
@@ -49,6 +49,7 @@ COPY --from=linux-nitro /nsm.ko .
 COPY --from=iproute2 . /
 COPY --from=musl . /
 COPY --from=build-egress /egress .
+COPY in/resolv.conf resolv.conf
 COPY <<-EOF initramfs.list
 	file /init     init    0755 0 0
 	file /nsm.ko   nsm.ko  0755 0 0
@@ -71,6 +72,7 @@ COPY <<-EOF initramfs.list
 	file /egress           /egress          0700 0 0
 	file /usr/sbin/ip      /usr/sbin/ip     0700 0 0
 	file /lib/ld-musl-x86  /usr/lib/ld-musl-x86_64.so.1                   0700 0 0
+	file /etc/resolv.conf  resolv.conf      0644 0 0
 EOF
 ENV CPIO_TIMESTAMP=1
 ENV KBUILD_BUILD_TIMESTAMP=1


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

Adds DNS resolution using google's 8.8.4.4 public dns server by configuring the enclave image with `/etc/resolv.conf` entry.

## How I Tested These Changes
Qemu/locally
