### PR TITLE
qos_nsm: add dynamic mock attestation docs

### DIFF
--- a/docs/guide_dev.md
+++ b/docs/guide_dev.md
@@ -4,7 +4,7 @@ This guide explains how to run QOS locally in mock mode for development and debu
 
 ## Overview
 
-Mock mode allows you to run QOS locally without an AWS Nitro enclave. It uses a mock NSM (Nitro Secure Module) that returns hardcoded attestation documents, making it ideal for rapid development and testing.
+Mock mode allows you to run QOS locally without an AWS Nitro enclave. It uses a mock NSM (Nitro Secure Module) that returns parseable attestation documents, making it ideal for rapid development and testing.
 
 ## Prerequisites
 
@@ -91,14 +91,15 @@ The `dangerous-dev-boot` command is a development shortcut that automates the en
 ### Mock NSM Behavior
 
 The mock NSM:
-- Returns a **hardcoded** attestation document (from `qos_nsm/src/static/mock_attestation_doc`)
-- Uses **hardcoded PCR values** (all defined in `qos_nsm/src/mock.rs`)
+- Returns a fresh, parseable attestation document for each request
+- Preserves request `user_data`, `nonce`, and `public_key` fields in the document
+- Uses deterministic mock PCR values (all defined in `qos_nsm/src/mock.rs`)
 - Uses a **fixed timestamp** (unless `mock_realtime` feature is enabled)
-- Does not perform real cryptographic attestation
+- Does not produce AWS Nitro PKI-signed attestation documents
 
 ### Why --unsafe-eph-path-override?
 
-The boot flow requires the enclave side to have the ephemeral private key and the client side to have the associated public key. We typically embed the ephemeral public key in the attestation document: clients are expected to verify the attestation document before using the ephemeral public key. Locally, we cannot generate attestation documents, so we return a hardcoded mock attestation document. The mock attestation document contains an **invalid** ephemeral public key, and even if it was valid we would not have access to the associated private key.
+The boot flow requires the enclave side to have the ephemeral private key and the client side to have the associated public key. We typically embed the ephemeral public key in the attestation document: clients are expected to verify the attestation document before using the ephemeral public key. Locally, `DynamicMockNsm` embeds the request public key in a parseable mock attestation document, but the document is not AWS-root-verifiable.
 
 The `--unsafe-eph-path-override` flag tells the client to:
 1. **Ignore** the public key from the attestation document
@@ -115,7 +116,7 @@ The `--unsafe-eph-path-override` flag tells the client to:
 
 ### Alternative: Skip the Override
 
-If you prefer not to use `--unsafe-eph-path-override`, you can omit it entirely. The client will attempt to extract the public key from the attestation document. However, this may fail due to the PEM encoding issue.
+If you prefer not to use `--unsafe-eph-path-override`, you can omit it entirely. The client can extract the request public key from the dynamic mock attestation document, but local development still must not treat mock documents as AWS Nitro attestations.
 
 ## File System Layout
 
@@ -144,7 +145,7 @@ When running in mock mode, qos_core creates a `./local-enclave/` directory with:
 
 **Symptom:** `Ephemeral key not valid public key: EncodedPublicKeyTooLong`
 
-**Cause:** The mock attestation document has a PEM-encoded public key (800 bytes) instead of DER format.
+**Cause:** An old static fixture document has a PEM-encoded public key (800 bytes) instead of DER format. Runtime `--mock` mode uses `DynamicMockNsm`, which embeds the request public key instead.
 
 **Solution:** Use `--unsafe-eph-path-override ./local-enclave/qos.ephemeral.key`
 
@@ -184,7 +185,7 @@ Mock mode differs significantly from production:
 
 | Aspect | Mock Mode | Production |
 |--------|-----------|------------|
-| Attestation | Hardcoded document | Real AWS Nitro attestation |
+| Attestation | Parseable mock document | Real AWS Nitro attestation |
 | PCR Values | All zeros or mock values | Real enclave measurements |
 | Ephemeral Key | Generated fresh each boot | Generated fresh each boot |
 | Verification | None | Full cryptographic verification |

--- a/src/qos_core/src/cli.rs
+++ b/src/qos_core/src/cli.rs
@@ -73,11 +73,13 @@ impl EnclaveOpts {
 		if self.parsed.flag(MOCK).unwrap_or(false) {
 			#[cfg(feature = "mock")]
 			{
-				Box::new(qos_nsm::mock::MockNsm)
+				Box::new(qos_nsm::mock::DynamicMockNsm::new())
 			}
 			#[cfg(not(feature = "mock"))]
 			{
-				panic!("\"mock\" feature must be enabled to use `MockNsm`")
+				panic!(
+					"\"mock\" feature must be enabled to use `DynamicMockNsm`"
+				)
 			}
 		} else {
 			Box::new(Nsm)
@@ -306,6 +308,35 @@ mod test {
 		let opts = EnclaveOpts::new(&mut args);
 
 		assert_eq!(opts.manifest_file(), "brawndo".to_string());
+	}
+
+	#[test]
+	#[cfg(feature = "mock")]
+	fn mock_nsm_embeds_attestation_request_public_key() {
+		let mut args: Vec<_> =
+			vec!["binary", "--usock", "./test.sock", "--mock"]
+				.into_iter()
+				.map(String::from)
+				.collect();
+		let opts = EnclaveOpts::new(&mut args);
+		let public_key = vec![9; 65];
+
+		let response = opts.nsm().nsm_process_request(
+			qos_nsm::types::NsmRequest::Attestation {
+				user_data: None,
+				nonce: None,
+				public_key: Some(public_key.clone()),
+			},
+		);
+
+		let qos_nsm::types::NsmResponse::Attestation { document } = response
+		else {
+			panic!("expected attestation response");
+		};
+		let doc =
+			qos_nsm::nitro::unsafe_attestation_doc_from_der(&document).unwrap();
+
+		assert_eq!(doc.public_key.unwrap().into_vec(), public_key);
 	}
 
 	#[test]

--- a/src/qos_nsm/README.md
+++ b/src/qos_nsm/README.md
@@ -1,0 +1,41 @@
+# `qos_nsm`
+
+`qos_nsm` contains QOS types and provider implementations for the AWS Nitro
+Secure Module (NSM) API. QOS uses this crate to request attestation documents,
+parse Nitro attestation documents, and verify the document fields that bind a
+running enclave to an approved manifest.
+
+The main abstraction is `NsmProvider`. Production code uses `Nsm`, which sends
+`NsmRequest` values to the AWS Nitro NSM driver. Tests and local development can
+use mock providers that implement the same trait.
+
+## Providers
+
+- `Nsm`: the production provider. It sends `NsmRequest` values to the AWS Nitro
+  NSM driver and returns `NsmResponse` values from the driver.
+- `MockNsm`: a static test provider behind the `mock` feature. It returns the
+  fixed attestation document embedded in this crate. This is useful for tests
+  that need stable historical fixture data.
+- `DynamicMockNsm`: a configurable test provider behind the `mock` feature. It
+  creates a fresh, parseable COSE Sign1 attestation document for each
+  attestation request and preserves the request's `user_data`, `nonce`, and
+  `public_key` fields.
+
+`DynamicMockNsm` supports local end-to-end tests for pivot applications that call
+the attestation API, return app-level proofs, and include an attestation document
+plus manifest in their response. Like a real NSM request, the ephemeral public
+key must be supplied in `NsmRequest::Attestation`.
+
+## Attestation Scope
+
+The Nitro helpers in `nitro` expose two levels of parsing:
+
+- `unsafe_attestation_doc_from_der` decodes the COSE payload into an
+  `AttestationDoc` without certificate-chain or signature validation.
+- `attestation_doc_from_der` performs AWS Nitro certificate-chain validation and
+  verifies the COSE signature against the attestation document certificate.
+
+Mock providers are only for local development and tests. In particular,
+`DynamicMockNsm` creates documents that are useful for checking QOS protocol
+fields such as manifest hash, PCRs, nonce, and ephemeral public key, but it does
+not produce AWS Nitro PKI-signed documents.

--- a/src/qos_nsm/src/lib.rs
+++ b/src/qos_nsm/src/lib.rs
@@ -1,4 +1,4 @@
-//! Endpoints and types for an enclaves attestation flow.
+#![doc = include_str!("../README.md")]
 
 pub mod nitro;
 mod nsm;

--- a/src/qos_nsm/src/mock.rs
+++ b/src/qos_nsm/src/mock.rs
@@ -1,12 +1,40 @@
 //! Mocks for external attest endpoints. Only for testing.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
+
+use aws_nitro_enclaves_cose::{
+	CoseSign1,
+	crypto::{
+		Hash, MessageDigest, SignatureAlgorithm, SigningPrivateKey,
+		SigningPublicKey,
+	},
+	error::CoseError,
+	header_map::HeaderMap,
+};
+use aws_nitro_enclaves_nsm_api::api::{AttestationDoc, Digest};
+use p384::{
+	PublicKey,
+	ecdsa::{
+		Signature, SigningKey, VerifyingKey, signature::hazmat::PrehashSigner,
+	},
+};
+use serde_bytes::ByteBuf;
 
 use crate::{
 	nitro,
 	nsm::NsmProvider,
-	types::{NsmDigest, NsmRequest, NsmResponse},
+	types::{NsmDigest, NsmErrorCode, NsmRequest, NsmResponse},
 };
+
+#[cfg(test)]
+use crate::nitro::{
+	unsafe_attestation_doc_from_der, verify_attestation_doc_against_user_input,
+};
+
+#[cfg(test)]
+fn hex_pcr(pcr: &str) -> Vec<u8> {
+	qos_hex::decode(pcr).unwrap()
+}
 
 /// DO NOT USE IN PRODUCTION - ONLY FOR TESTS.
 /// The `user_data` for [`MOCK_NSM_ATTESTATION_DOCUMENT`].
@@ -36,6 +64,199 @@ pub const MOCK_PCR3: &str = "000000000000000000000000000000000000000000000000000
 // This was generate using the `gen_att_doc` script in `integration`.
 pub const MOCK_NSM_ATTESTATION_DOCUMENT: &[u8] =
 	include_bytes!("./static/mock_attestation_doc");
+
+const DYNAMIC_MOCK_MODULE_ID: &str = "dynamic_mock_module_id";
+const DYNAMIC_MOCK_CERTIFICATE: &[u8] = b"dynamic mock certificate";
+const DYNAMIC_MOCK_CA_BUNDLE: &[u8] = b"dynamic mock ca bundle";
+const DYNAMIC_MOCK_P384_SECRET: &[u8; 48] = &[
+	0x55, 0xc6, 0xaa, 0x81, 0x5a, 0x31, 0x74, 0x1b, 0xc3, 0x7f, 0x0f, 0xfd,
+	0xde, 0xa7, 0x3a, 0xf2, 0x39, 0x7b, 0xad, 0x64, 0x08, 0x16, 0xef, 0x22,
+	0xbf, 0xb6, 0x89, 0xef, 0xc1, 0xb6, 0xcc, 0x68, 0x2a, 0x73, 0xf7, 0xe5,
+	0xa6, 0x57, 0x24, 0x8e, 0x3a, 0xba, 0xd5, 0x00, 0xe4, 0x6d, 0x5a, 0xfc,
+];
+
+/// Mock Nitro Secure Module endpoint that creates parseable attestation docs.
+#[derive(Clone, Debug)]
+pub struct DynamicMockNsm {
+	module_id: String,
+	timestamp_ms: u64,
+	pcrs: BTreeMap<usize, ByteBuf>,
+	signing_key: [u8; 48],
+}
+
+impl DynamicMockNsm {
+	/// Create a new dynamic mock NSM provider.
+	///
+	/// # Panics
+	///
+	/// Panics if this crate's hardcoded mock PCR constants are invalid hex.
+	#[must_use]
+	pub fn new() -> Self {
+		Self {
+			module_id: DYNAMIC_MOCK_MODULE_ID.to_string(),
+			timestamp_ms: MOCK_ATTESTATION_DOC_TIMESTAMP,
+			pcrs: BTreeMap::from([
+				(0, ByteBuf::from(qos_hex::decode(MOCK_PCR0).unwrap())),
+				(1, ByteBuf::from(qos_hex::decode(MOCK_PCR1).unwrap())),
+				(2, ByteBuf::from(qos_hex::decode(MOCK_PCR2).unwrap())),
+				(3, ByteBuf::from(qos_hex::decode(MOCK_PCR3).unwrap())),
+			]),
+			signing_key: *DYNAMIC_MOCK_P384_SECRET,
+		}
+	}
+
+	/// Set the timestamp included in generated attestation documents.
+	#[must_use]
+	pub fn with_timestamp_ms(mut self, timestamp_ms: u64) -> Self {
+		self.timestamp_ms = timestamp_ms;
+		self
+	}
+
+	/// Set the module id included in generated attestation documents.
+	#[must_use]
+	pub fn with_module_id(mut self, module_id: impl Into<String>) -> Self {
+		self.module_id = module_id.into();
+		self
+	}
+
+	/// Set a PCR value included in generated attestation documents.
+	#[must_use]
+	pub fn with_pcr(mut self, index: usize, value: impl Into<Vec<u8>>) -> Self {
+		self.pcrs.insert(index, ByteBuf::from(value.into()));
+		self
+	}
+
+	fn attestation_document(
+		&self,
+		user_data: Option<Vec<u8>>,
+		nonce: Option<Vec<u8>>,
+		public_key: Option<Vec<u8>>,
+	) -> Vec<u8> {
+		let doc = AttestationDoc {
+			module_id: self.module_id.clone(),
+			digest: Digest::SHA384,
+			timestamp: self.timestamp_ms,
+			pcrs: self.pcrs.clone(),
+			certificate: ByteBuf::from(DYNAMIC_MOCK_CERTIFICATE.to_vec()),
+			cabundle: vec![ByteBuf::from(DYNAMIC_MOCK_CA_BUNDLE.to_vec())],
+			public_key: public_key.map(ByteBuf::from),
+			user_data: user_data.map(ByteBuf::from),
+			nonce: nonce.map(ByteBuf::from),
+		};
+		let key = P384PrivateKey::new(self.signing_key);
+		CoseSign1::new::<Sha2>(&doc.to_binary(), &HeaderMap::new(), &key)
+			.expect("dynamic mock attestation document is signable")
+			.as_bytes(false)
+			.expect("dynamic mock attestation document is serializable")
+	}
+}
+
+impl Default for DynamicMockNsm {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+impl NsmProvider for DynamicMockNsm {
+	fn nsm_process_request(&self, request: NsmRequest) -> NsmResponse {
+		match request {
+			NsmRequest::Attestation { user_data, nonce, public_key } => {
+				NsmResponse::Attestation {
+					document: self
+						.attestation_document(user_data, nonce, public_key),
+				}
+			}
+			NsmRequest::DescribeNSM => NsmResponse::DescribeNSM {
+				version_major: 1,
+				version_minor: 2,
+				version_patch: 14,
+				module_id: self.module_id.clone(),
+				max_pcrs: 1024,
+				locked_pcrs: BTreeSet::from([90, 91, 92]),
+				digest: NsmDigest::SHA384,
+			},
+			NsmRequest::ExtendPCR { index: _, data: _ } => {
+				NsmResponse::Error(NsmErrorCode::InvalidOperation)
+			}
+			NsmRequest::GetRandom => {
+				NsmResponse::GetRandom { random: vec![4, 2, 0, 69] }
+			}
+			NsmRequest::LockPCR { index: _ } => NsmResponse::LockPCR,
+			NsmRequest::LockPCRs { range: _ } => NsmResponse::LockPCRs,
+			NsmRequest::DescribePCR { index } => {
+				self.pcrs.get(&usize::from(index)).map_or(
+					NsmResponse::Error(NsmErrorCode::InvalidIndex),
+					|pcr| NsmResponse::DescribePCR {
+						lock: false,
+						data: pcr.to_vec(),
+					},
+				)
+			}
+		}
+	}
+
+	fn timestamp_ms(&self) -> Result<u64, nitro::AttestError> {
+		Ok(self.timestamp_ms)
+	}
+}
+
+struct P384PrivateKey {
+	secret: p384::SecretKey,
+}
+
+impl P384PrivateKey {
+	fn new(secret: [u8; 48]) -> Self {
+		Self { secret: p384::SecretKey::from_slice(&secret).unwrap() }
+	}
+}
+
+impl SigningPrivateKey for P384PrivateKey {
+	fn sign(&self, digest: &[u8]) -> Result<Vec<u8>, CoseError> {
+		let signer = SigningKey::from(&self.secret);
+		signer
+			.sign_prehash(digest)
+			.map(|sig: Signature| sig.to_vec())
+			.map_err(|e| CoseError::SignatureError(Box::new(e)))
+	}
+}
+
+impl SigningPublicKey for P384PrivateKey {
+	fn get_parameters(
+		&self,
+	) -> Result<(SignatureAlgorithm, MessageDigest), CoseError> {
+		Ok((SignatureAlgorithm::ES384, MessageDigest::Sha384))
+	}
+
+	fn verify(
+		&self,
+		digest: &[u8],
+		signature: &[u8],
+	) -> Result<bool, CoseError> {
+		use p384::ecdsa::signature::hazmat::PrehashVerifier as _;
+
+		let signature_wrapped = Signature::try_from(signature)
+			.map_err(|e| CoseError::SignatureError(Box::new(e)))?;
+		let verifier =
+			VerifyingKey::from(PublicKey::from(self.secret.public_key()));
+		verifier
+			.verify_prehash(digest, &signature_wrapped)
+			.map(|()| true)
+			.map_err(|e| CoseError::SignatureError(Box::new(e)))
+	}
+}
+
+struct Sha2;
+impl Hash for Sha2 {
+	fn hash(digest: MessageDigest, data: &[u8]) -> Result<Vec<u8>, CoseError> {
+		use sha2::Digest as _;
+
+		match digest {
+			MessageDigest::Sha256 => Ok(sha2::Sha256::digest(data).to_vec()),
+			MessageDigest::Sha384 => Ok(sha2::Sha384::digest(data).to_vec()),
+			MessageDigest::Sha512 => Ok(sha2::Sha512::digest(data).to_vec()),
+		}
+	}
+}
 
 /// Mock Nitro Secure Module endpoint that should only ever be used for testing.
 pub struct MockNsm;
@@ -90,5 +311,64 @@ impl NsmProvider for MockNsm {
 					.map_err(|_| nitro::AttestError::InvalidTimeStamp)?
 			}
 		}
+	}
+}
+
+#[cfg(test)]
+mod dynamic_mock_nsm_tests {
+	use serde_bytes::ByteBuf;
+
+	use super::*;
+
+	#[test]
+	fn dynamic_mock_nsm_embeds_attestation_request_fields() {
+		let user_data = vec![1, 2, 3];
+		let nonce = vec![4, 5, 6];
+		let public_key = vec![7; 65];
+		let nsm = DynamicMockNsm::new();
+
+		let response = nsm.nsm_process_request(NsmRequest::Attestation {
+			user_data: Some(user_data.clone()),
+			nonce: Some(nonce.clone()),
+			public_key: Some(public_key.clone()),
+		});
+
+		let NsmResponse::Attestation { document } = response else {
+			panic!("expected attestation response");
+		};
+
+		let doc = unsafe_attestation_doc_from_der(&document).unwrap();
+		assert_eq!(doc.user_data, Some(ByteBuf::from(user_data)));
+		assert_eq!(doc.nonce, Some(ByteBuf::from(nonce)));
+		assert_eq!(doc.public_key, Some(ByteBuf::from(public_key)));
+	}
+
+	#[test]
+	fn dynamic_mock_nsm_field_verification_matches_request_inputs() {
+		let user_data =
+			qos_hex::decode(MOCK_USER_DATA_NSM_ATTESTATION_DOCUMENT).unwrap();
+		let nsm = DynamicMockNsm::new();
+
+		let response = nsm.nsm_process_request(NsmRequest::Attestation {
+			user_data: Some(user_data.clone()),
+			nonce: None,
+			public_key: None,
+		});
+
+		let NsmResponse::Attestation { document } = response else {
+			panic!("expected attestation response");
+		};
+
+		let doc = unsafe_attestation_doc_from_der(&document).unwrap();
+
+		verify_attestation_doc_against_user_input(
+			&doc,
+			&user_data,
+			&hex_pcr(MOCK_PCR0),
+			&hex_pcr(MOCK_PCR1),
+			&hex_pcr(MOCK_PCR2),
+			&hex_pcr(MOCK_PCR3),
+		)
+		.unwrap();
 	}
 }


### PR DESCRIPTION
## Stack
- Base: `main`
- Head: `codex/dynamic-mock-nsm`
- Position: PR 1 of 3

## Summary
- Add qos_nsm crate docs describing NSM providers and attestation parsing scope.
- Add DynamicMockNsm, which creates a parseable COSE Sign1 attestation document per request and preserves user_data, nonce, and public_key.
- Switch qos_core --mock to DynamicMockNsm while keeping the static MockNsm fixture provider for tests.
- Update the local development guide for parseable, non-AWS-root-verifiable mock docs.

## Verification
- PASS: cargo fmt --all -- --check
- PASS: cargo test -p qos_nsm --features mock
- PARTIAL: cargo test -p qos_core --features mock (87 passed, including new CLI test; 3 existing io::stream Unix socket tests fail in this Modal volume with EOPNOTSUPP: Operation not supported)
- PASS: cargo clippy -p qos_nsm -p qos_core --features mock -- -D warnings
- PASS: cargo check -p qos_nsm
- PASS: cargo check -p qos_core
- PASS: git diff --check

## Known Risks / Follow-ups
- DynamicMockNsm docs are parseable for local protocol checks but intentionally not AWS Nitro PKI-verifiable in this PR.
- Full mock certificate-chain verification is planned in the stacked follow-up PR.
