### PR TITLE
qos_core: set egress tunnel MTU size to 1320

### DIFF
--- a/src/qos_core/src/egress.rs
+++ b/src/qos_core/src/egress.rs
@@ -84,6 +84,7 @@ pub fn init_egress_tun() {
 	run_ip("tuntap add enclave_egress mode tun", "tuntap add failed");
 	run_ip("link set lo up", "unable to bring up lo");
 	run_ip("address add 172.29.107.65/32 dev lo", "ip assign to lo failed");
+	run_ip("link set mtu 1320 dev enclave_egress", "unable to set MTU size"); // MTU 1340 is max for calico wg-v6-cali so we need <= to that
 	run_ip("link set enclave_egress up", "unable to bring up egress");
 	run_ip("route add default dev enclave_egress", "unable to route");
 }

--- a/src/scripts/enclave_egress_interfaces.sh
+++ b/src/scripts/enclave_egress_interfaces.sh
@@ -11,6 +11,9 @@ sudo ip tuntap add host_egress mode tun
 # assign 10.0.0.2/28 to host_egress to mask the martians
 sudo ip address add 172.29.107.66/28 dev host_egress
 
+# set MTU size to match calico limits in prod
+sudo ip link set mtu 1320 dev host_egress
+
 # bring the interface up
 sudo ip link set host_egress up
 


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

Setting MTU on egress tunnel interface fixes frame drop issues due to calico wireguard transport.

## How I Tested These Changes

In dev
