### PR TITLE
qos_core: unify ports into system range

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,22 +55,23 @@ stop:
 	-killall vhost-device-vsock
 	rm -f /tmp/vhost4.socket
 
+# ports are control port 2000, egress bridge port 2001 and user/pivot ingress port 3000
 /tmp/vhost4.socket:
-	vhost-device-vsock --vm guest-cid=4,forward-cid=1,forward-listen=3000+9001+9002,socket=/tmp/vhost4.socket &
+	vhost-device-vsock --vm guest-cid=4,forward-cid=1,forward-listen=2000+2001+3000,socket=/tmp/vhost4.socket &
 
 .PHONY: host
 host:
 	cargo run --locked -p qos_host --features qemu -- \
 		--host-ip 0.0.0.0 \
-		--host-port 3001 \
+		--host-port 2000 \
 		--cid 1 \
-		--port 9001
+		--port 2000
 
 .PHONY: bridge
 bridge: target/x86_64-unknown-linux-musl/release-panic-abort/egress
 	cargo run -p qos_bridge --locked --bin ingress --features egress,qemu -- \
 		--cid 1 \
-		--control-url http://127.0.0.1:3001/qos \
+		--control-url http://127.0.0.1:2000/qos \
 		--vsock-to-host false \
 		--egress-bin-path target/x86_64-unknown-linux-musl/release-panic-abort/egress
 
@@ -90,6 +91,8 @@ target/x86_64-unknown-linux-musl/release-panic-abort/egress: \
 	src/qos_bridge/Cargo.toml \
 	src/qos_bridge/src/bin/egress.rs \
 	src/qos_bridge/src/*.rs \
+	src/qos_core/src/**/*.rs \
+	src/qos_core/Cargo.toml \
 	Cargo.toml
 	cargo build --profile release-panic-abort --features egress,qemu --locked --target x86_64-unknown-linux-musl -p qos_bridge --bin egress
 

--- a/src/init/init.rs
+++ b/src/init/init.rs
@@ -78,10 +78,7 @@ async fn main() {
 		PIVOT_FILE.to_string(),
 	);
 
-	#[cfg(feature = "qemu")]
-	const START_PORT: u32 = 9001; // avoid root level ports since we match on local host
-	#[cfg(not(feature = "qemu"))]
-	const START_PORT: u32 = 3;
+	const START_PORT: u32 = 2000;
 	let core_socket =
 		SocketAddress::new_vsock(cid, START_PORT, VMADDR_NO_FLAGS);
 

--- a/src/integration/examples/boot_enclave.rs
+++ b/src/integration/examples/boot_enclave.rs
@@ -29,7 +29,7 @@ async fn main() {
 
 	const PIVOT_HASH_PATH: &str = "/tmp/enclave-example-pivot-hash.txt";
 
-	let host_port = 3001;
+	let host_port = 2000;
 	let tmp = PathWrapper::from("/tmp/enclave-example");
 	let _ = PathWrapper::from(PIVOT_HASH_PATH);
 	fs::create_dir_all(&tmp).unwrap();

--- a/src/qos_core/src/egress.rs
+++ b/src/qos_core/src/egress.rs
@@ -18,13 +18,8 @@ use nix::{
 	unistd::{read, write},
 };
 
-/// egress vsock port used both in and out of the enclave to provide transparent egress data transfer
-#[cfg(not(feature = "qemu"))]
-pub const EGRESS_VSOCK_PORT: u32 = 1000; // reserved range so user ports don't interfere
-
-/// egress vsock port used both in and out of the enclave to provide transparent egress data transfer
-#[cfg(feature = "qemu")]
-pub const EGRESS_VSOCK_PORT: u32 = 9002; // open range for qemu local debug
+/// Vsock port used to connect enclave egress to host egress
+pub const EGRESS_VSOCK_PORT: u32 = 2001;
 
 /// opens enclave side egress bridging using given cid and port blocking forever
 /// # Panics


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

Unifies our internal and external port structure with the following basic rule:
1. Ports `< 3000` are reserved "system" ports and are not to be used by pivot apps/users
2. Ports `>= 3000` are app ports to be used as users need

Currently we are operating these ports:
1. `vsock` port `3` used by the enclave `init/reaper` and `qos_host` for boot instruction messaging
2. `vsock` and `tcp` port `3000` used by `pivot/app` and `qos_bridge` as  ingress default app port for app hosting functionality
3. `vsock` and `ip (both tcp and udp)` port `1000` used by `qos_bridge` enclave-side and host-side for egress bridging

Since ports `<= 1024` are only usable by `root`, and to unify our port structure better this PR changes:

1. `vsock` port `3` is now `2000` - this enabled root-less local hosting for `qemu` runs
2. `vsock` and `ip` port `1000` is now `2001` - this removes the `qemu` compile time feature switch and unifies  things
3. `http` port `3001` used by `qos_host` is now `2000` to match the control `vsock` port it forwards to and to free ports `>= 3000` for app use

NOTE: this PR needs #737 merged and mono and tvc follow ups (TODO)

## How I Tested These Changes

Locally so far

## Pre merge check list

- [ ] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
