### PR TITLE
A more general fallback to borsh protocol messages

### DIFF
--- a/src/qos_client/src/cli/services.rs
+++ b/src/qos_client/src/cli/services.rs
@@ -1293,7 +1293,7 @@ fn post_request_with_encoding(
 ) -> Result<ProtocolMsg, String> {
 	match encoding {
 		ProtocolMsgEncoding::Borsh => request::post_borsh(uri, req),
-		ProtocolMsgEncoding::Json => request::post(uri, req),
+		ProtocolMsgEncoding::Json => request::post_json(uri, req),
 	}
 }
 

--- a/src/qos_client/src/lib.rs
+++ b/src/qos_client/src/lib.rs
@@ -8,7 +8,10 @@ pub mod yubikey;
 pub mod request {
 	use std::io::Read;
 
-	use qos_core::protocol::msg::{ProtocolMsg, ProtocolMsgEncoding};
+	use qos_core::protocol::{
+		ProtocolError,
+		msg::{ProtocolMsg, ProtocolMsgEncoding},
+	};
 
 	const MAX_SIZE: u64 = u32::MAX as u64;
 	const ERROR_BODY_PREFIX_LIMIT: usize = 256;
@@ -21,6 +24,25 @@ pub mod request {
 	/// cannot be read, or deserialization fails.
 	///
 	pub fn post(url: &str, msg: &ProtocolMsg) -> Result<ProtocolMsg, String> {
+		match post_json(url, msg) {
+			Ok(ProtocolMsg::ProtocolErrorResponse(
+				ProtocolError::ProtocolMsgDeserialization,
+			)) => post_borsh(url, msg),
+			result => result,
+		}
+	}
+
+	/// Post a [`qos_core::protocol::msg::ProtocolMsg`] using JSON wire
+	/// encoding.
+	///
+	/// # Errors
+	///
+	/// Returns an error string if the HTTP request fails, the response
+	/// cannot be read, or deserialization fails.
+	pub(crate) fn post_json(
+		url: &str,
+		msg: &ProtocolMsg,
+	) -> Result<ProtocolMsg, String> {
 		post_wire(url, msg, ProtocolMsgEncoding::Json)
 	}
 


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

Insead of adding another specific fallback I just added a more general fallback to borsh to avoid missing any more cases like this.

## How I Tested These Changes

## Pre merge check list

- [ ] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
