### PR TITLE
Add dynamic mock NSM

### DIFF
--- a/docs/guide_dev.md
+++ b/docs/guide_dev.md
@@ -91,16 +91,19 @@ The `dangerous-dev-boot` command is a development shortcut that automates the en
 ### Mock NSM Behavior
 
 The mock NSM:
-- Returns a **hardcoded** attestation document (from `qos_nsm/src/static/mock_attestation_doc`)
+- Returns dynamically generated, parseable attestation documents for live
+  attestation requests
+- Embeds the requested `user_data`, `nonce`, and public key in the generated
+  attestation document
 - Uses **hardcoded PCR values** (all defined in `qos_nsm/src/mock.rs`)
 - Uses a **fixed timestamp** (unless `mock_realtime` feature is enabled)
-- Does not perform real cryptographic attestation
+- Does not produce AWS Nitro PKI-signed attestation documents
 
 ### Why --unsafe-eph-path-override?
 
-The boot flow requires the enclave side to have the ephemeral private key and the client side to have the associated public key. We typically embed the ephemeral public key in the attestation document: clients are expected to verify the attestation document before using the ephemeral public key. Locally, we cannot generate attestation documents, so we return a hardcoded mock attestation document. The mock attestation document contains an **invalid** ephemeral public key, and even if it was valid we would not have access to the associated private key.
+The boot flow requires the enclave side to have the ephemeral private key and the client side to have the associated public key. We typically embed the ephemeral public key in the attestation document: clients are expected to verify the attestation document before using the ephemeral public key. In mock mode, `qos_core` passes the ephemeral public key in the attestation request, and the mock NSM embeds that request value in live attestation documents.
 
-The `--unsafe-eph-path-override` flag tells the client to:
+The `--unsafe-eph-path-override` flag remains useful when your local client and local `qos_core` configuration use a non-production key path. It tells the client to:
 1. **Ignore** the public key from the attestation document
 2. **Read** the actual ephemeral key from the filesystem
 3. **Use** that key for encrypting quorum shares
@@ -108,14 +111,14 @@ The `--unsafe-eph-path-override` flag tells the client to:
 **The flow:**
 1. qos_core generates a fresh ephemeral key during `BootStandardRequest`
 2. qos_core writes private key to `./local-enclave/qos.ephemeral.key`
-3. qos_core returns the (broken) mock attestation document
-4. Client reads `./local-enclave/qos.ephemeral.key` for the real public key
+3. qos_core requests a mock attestation document with the ephemeral public key
+4. Client reads `./local-enclave/qos.ephemeral.key` for the real public key when the override is configured
 5. Client encrypts shares correctly
 6. Decryption succeeds
 
 ### Alternative: Skip the Override
 
-If you prefer not to use `--unsafe-eph-path-override`, you can omit it entirely. The client will attempt to extract the public key from the attestation document. However, this may fail due to the PEM encoding issue.
+If you prefer not to use `--unsafe-eph-path-override`, you can omit it entirely. The client will attempt to extract the public key from the attestation document.
 
 ## File System Layout
 
@@ -139,14 +142,6 @@ When running in mock mode, qos_core creates a `./local-enclave/` directory with:
 
 **Solution:**
 - Use `--unsafe-eph-path-override ./local-enclave/qos.ephemeral.key`
-
-### EncodedPublicKeyTooLong Error
-
-**Symptom:** `Ephemeral key not valid public key: EncodedPublicKeyTooLong`
-
-**Cause:** The mock attestation document has a PEM-encoded public key (800 bytes) instead of DER format.
-
-**Solution:** Use `--unsafe-eph-path-override ./local-enclave/qos.ephemeral.key`
 
 ### Socket Connection Refused
 

--- a/src/qos_core/src/cli.rs
+++ b/src/qos_core/src/cli.rs
@@ -73,11 +73,11 @@ impl EnclaveOpts {
 		if self.parsed.flag(MOCK).unwrap_or(false) {
 			#[cfg(feature = "mock")]
 			{
-				Box::new(qos_nsm::mock::MockNsm)
+				Box::new(qos_nsm::mock::DynamicMockNsm::new())
 			}
 			#[cfg(not(feature = "mock"))]
 			{
-				panic!("\"mock\" feature must be enabled to use `MockNsm`")
+				panic!("\"mock\" feature must be enabled to use mock NSM")
 			}
 		} else {
 			Box::new(Nsm)
@@ -251,6 +251,37 @@ mod test {
 			*opts.parsed.single(USOCK).unwrap(),
 			"/tmp/usock".to_string()
 		);
+	}
+
+	#[cfg(feature = "mock")]
+	#[test]
+	fn mock_nsm_embeds_request_public_key() {
+		let public_key = vec![1, 2, 3, 4];
+		let mut args: Vec<_> = vec![
+			"binary",
+			"--usock",
+			"/tmp/qos-core-cli-dynamic-mock-nsm.sock",
+			"--mock",
+		]
+		.into_iter()
+		.map(String::from)
+		.collect();
+		let opts = EnclaveOpts::new(&mut args);
+		let response = opts.nsm().nsm_process_request(
+			qos_nsm::types::NsmRequest::Attestation {
+				user_data: None,
+				nonce: None,
+				public_key: Some(public_key.clone()),
+			},
+		);
+
+		let qos_nsm::types::NsmResponse::Attestation { document } = response
+		else {
+			panic!("expected attestation response");
+		};
+		let doc =
+			qos_nsm::nitro::unsafe_attestation_doc_from_der(&document).unwrap();
+		assert_eq!(doc.public_key.unwrap().as_slice(), public_key);
 	}
 
 	#[test]

--- a/src/qos_nsm/README.md
+++ b/src/qos_nsm/README.md
@@ -1,0 +1,41 @@
+# `qos_nsm`
+
+`qos_nsm` contains QOS types and provider implementations for the AWS Nitro
+Secure Module (NSM) API. QOS uses this crate to request attestation documents,
+parse Nitro attestation documents, and verify the document fields that bind a
+running enclave to an approved manifest.
+
+The main abstraction is `NsmProvider`. Production code uses `Nsm`, which sends
+requests to the Nitro NSM driver. Tests and local development can use mock
+providers that implement the same trait.
+
+## Providers
+
+- `Nsm`: the production provider. It sends `NsmRequest` values to the AWS Nitro
+  NSM driver and returns `NsmResponse` values from the driver.
+- `MockNsm`: a static test provider behind the `mock` feature. It returns the
+  fixed attestation document embedded in this crate. This is useful for tests
+  that need stable historical fixture data.
+- `DynamicMockNsm`: a configurable test provider behind the `mock` feature. It
+  creates a fresh, parseable COSE Sign1 attestation document for each
+  attestation request and preserves the request's `user_data`, `nonce`, and
+  `public_key` fields.
+
+`DynamicMockNsm` supports local end-to-end tests for pivot applications that call
+the attestation API, return app-level proofs, and include an attestation document
+plus manifest in their response. Like a real NSM request, the ephemeral public
+key must be supplied in `NsmRequest::Attestation`.
+
+## Attestation Scope
+
+The Nitro helpers in `nitro` expose two levels of parsing:
+
+- `unsafe_attestation_doc_from_der` decodes the COSE payload into an
+  `AttestationDoc` without certificate-chain or signature validation.
+- `attestation_doc_from_der` performs AWS Nitro certificate-chain validation and
+  verifies the COSE signature against the attestation document certificate.
+
+Mock providers are only for local development and tests. In particular,
+`DynamicMockNsm` creates documents that are useful for checking QOS protocol
+fields such as manifest hash, PCRs, nonce, and ephemeral public key, but it does
+not produce AWS Nitro PKI-signed documents.

--- a/src/qos_nsm/src/lib.rs
+++ b/src/qos_nsm/src/lib.rs
@@ -1,4 +1,4 @@
-//! Endpoints and types for an enclaves attestation flow.
+#![doc = include_str!("../README.md")]
 
 pub mod nitro;
 mod nsm;

--- a/src/qos_nsm/src/mock.rs
+++ b/src/qos_nsm/src/mock.rs
@@ -1,11 +1,24 @@
 //! Mocks for external attest endpoints. Only for testing.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
+
+use aws_nitro_enclaves_cose::{
+	CoseSign1,
+	crypto::{
+		Hash, MessageDigest, SignatureAlgorithm, SigningPrivateKey,
+		SigningPublicKey,
+	},
+	error::CoseError,
+	header_map::HeaderMap,
+};
+use aws_nitro_enclaves_nsm_api::api::{AttestationDoc, Digest};
+use p384::ecdsa::{Signature, SigningKey, VerifyingKey};
+use serde_bytes::ByteBuf;
 
 use crate::{
 	nitro,
 	nsm::NsmProvider,
-	types::{NsmDigest, NsmRequest, NsmResponse},
+	types::{NsmDigest, NsmErrorCode, NsmRequest, NsmResponse},
 };
 
 /// DO NOT USE IN PRODUCTION - ONLY FOR TESTS.
@@ -37,6 +50,15 @@ pub const MOCK_PCR3: &str = "000000000000000000000000000000000000000000000000000
 pub const MOCK_NSM_ATTESTATION_DOCUMENT: &[u8] =
 	include_bytes!("./static/mock_attestation_doc");
 
+const MOCK_MODULE_ID: &str = "mock_module_id";
+const MOCK_NSM_VERSION_MAJOR: u16 = 1;
+const MOCK_NSM_VERSION_MINOR: u16 = 2;
+const MOCK_NSM_VERSION_PATCH: u16 = 14;
+const MOCK_MAX_PCRS: u16 = 1024;
+const MOCK_LOCKED_PCRS: [u16; 3] = [90, 91, 92];
+const MOCK_EXTEND_PCR_RESPONSE: [u8; 4] = [3, 4, 7, 4];
+const MOCK_RANDOM_RESPONSE: [u8; 4] = [4, 2, 0, 69];
+
 /// Mock Nitro Secure Module endpoint that should only ever be used for testing.
 pub struct MockNsm;
 impl NsmProvider for MockNsm {
@@ -50,25 +72,28 @@ impl NsmProvider for MockNsm {
 				document: MOCK_NSM_ATTESTATION_DOCUMENT.to_vec(),
 			},
 			NsmRequest::DescribeNSM => NsmResponse::DescribeNSM {
-				version_major: 1,
-				version_minor: 2,
-				version_patch: 14,
-				module_id: "mock_module_id".to_string(),
-				max_pcrs: 1024,
-				locked_pcrs: BTreeSet::from([90, 91, 92]),
+				version_major: MOCK_NSM_VERSION_MAJOR,
+				version_minor: MOCK_NSM_VERSION_MINOR,
+				version_patch: MOCK_NSM_VERSION_PATCH,
+				module_id: MOCK_MODULE_ID.to_string(),
+				max_pcrs: MOCK_MAX_PCRS,
+				locked_pcrs: BTreeSet::from(MOCK_LOCKED_PCRS),
 				digest: NsmDigest::SHA256,
 			},
 			NsmRequest::ExtendPCR { index: _, data: _ } => {
-				NsmResponse::ExtendPCR { data: vec![3, 4, 7, 4] }
+				NsmResponse::ExtendPCR {
+					data: MOCK_EXTEND_PCR_RESPONSE.to_vec(),
+				}
 			}
 			NsmRequest::GetRandom => {
-				NsmResponse::GetRandom { random: vec![4, 2, 0, 69] }
+				NsmResponse::GetRandom { random: MOCK_RANDOM_RESPONSE.to_vec() }
 			}
 			NsmRequest::LockPCR { index: _ } => NsmResponse::LockPCR,
 			NsmRequest::LockPCRs { range: _ } => NsmResponse::LockPCRs,
-			NsmRequest::DescribePCR { index: _ } => {
-				NsmResponse::DescribePCR { lock: false, data: vec![3, 4, 7, 4] }
-			}
+			NsmRequest::DescribePCR { index: _ } => NsmResponse::DescribePCR {
+				lock: false,
+				data: MOCK_EXTEND_PCR_RESPONSE.to_vec(),
+			},
 		}
 	}
 
@@ -90,5 +115,266 @@ impl NsmProvider for MockNsm {
 					.map_err(|_| nitro::AttestError::InvalidTimeStamp)?
 			}
 		}
+	}
+}
+
+/// A configurable mock Nitro Secure Module endpoint for local tests.
+///
+/// Unlike [`MockNsm`], this provider creates a fresh attestation document for
+/// each [`NsmRequest::Attestation`] request. The generated document preserves
+/// the request's `user_data`, `nonce`, and `public_key` fields.
+///
+/// This mock produces a parseable COSE Sign1 attestation document. It is for
+/// local development and tests only, and it does not produce an attestation
+/// document signed by the AWS Nitro PKI.
+#[derive(Clone, Debug)]
+pub struct DynamicMockNsm {
+	module_id: String,
+	timestamp_ms: u64,
+	pcrs: BTreeMap<usize, ByteBuf>,
+	signing_key: P384PrivateKey,
+}
+
+impl DynamicMockNsm {
+	/// Create a dynamic mock NSM with the same default PCRs and timestamp as
+	/// [`MockNsm`].
+	#[must_use]
+	pub fn new() -> Self {
+		Self {
+			module_id: MOCK_MODULE_ID.to_string(),
+			timestamp_ms: MOCK_ATTESTATION_DOC_TIMESTAMP,
+			pcrs: default_pcrs(),
+			signing_key: P384PrivateKey::deterministic(),
+		}
+	}
+
+	/// Configure the timestamp embedded in generated attestation documents.
+	#[must_use]
+	pub fn with_timestamp_ms(mut self, timestamp_ms: u64) -> Self {
+		self.timestamp_ms = timestamp_ms;
+		self
+	}
+
+	/// Configure the module ID embedded in generated attestation documents.
+	#[must_use]
+	pub fn with_module_id(mut self, module_id: impl Into<String>) -> Self {
+		self.module_id = module_id.into();
+		self
+	}
+
+	/// Configure a PCR value embedded in generated attestation documents.
+	#[must_use]
+	pub fn with_pcr(mut self, index: usize, data: Vec<u8>) -> Self {
+		self.pcrs.insert(index, ByteBuf::from(data));
+		self
+	}
+
+	fn attestation(
+		&self,
+		user_data: Option<Vec<u8>>,
+		nonce: Option<Vec<u8>>,
+		public_key: Option<Vec<u8>>,
+	) -> NsmResponse {
+		let doc = AttestationDoc {
+			module_id: self.module_id.clone(),
+			digest: Digest::SHA384,
+			timestamp: self.timestamp_ms,
+			pcrs: self.pcrs.clone(),
+			certificate: ByteBuf::from(vec![1]),
+			cabundle: vec![ByteBuf::from(vec![1])],
+			public_key: public_key.map(ByteBuf::from),
+			user_data: user_data.map(ByteBuf::from),
+			nonce: nonce.map(ByteBuf::from),
+		};
+
+		match CoseSign1::new::<MockSha2>(
+			&doc.to_binary(),
+			&HeaderMap::new(),
+			&self.signing_key,
+		)
+		.and_then(|cose| cose.as_bytes(true))
+		{
+			Ok(document) => NsmResponse::Attestation { document },
+			Err(_) => NsmResponse::Error(NsmErrorCode::InternalError),
+		}
+	}
+}
+
+impl Default for DynamicMockNsm {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+impl NsmProvider for DynamicMockNsm {
+	fn nsm_process_request(&self, request: NsmRequest) -> NsmResponse {
+		match request {
+			NsmRequest::Attestation { user_data, nonce, public_key } => {
+				self.attestation(user_data, nonce, public_key)
+			}
+			NsmRequest::DescribeNSM => NsmResponse::DescribeNSM {
+				version_major: MOCK_NSM_VERSION_MAJOR,
+				version_minor: MOCK_NSM_VERSION_MINOR,
+				version_patch: MOCK_NSM_VERSION_PATCH,
+				module_id: self.module_id.clone(),
+				max_pcrs: MOCK_MAX_PCRS,
+				locked_pcrs: BTreeSet::from(MOCK_LOCKED_PCRS),
+				digest: NsmDigest::SHA384,
+			},
+			NsmRequest::DescribePCR { index } => {
+				let Some(data) = self.pcrs.get(&usize::from(index)) else {
+					return NsmResponse::Error(NsmErrorCode::InvalidIndex);
+				};
+				NsmResponse::DescribePCR { lock: true, data: data.to_vec() }
+			}
+			NsmRequest::ExtendPCR { index: _, data: _ } => {
+				NsmResponse::Error(NsmErrorCode::InvalidOperation)
+			}
+			NsmRequest::GetRandom => {
+				NsmResponse::GetRandom { random: MOCK_RANDOM_RESPONSE.to_vec() }
+			}
+			NsmRequest::LockPCR { index: _ } => NsmResponse::LockPCR,
+			NsmRequest::LockPCRs { range: _ } => NsmResponse::LockPCRs,
+		}
+	}
+
+	fn timestamp_ms(&self) -> Result<u64, nitro::AttestError> {
+		Ok(self.timestamp_ms)
+	}
+}
+
+fn default_pcrs() -> BTreeMap<usize, ByteBuf> {
+	BTreeMap::from([
+		(0, ByteBuf::from(qos_hex::decode(MOCK_PCR0).expect("valid PCR0"))),
+		(1, ByteBuf::from(qos_hex::decode(MOCK_PCR1).expect("valid PCR1"))),
+		(2, ByteBuf::from(qos_hex::decode(MOCK_PCR2).expect("valid PCR2"))),
+		(3, ByteBuf::from(qos_hex::decode(MOCK_PCR3).expect("valid PCR3"))),
+	])
+}
+
+#[derive(Clone, Debug)]
+struct P384PrivateKey(p384::SecretKey);
+
+impl P384PrivateKey {
+	fn deterministic() -> Self {
+		let secret = qos_hex::decode(
+			"55c6aa815a31741bc37f0ffddea73af2397bad640816ef22bfb689efc1b6cc682a73f7e5a657248e3abad500e46d5afc",
+		)
+		.expect("valid deterministic p384 secret");
+		Self(p384::SecretKey::from_slice(&secret).expect("valid p384 secret"))
+	}
+}
+
+impl SigningPrivateKey for P384PrivateKey {
+	fn sign(&self, digest: &[u8]) -> Result<Vec<u8>, CoseError> {
+		use p384::ecdsa::signature::hazmat::PrehashSigner as _;
+
+		let signer = SigningKey::from(&self.0);
+		signer
+			.sign_prehash(digest)
+			.map(|sig: Signature| sig.to_vec())
+			.map_err(|e| CoseError::SignatureError(Box::new(e)))
+	}
+}
+
+impl SigningPublicKey for P384PrivateKey {
+	fn get_parameters(
+		&self,
+	) -> Result<(SignatureAlgorithm, MessageDigest), CoseError> {
+		Ok((SignatureAlgorithm::ES384, MessageDigest::Sha384))
+	}
+
+	fn verify(
+		&self,
+		digest: &[u8],
+		signature: &[u8],
+	) -> Result<bool, CoseError> {
+		use p384::ecdsa::signature::hazmat::PrehashVerifier as _;
+
+		let signature_wrapped = Signature::try_from(signature)
+			.map_err(|e| CoseError::SignatureError(Box::new(e)))?;
+
+		let verifier = VerifyingKey::from(self.0.public_key());
+		verifier
+			.verify_prehash(digest, &signature_wrapped)
+			.map(|()| true)
+			.map_err(|e| CoseError::SignatureError(Box::new(e)))
+	}
+}
+
+struct MockSha2;
+impl Hash for MockSha2 {
+	fn hash(digest: MessageDigest, data: &[u8]) -> Result<Vec<u8>, CoseError> {
+		use sha2::Digest as _;
+
+		match digest {
+			MessageDigest::Sha256 => Ok(sha2::Sha256::digest(data).to_vec()),
+			MessageDigest::Sha384 => Ok(sha2::Sha384::digest(data).to_vec()),
+			MessageDigest::Sha512 => Ok(sha2::Sha512::digest(data).to_vec()),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::nitro::{
+		unsafe_attestation_doc_from_der,
+		verify_attestation_doc_against_user_input,
+	};
+
+	fn hex_pcr(value: &str) -> Vec<u8> {
+		qos_hex::decode(value).unwrap()
+	}
+
+	#[test]
+	fn dynamic_mock_nsm_embeds_attestation_request_fields() {
+		let user_data = vec![1, 2, 3, 4];
+		let nonce = vec![5, 6, 7, 8];
+		let public_key = vec![9, 10, 11, 12];
+		let nsm = DynamicMockNsm::new();
+
+		let response = nsm.nsm_process_request(NsmRequest::Attestation {
+			user_data: Some(user_data.clone()),
+			nonce: Some(nonce.clone()),
+			public_key: Some(public_key.clone()),
+		});
+
+		let NsmResponse::Attestation { document } = response else {
+			panic!("expected attestation response");
+		};
+		let doc = unsafe_attestation_doc_from_der(&document).unwrap();
+		assert_eq!(doc.user_data.unwrap().as_slice(), user_data);
+		assert_eq!(doc.nonce.unwrap().as_slice(), nonce);
+		assert_eq!(doc.public_key.as_ref().unwrap().as_slice(), public_key);
+	}
+
+	#[test]
+	fn dynamic_mock_nsm_field_verification_matches_request_inputs() {
+		let public_key = vec![9, 10, 11, 12];
+		let user_data =
+			qos_hex::decode(MOCK_USER_DATA_NSM_ATTESTATION_DOCUMENT).unwrap();
+		let nsm = DynamicMockNsm::new();
+
+		let response = nsm.nsm_process_request(NsmRequest::Attestation {
+			user_data: Some(user_data.clone()),
+			nonce: None,
+			public_key: Some(public_key.clone()),
+		});
+
+		let NsmResponse::Attestation { document } = response else {
+			panic!("expected attestation response");
+		};
+		let doc = unsafe_attestation_doc_from_der(&document).unwrap();
+		assert_eq!(doc.public_key.as_ref().unwrap().as_slice(), public_key);
+		verify_attestation_doc_against_user_input(
+			&doc,
+			&user_data,
+			&hex_pcr(MOCK_PCR0),
+			&hex_pcr(MOCK_PCR1),
+			&hex_pcr(MOCK_PCR2),
+			&hex_pcr(MOCK_PCR3),
+		)
+		.unwrap();
 	}
 }


### PR DESCRIPTION
## Summary
- add qos_nsm::mock::DynamicMockNsm for parseable per-request mock attestation documents
- preserve attestation request fields, including the public key supplied in NsmRequest::Attestation
- switch qos_core --mock to use DynamicMockNsm and document qos_nsm providers in crate README
