### PR TITLE
TEST: test using smaller MTU and cluster DNS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,6 +1280,7 @@ dependencies = [
 name = "integration"
 version = "0.10.2"
 dependencies = [
+ "axum",
  "borsh",
  "futures",
  "nix 0.30.1",
@@ -1294,6 +1295,7 @@ dependencies = [
  "qos_test_primitives",
  "rand 0.9.4",
  "rustls",
+ "serde",
  "serde_json",
  "sha2",
  "tokio",

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include src/macros.mk
 
 PIVOT_BIN ?= pivot_download
-PIVOT_ARGS ?= [http://objdump.katona.me/program.bin]
+PIVOT_ARGS ?= []
 REGISTRY := local
 CARGO_WORKSPACE_FILES := Cargo.toml Cargo.lock
 .DEFAULT_GOAL :=

--- a/src/integration/Cargo.toml
+++ b/src/integration/Cargo.toml
@@ -28,13 +28,15 @@ qos_p256 = { workspace = true, features = ["mock"] }
 qos_test_primitives = { workspace = true }
 zeroize = { workspace = true }
 
+axum = { workspace = true, default-features = false, features = ["http1", "json"] }
 futures = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "fs"] }
 borsh = { workspace = true }
 nix = { workspace = true }
 rustls = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 webpki-roots = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "fs"] }
 tokio-rustls = { workspace = true }
 
 [dev-dependencies]

--- a/src/integration/examples/pivot_download.rs
+++ b/src/integration/examples/pivot_download.rs
@@ -3,11 +3,51 @@ use std::{
 	time::{Duration, SystemTime},
 };
 
+use axum::{Json, Router, http::StatusCode, response::IntoResponse};
+use serde::{Deserialize, Serialize};
 use sha2::Digest;
 use ureq::Resolver;
 
 struct FixedResolver {
 	ip_addr: SocketAddr,
+}
+
+// download request
+#[derive(Debug, Deserialize)]
+struct DlRequest {
+	url: url::Url,
+	ip_override: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct DlResponse {
+	status: u16,
+	size: usize,
+	duration: Duration,
+	sha256sum: String,
+	error: Option<String>,
+}
+
+impl DlResponse {
+	pub fn unexpected_response(code: u16, r: ureq::Response) -> Self {
+		Self {
+			status: code,
+			size: 0,
+			duration: Duration::ZERO,
+			sha256sum: String::new(),
+			error: Some(r.status_text().to_string()),
+		}
+	}
+
+	pub fn transport_error(t: ureq::Transport) -> Self {
+		Self {
+			status: 500,
+			size: 0,
+			duration: Duration::ZERO,
+			sha256sum: String::new(),
+			error: Some(t.message().unwrap_or("unknown error").to_string()),
+		}
+	}
 }
 
 impl Resolver for FixedResolver {
@@ -16,48 +56,73 @@ impl Resolver for FixedResolver {
 	}
 }
 
-// arguments are <url> [ip_override]
-//    url - the url of the file to download (GET)
-//    ip_override - an optional <ip:port> e.g. 127.0.0.1:80 that is used to avoid dns lookup with the given url if given
-fn main() {
-	let mut args = std::env::args();
-	let url = url::Url::parse(&args.nth(1).expect("no url provided"))
-		.expect("invalid url");
-	let ip_override = args.next(); // provides ip override if we want to avoid dns
+async fn serve() {
+	// build our application with a single route
+	let app = Router::new().route("/", axum::routing::post(download));
 
-	println!("sleeping 10s before download");
-	std::thread::sleep(std::time::Duration::from_secs(10));
+	println!("axum server running, listening on http://127.0.0.1:3000");
+	// run it with hyper on localhost:3000
+	axum::Server::bind(&"127.0.0.1:3000".parse().unwrap())
+		.serve(app.into_make_service())
+		.await
+		.unwrap();
+}
 
-	let client_builder = if let Some(ip) = ip_override {
-		let ip_addr = ip.parse().expect("invalid override ip");
-		let base_url = url.host_str().expect("no host in url");
+async fn download(
+	Json(DlRequest { url, ip_override }): Json<DlRequest>,
+) -> impl IntoResponse {
+	let response = tokio::task::spawn_blocking(move || {
+		let client_builder = if let Some(ip) = ip_override {
+			let ip_addr = ip.parse().expect("invalid override ip");
+			let base_url = url.host_str().expect("no host in url");
 
-		println!("using override ip of {ip} for base url {base_url}");
+			println!("using override ip of {ip} for base url {base_url}");
 
-		ureq::builder().resolver(FixedResolver { ip_addr })
-	} else {
-		ureq::builder()
-	};
+			ureq::builder().resolver(FixedResolver { ip_addr })
+		} else {
+			ureq::builder()
+		};
 
-	let client = client_builder.timeout(Duration::from_mins(1)).build();
+		let client = client_builder.timeout(Duration::from_mins(1)).build();
 
-	println!("starting download of {url}");
-	let request = client.get(url.as_ref());
+		println!("starting download of {url}");
+		let request = client.get(url.as_ref());
 
-	let start = SystemTime::now();
-	let dl = request.call().expect("unable to download");
+		let start = SystemTime::now();
+		let dl = match request.call() {
+			Ok(r) => r,
+			Err(ureq::Error::Status(code, r)) => return (StatusCode::from_u16(code).unwrap(), DlResponse::unexpected_response(code, r)),
+			Err(ureq::Error::Transport(e)) => return (StatusCode::INTERNAL_SERVER_ERROR, DlResponse::transport_error(e))
+		};
 
-	let status = dl.status();
-	let bytes: Vec<u8> = dl.into_string().unwrap().bytes().collect();
+		let status = dl.status();
+		let bytes: Vec<u8> = dl.into_string().unwrap().bytes().collect();
 
-	let size = bytes.len();
-	let ss = sha2::Sha256::digest(bytes);
+		let size = bytes.len();
+		let sha256sum = sha2::Sha256::digest(bytes);
+		let duration = SystemTime::now().duration_since(start).unwrap();
 
-	println!(
-		"download complete\n\tstatus: {}\n\tsize: {}\n\tduration: {:?}\n\tsha256sum:{:x}",
-		status,
-		size,
-		SystemTime::now().duration_since(start).unwrap(),
-		ss,
-	);
+		println!(
+			"download complete\n\tstatus: {}\n\tsize: {}\n\tduration: {:?}\n\tsha256sum:{:x}",
+			status,
+			size,
+			duration,
+			sha256sum,
+		);
+
+		(StatusCode::OK, DlResponse {
+			status,
+			size,
+			duration,
+			sha256sum: format!("{sha256sum:x}"),
+			error: None,
+		})
+	}).await.expect("unable to join blocking task");
+
+	(response.0, Json(response.1))
+}
+
+#[tokio::main]
+async fn main() {
+	serve().await
 }

--- a/src/qos_core/src/egress.rs
+++ b/src/qos_core/src/egress.rs
@@ -84,8 +84,17 @@ pub fn init_egress_tun() {
 	run_ip("tuntap add enclave_egress mode tun", "tuntap add failed");
 	run_ip("link set lo up", "unable to bring up lo");
 	run_ip("address add 172.29.107.65/32 dev lo", "ip assign to lo failed");
+	run_ip("link set mtu 1320 dev enclave_egress", "unable to set MTU size"); // MTU 1340 is max for calico wg-v6-cali so we need <= to that
 	run_ip("link set enclave_egress up", "unable to bring up egress");
 	run_ip("route add default dev enclave_egress", "unable to route");
+
+	let child = run_with_ld(IP_PATH, "link show enclave_egress")
+		.expect("unable to show link info");
+	let output = child.wait_with_output().expect("unable to run link show");
+	println!(
+		"{}",
+		std::str::from_utf8(&output.stdout).expect("unable to parse ip output")
+	);
 }
 
 /// Create core vsock socket in streaming mode

--- a/src/qos_core/src/io/host_bridge.rs
+++ b/src/qos_core/src/io/host_bridge.rs
@@ -139,6 +139,10 @@ async fn tcp_to_vsock(
 				return;
 			}
 
+			// see https://github.com/rust-vmm/vhost-device/issues/963
+			#[cfg(feature = "qemu")]
+			tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
 			if let Err(err) =
 				copy_bidirectional(&mut tcp_stream, &mut stream).await
 			{

--- a/src/qos_core/src/io/stream.rs
+++ b/src/qos_core/src/io/stream.rs
@@ -151,8 +151,9 @@ impl Stream {
 		if self.inner.is_none() {
 			self.connect().await?;
 
+			// see https://github.com/rust-vmm/vhost-device/issues/963
 			#[cfg(feature = "qemu")]
-			tokio::time::sleep(std::time::Duration::from_millis(50)).await; // see https://github.com/rust-vmm/vhost-device/issues/963
+			tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 		} else {
 			eprintln!("SocketStream already connected, call proceeding");
 		}

--- a/src/scripts/enclave_egress_interfaces.sh
+++ b/src/scripts/enclave_egress_interfaces.sh
@@ -11,6 +11,9 @@ sudo ip tuntap add host_egress mode tun
 # assign 10.0.0.2/28 to host_egress to mask the martians
 sudo ip address add 172.29.107.66/28 dev host_egress
 
+# set MTU size to match calico limits in prod
+sudo ip link set mtu 1320 dev host_egress
+
 # bring the interface up
 sudo ip link set host_egress up
 


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

## How I Tested These Changes

## Pre merge check list

- [ ] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
