### PR TITLE
Zeke/fix egress

### DIFF
--- a/src/images/qos_bridge_egress/Containerfile
+++ b/src/images/qos_bridge_egress/Containerfile
@@ -5,7 +5,7 @@ FROM base AS build
 RUN <<-EOF
 	set -eux
 	cd /src && \
-		cargo build ${CARGOFLAGS} -p qos_bridge --bin ingress &&
+		cargo build ${CARGOFLAGS} -p qos_bridge --bin ingress --features egress &&
 		cargo build ${CARGOFLAGS} -p qos_bridge --bin egress --features egress
 	cp /src/target/${TARGET}/release/ingress /qos_bridge
 	cp /src/target/${TARGET}/release/egress /qos_egress

--- a/src/images/qos_enclave_egress/Containerfile
+++ b/src/images/qos_enclave_egress/Containerfile
@@ -69,7 +69,7 @@ COPY <<-EOF initramfs.list
 	dir  /dev/shm          0755 0 0
 	dir  /dev/pts          0755 0 0
 	nod  /dev/console      0600 0 0 c 5 1
-	file /egress           /egress          0700 0 0
+	file /egress           egress           0700 0 0
 	file /usr/sbin/ip      /usr/sbin/ip     0700 0 0
 	file /lib/ld-musl-x86  /usr/lib/ld-musl-x86_64.so.1                   0700 0 0
 	file /etc/resolv.conf  resolv.conf      0644 0 0


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

## How I Tested These Changes

## Pre merge check list

- [ ] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
