### PR TITLE
qos_core: configure attestation verifier root

### DIFF
--- a/docs/guide_dev.md
+++ b/docs/guide_dev.md
@@ -95,11 +95,16 @@ The mock NSM:
 - Preserves request `user_data`, `nonce`, and `public_key` fields in the document
 - Uses deterministic mock PCR values (all defined in `qos_nsm/src/mock.rs`)
 - Uses a **fixed timestamp** (unless `mock_realtime` feature is enabled)
-- Does not produce AWS Nitro PKI-signed attestation documents
+- Uses a deterministic mock certificate chain, not the AWS Nitro PKI
+
+Production verification defaults to the AWS Nitro root CA. Local tests that need
+full mock-chain verification must pass `--unsafe-attestation-root-ca-der` with
+the mock root DER. This override is unsafe and should never be used in
+production.
 
 ### Why --unsafe-eph-path-override?
 
-The boot flow requires the enclave side to have the ephemeral private key and the client side to have the associated public key. We typically embed the ephemeral public key in the attestation document: clients are expected to verify the attestation document before using the ephemeral public key. Locally, `DynamicMockNsm` embeds the request public key in a parseable mock attestation document, but the document is not AWS-root-verifiable.
+The boot flow requires the enclave side to have the ephemeral private key and the client side to have the associated public key. We typically embed the ephemeral public key in the attestation document: clients are expected to verify the attestation document before using the ephemeral public key. Locally, `DynamicMockNsm` embeds the request public key in a parseable mock attestation document. Full local verification requires the explicit unsafe mock-root override.
 
 The `--unsafe-eph-path-override` flag tells the client to:
 1. **Ignore** the public key from the attestation document
@@ -109,7 +114,7 @@ The `--unsafe-eph-path-override` flag tells the client to:
 **The flow:**
 1. qos_core generates a fresh ephemeral key during `BootStandardRequest`
 2. qos_core writes private key to `./local-enclave/qos.ephemeral.key`
-3. qos_core returns the (broken) mock attestation document
+3. qos_core returns the mock attestation document
 4. Client reads `./local-enclave/qos.ephemeral.key` for the real public key
 5. Client encrypts shares correctly
 6. Decryption succeeds
@@ -188,7 +193,7 @@ Mock mode differs significantly from production:
 | Attestation | Parseable mock document | Real AWS Nitro attestation |
 | PCR Values | All zeros or mock values | Real enclave measurements |
 | Ephemeral Key | Generated fresh each boot | Generated fresh each boot |
-| Verification | None | Full cryptographic verification |
+| Verification | Explicit mock-root override | AWS Nitro root CA |
 | Security | **INSECURE** | Secure enclave isolation |
 
 **Never deploy with the `mock` feature enabled in production environments.**

--- a/docs/key_forward.md
+++ b/docs/key_forward.md
@@ -50,7 +50,7 @@ The details for how QOS nodes communicate with each other can vary, but for the 
     ```
 
 4) The Original Node processes the request by performing the following steps:
-    1) Check the basic validity of the attestation doc (cert chain etc). Ensures that the attestation document is actually from an AWS controlled NSM module and the document's timestamp was recent.
+    1) Check the basic validity of the attestation doc (cert chain etc). By default this uses the AWS Nitro root CA, ensuring that the attestation document is from an AWS-controlled NSM module and that the document's timestamp was recent. Local mock tests may explicitly pass an unsafe trusted-root override for the mock root CA.
     1) Check the signatures over the New Manifest. Ensures that K Manifest Set Members approved the New Manifest.
     1) Check that the Quorum Key of the Local Manifest matches the Quorum Key of the New Manifest. This ensures the request is for the correct Quorum Key.
     1) Check that the Manifest Set of the New Manifest matches the Manifest Set of the Local Manifest. Ensures that the signatures are from a trusted Manifest Set. Note that there is still a vulnerability here if we try to retire a Manifest Set because a critical threshold of it was compromised - that malicious Manifest Set could boot off of an Original Node - thus it's important to retire all Original Nodes ASAP that use compromised Manifest Sets.

--- a/src/integration/tests/key.rs
+++ b/src/integration/tests/key.rs
@@ -4,6 +4,7 @@ use integration::{
 	LOCAL_HOST, PCR3_PRE_IMAGE_PATH, PIVOT_LOOP_PATH, QOS_DIST_DIR,
 };
 use qos_crypto::sha_256;
+use qos_nsm::mock::mock_root_certificate_der;
 use qos_p256::{P256Pair, P256Public};
 use qos_test_primitives::{ChildWrapper, PathWrapper};
 
@@ -20,7 +21,9 @@ const USERS: &[&str] = &["user1", "user2", "user3"];
 const TEST_MSG: &str = "test-msg";
 const NEW_ATTESTATION_DOC_PATH: &str = "/tmp/key-fwd-e2e/new_attestation_doc";
 const ENCRYPTED_QUORUM_KEY_PATH: &str = "/tmp/key-fwd-e2e/encrypted_quorum_key";
-const SHARED_EPH_PATH: &str = "/tmp/key-fwd-e2e/shared_eph.secret";
+const OLD_EPH_PATH: &str = "/tmp/key-fwd-e2e/old_eph.secret";
+const NEW_EPH_PATH: &str = "/tmp/key-fwd-e2e/new_eph.secret";
+const MOCK_ROOT_CA_DER_PATH: &str = "/tmp/key-fwd-e2e/mock_root_ca.der";
 const QUORUM_KEY_PUB_PATH: &str =
 	"./mock/namespaces/quit-coding-to-vape/quorum_key.pub";
 
@@ -29,6 +32,7 @@ async fn key_fwd_e2e() {
 	// Make sure everything in the temp dir gets dropped
 	let _ = PathWrapper::from(TMP_DIR);
 	fs::create_dir_all(BOOT_DIR).unwrap();
+	fs::write(MOCK_ROOT_CA_DER_PATH, mock_root_certificate_der()).unwrap();
 	let old_host_port = qos_test_primitives::find_free_port().unwrap();
 	let new_host_port = qos_test_primitives::find_free_port().unwrap();
 
@@ -36,32 +40,6 @@ async fn key_fwd_e2e() {
 	generate_manifest_envelope();
 	let (_enclave_child_wrapper, _host_child_wrapper) =
 		boot_old_enclave(old_host_port);
-
-	// We manually remove the ephemeral key file because if we didn't, we'd get a failure from the
-	// NEW enclave: as it comes up it'd try to write its ephemeral key at `SHARED_EPH_PATH` and fail
-	// to write because the file already exists.
-	// Why does the file already exist? Because the OLD enclave already persisted its ephemeral key
-	// there (and why is this a problem you ask? Well, that's just the semantics of `write_as_read_only`
-	// -- for security reasons, we want to avoid silently/accidentally overriding key material)
-	//
-	// Another question you might ask is: why do we need to share this ephemeral key path at all?
-	// Can't we just give OLD and NEW enclaves their own ephemeral path and be done?
-	// That's a nice thought, but unfortunately we can't quite do that. To perform a key-forward boot,
-	// in normal conditions, the OLD enclave encrypts its quorum key to the NEW enclave's ephemeral
-	// public key. The "transport" mechanism for this public key is the AWS attestation (`public_key` field).
-	// Which means we'd need to produce AWS attestations dynamically. And unfortunately, that's just a pain
-	// in the rear to mock/produce in testing. So here we are.
-	//
-	// The solution we've found is to share the ephemeral key between OLD and NEW enclave AND have
-	// a special case: when `qos_core` is compiled with the `mock` feature, the OLD enclave encrypts its
-	// quorum key to its _own_ ephemeral public key (rather than the AWS attestation `public_key` field.)
-	// See `export_key_internal` for details.
-	//
-	// Because the OLD and NEW enclave share the ephemeral key path, the NEW enclave can trivially decrypt
-	// the encrypted quorum key that is injected, and the integration test works.
-	//
-	// This is obviously a test-only quirk: in a real situation enclaves have their own filesystems..!
-	fs::remove_file(SHARED_EPH_PATH).unwrap();
 
 	// start up new enclave
 	let new_secret_path = "/tmp/key-fwd-e2e/new_secret.secret";
@@ -80,10 +58,10 @@ async fn key_fwd_e2e() {
 				"--pivot-file",
 				new_pivot_path,
 				"--ephemeral-file",
-				SHARED_EPH_PATH, /* this is shared so the old enclave can
-				                  * encrypt to this key. See `extract_key`
-				                  * logic */
+				NEW_EPH_PATH,
 				"--mock",
+				"--unsafe-attestation-root-ca-der",
+				MOCK_ROOT_CA_DER_PATH,
 				"--manifest-file",
 				new_manifest_path,
 			])
@@ -276,8 +254,10 @@ fn boot_old_enclave(old_host_port: u16) -> (ChildWrapper, ChildWrapper) {
 				"--pivot-file",
 				old_pivot_path,
 				"--ephemeral-file",
-				SHARED_EPH_PATH,
+				OLD_EPH_PATH,
 				"--mock",
+				"--unsafe-attestation-root-ca-der",
+				MOCK_ROOT_CA_DER_PATH,
 				"--manifest-file",
 				old_manifest_path,
 			])
@@ -395,7 +375,7 @@ fn boot_old_enclave(old_host_port: u16) -> (ChildWrapper, ChildWrapper) {
 					user,
 					"--unsafe-skip-attestation",
 					"--unsafe-eph-path-override",
-					SHARED_EPH_PATH,
+					OLD_EPH_PATH,
 					"--unsafe-auto-confirm",
 				])
 				.spawn()

--- a/src/qos_core/src/cli.rs
+++ b/src/qos_core/src/cli.rs
@@ -1,6 +1,6 @@
 //! CLI for running an enclave binary.
 
-use std::env;
+use std::{env, fs};
 
 use qos_nsm::{Nsm, NsmProvider};
 
@@ -9,6 +9,7 @@ use crate::{
 	handles::Handles,
 	io::SocketAddress,
 	parser::{GetParserForOptions, OptionsParser, Parser, Token},
+	protocol::AttestationVerifierConfig,
 	reaper::Reaper,
 };
 
@@ -31,6 +32,7 @@ pub const EPHEMERAL_FILE_OPT: &str = "ephemeral-file";
 pub const MANIFEST_FILE_OPT: &str = "manifest-file";
 /// Name for the option to specify the maximum `StreamPool` size.
 pub const POOL_SIZE: &str = "pool-size";
+const UNSAFE_ATTESTATION_ROOT_CA_DER: &str = "unsafe-attestation-root-ca-der";
 
 /// CLI options for starting up the enclave server.
 #[derive(Default, Clone, Debug, PartialEq)]
@@ -73,7 +75,10 @@ impl EnclaveOpts {
 		if self.parsed.flag(MOCK).unwrap_or(false) {
 			#[cfg(feature = "mock")]
 			{
-				Box::new(qos_nsm::mock::DynamicMockNsm::new())
+				Box::new(
+					qos_nsm::mock::DynamicMockNsm::new()
+						.with_mock_certificate_chain(),
+				)
 			}
 			#[cfg(not(feature = "mock"))]
 			{
@@ -116,6 +121,20 @@ impl EnclaveOpts {
 			.expect("has a default value.")
 			.clone()
 	}
+
+	fn attestation_verifier_config(&self) -> AttestationVerifierConfig {
+		self.parsed.single(UNSAFE_ATTESTATION_ROOT_CA_DER).map_or_else(
+			AttestationVerifierConfig::aws_nitro,
+			|path| {
+				let root_der = fs::read(path).unwrap_or_else(|err| {
+					panic!(
+						"failed to read unsafe attestation root CA DER at {path}: {err}"
+					)
+				});
+				AttestationVerifierConfig::from_trusted_root_der(root_der)
+			},
+		)
+	}
 }
 
 /// Enclave server CLI.
@@ -134,9 +153,10 @@ impl CLI {
 		} else if opts.parsed.help() {
 			println!("{}", opts.parsed.info());
 		} else {
+			let attestation_verifier = opts.attestation_verifier_config();
 			// start reaper in a task so we can terminate on ctrl+c properly
 			tokio::spawn(async move {
-				Reaper::execute(
+				Reaper::execute_with_attestation_verifier(
 					&Handles::new(
 						opts.ephemeral_file(),
 						opts.quorum_file(),
@@ -147,6 +167,7 @@ impl CLI {
 					opts.enclave_socket()
 						.expect("Unable to create enclave socket"),
 					None,
+					attestation_verifier,
 				)
 				.await;
 			});
@@ -201,6 +222,10 @@ impl GetParserForOptions for EnclaveParser {
 				Token::new(MANIFEST_FILE_OPT, "path to file where the Manifest should be written. Use default for production")
 					.takes_value(true)
 					.default_value(MANIFEST_FILE)
+			)
+			.token(
+				Token::new(UNSAFE_ATTESTATION_ROOT_CA_DER, "UNSAFE: path to a DER root CA for local attestation verification override. Production defaults to AWS Nitro root.")
+					.takes_value(true)
 			)
 	}
 }
@@ -308,6 +333,44 @@ mod test {
 		let opts = EnclaveOpts::new(&mut args);
 
 		assert_eq!(opts.manifest_file(), "brawndo".to_string());
+	}
+
+	#[test]
+	fn parse_unsafe_attestation_root_ca_der() {
+		let mut args: Vec<_> = vec![
+			"binary",
+			"--usock",
+			"./test.sock",
+			"--unsafe-attestation-root-ca-der",
+			"./root.der",
+		]
+		.into_iter()
+		.map(String::from)
+		.collect();
+		let opts = EnclaveOpts::new(&mut args);
+
+		assert_eq!(
+			opts.parsed.single(UNSAFE_ATTESTATION_ROOT_CA_DER).unwrap(),
+			"./root.der"
+		);
+	}
+
+	#[test]
+	#[should_panic = "failed to read unsafe attestation root CA DER at ./missing-root.der"]
+	fn panic_on_missing_unsafe_attestation_root_ca_der() {
+		let mut args: Vec<_> = vec![
+			"binary",
+			"--usock",
+			"./test.sock",
+			"--unsafe-attestation-root-ca-der",
+			"./missing-root.der",
+		]
+		.into_iter()
+		.map(String::from)
+		.collect();
+		let opts = EnclaveOpts::new(&mut args);
+
+		let _ = opts.attestation_verifier_config();
 	}
 
 	#[test]

--- a/src/qos_core/src/protocol/mod.rs
+++ b/src/qos_core/src/protocol/mod.rs
@@ -11,8 +11,8 @@ pub mod services;
 mod state;
 
 pub use error::ProtocolError;
-pub use state::ProtocolPhase;
 pub(crate) use state::ProtocolState;
+pub use state::{AttestationVerifierConfig, ProtocolPhase};
 
 pub(crate) mod processor;
 use tokio::sync::RwLock;

--- a/src/qos_core/src/protocol/services/boot.rs
+++ b/src/qos_core/src/protocol/services/boot.rs
@@ -4,6 +4,8 @@ use std::{collections::HashSet, fmt};
 
 use qos_crypto::sha_256;
 use qos_nsm::types::NsmResponse;
+#[cfg(feature = "mock")]
+use qos_nsm::{NsmProvider, types::NsmRequest};
 use qos_p256::{P256Pair, P256Public};
 
 use crate::protocol::{
@@ -711,10 +713,36 @@ pub(in crate::protocol::services) fn put_manifest_and_pivot(
 	// 3. Make an attestation request, placing the manifest hash in the
 	// `user_data` field and the Ephemeral Key public key in the `public_key`
 	// field.
+	let public_key = ephemeral_key.public_key().to_bytes();
+	let user_data = manifest_envelope.manifest_hash().to_vec();
+	#[cfg(feature = "mock")]
+	let nsm_response = if state.attestation_verifier
+		== crate::protocol::AttestationVerifierConfig::mock_nsm()
+	{
+		let manifest = manifest_envelope.clone().manifest();
+		qos_nsm::mock::DynamicMockNsm::new()
+			.with_mock_certificate_chain()
+			.with_pcr(0, manifest.enclave().pcr0.clone())
+			.with_pcr(1, manifest.enclave().pcr1.clone())
+			.with_pcr(2, manifest.enclave().pcr2.clone())
+			.with_pcr(3, manifest.enclave().pcr3.clone())
+			.nsm_process_request(NsmRequest::Attestation {
+				user_data: Some(user_data),
+				nonce: None,
+				public_key: Some(public_key),
+			})
+	} else {
+		attestation::get_post_boot_attestation_doc(
+			&*state.attestor,
+			public_key,
+			user_data,
+		)
+	};
+	#[cfg(not(feature = "mock"))]
 	let nsm_response = attestation::get_post_boot_attestation_doc(
 		&*state.attestor,
-		ephemeral_key.public_key().to_bytes(),
-		manifest_envelope.manifest_hash().to_vec(),
+		public_key,
+		user_data,
 	);
 
 	// 4. Return the NSM Response containing COSE Sign1 encoded attestation

--- a/src/qos_core/src/protocol/services/key.rs
+++ b/src/qos_core/src/protocol/services/key.rs
@@ -2,10 +2,7 @@
 
 use aws_nitro_enclaves_nsm_api::api::AttestationDoc;
 use borsh::{BorshDeserialize, BorshSerialize};
-use qos_nsm::{
-	nitro::{AWS_ROOT_CERT_PEM, attestation_doc_from_der, cert_from_pem},
-	types::NsmResponse,
-};
+use qos_nsm::{nitro::attestation_doc_from_der, types::NsmResponse};
 use qos_p256::{P256Pair, P256Public};
 use serde::{Deserialize, Serialize};
 
@@ -100,6 +97,7 @@ pub(in crate::protocol) fn export_key(
 	let attestation_doc = verify_and_extract_attestation_doc_from_der(
 		cose_sign1_attestation_document,
 		&*state.attestor,
+		&state.attestation_verifier,
 	)?;
 
 	export_key_internal(state, &new_manifest_envelope, &attestation_doc)
@@ -120,23 +118,12 @@ fn export_key_internal(
 		attestation_doc,
 	)?;
 
-	let eph_key = {
-		#[cfg(not(feature = "mock"))]
-		{
-			let eph_key_bytes = attestation_doc
-				.public_key
-				.as_ref()
-				.ok_or(ProtocolError::MissingEphemeralKey)?;
-			P256Public::from_bytes(eph_key_bytes)
-				.map_err(|_| ProtocolError::InvalidEphemeralKey)?
-		}
-		#[cfg(feature = "mock")]
-		{
-			// For testing, the old enclave and new enclave will need to share
-			// an ephemeral key for this to work
-			state.handles.get_ephemeral_key()?.public_key()
-		}
-	};
+	let eph_key_bytes = attestation_doc
+		.public_key
+		.as_ref()
+		.ok_or(ProtocolError::MissingEphemeralKey)?;
+	let eph_key = P256Public::from_bytes(eph_key_bytes)
+		.map_err(|_| ProtocolError::InvalidEphemeralKey)?;
 
 	let quorum_key = state.handles.get_quorum_key()?;
 	// 10. Return the Quorum Key encrypted to the New Node's Ephemeral Key
@@ -255,17 +242,14 @@ fn validate_manifest(
 	// version of QOS. Note that we assume the values for PCR{0, 1 , 2}
 	// correspond to a desired version of QOS because the Manifest Set Members
 	// had K approvals.
-	#[cfg(not(feature = "mock"))]
-	{
-		qos_nsm::nitro::verify_attestation_doc_against_user_input(
-			attestation_doc,
-			&new_manifest.manifest_hash(),
-			&new_manifest.enclave().pcr0,
-			&new_manifest.enclave().pcr1,
-			&new_manifest.enclave().pcr2,
-			&new_manifest.enclave().pcr3,
-		)?;
-	}
+	qos_nsm::nitro::verify_attestation_doc_against_user_input(
+		attestation_doc,
+		&new_manifest.manifest_hash(),
+		&new_manifest.enclave().pcr0,
+		&new_manifest.enclave().pcr1,
+		&new_manifest.enclave().pcr2,
+		&new_manifest.enclave().pcr3,
+	)?;
 
 	// 9. Check that PCR3 in the New Manifest is in the Local Manifests. PCR3 is
 	// the IAM role assigned to the EC2 host of the enclave. An IAM role
@@ -287,13 +271,16 @@ fn validate_manifest(
 fn verify_and_extract_attestation_doc_from_der(
 	cose_sign1_der: &[u8],
 	nsm: &dyn qos_nsm::NsmProvider,
+	verifier: &crate::protocol::AttestationVerifierConfig,
 ) -> Result<AttestationDoc, ProtocolError> {
 	let current_time_milliseconds = nsm.timestamp_ms()?;
 	let current_time_seconds = current_time_milliseconds / 1_000;
-	let der_cert = cert_from_pem(AWS_ROOT_CERT_PEM)
-		.expect("hardcoded cert is valid. qed.");
-	attestation_doc_from_der(cose_sign1_der, &der_cert, current_time_seconds)
-		.map_err(Into::into)
+	attestation_doc_from_der(
+		cose_sign1_der,
+		verifier.trusted_root_der(),
+		current_time_seconds,
+	)
+	.map_err(Into::into)
 }
 
 #[cfg(test)]
@@ -302,16 +289,23 @@ mod test {
 
 	use aws_nitro_enclaves_nsm_api::api::{AttestationDoc, Digest};
 	use qos_crypto::sha_256;
-	use qos_nsm::{mock::MockNsm, types::NsmResponse};
+	use qos_nsm::{
+		NsmProvider,
+		mock::{DynamicMockNsm, MockNsm},
+		types::{NsmRequest, NsmResponse},
+	};
 	use qos_p256::P256Pair;
 	use qos_test_primitives::PathWrapper;
 	use serde_bytes::ByteBuf;
 
-	use super::{boot_key_forward, export_key_internal, validate_manifest};
+	use super::{
+		boot_key_forward, export_key, export_key_internal, validate_manifest,
+	};
 	use crate::{
 		handles::Handles,
 		protocol::{
-			ProtocolError, ProtocolPhase, ProtocolState, QosHash,
+			AttestationVerifierConfig, ProtocolError, ProtocolPhase,
+			ProtocolState, QosHash,
 			services::{
 				boot::{
 					Approval, Manifest, ManifestEnvelope, ManifestSet,
@@ -1094,6 +1088,59 @@ mod test {
 		use super::*;
 		use crate::protocol::services::key::EncryptedQuorumKey;
 
+		fn setup_export_key_handles(
+			name: &str,
+			manifest_envelope: &ManifestEnvelope,
+			quorum_pair: &P256Pair,
+		) -> Handles {
+			let ephemeral_file = format!("/tmp/{name}.eph.secret");
+			let manifest_file = format!("/tmp/{name}.manifest");
+			let quorum_file = format!("/tmp/{name}.quorum.secret");
+			let _ = std::fs::remove_file(&ephemeral_file);
+			let _ = std::fs::remove_file(&manifest_file);
+			let _ = std::fs::remove_file(&quorum_file);
+
+			P256Pair::generate().unwrap().to_hex_file(&ephemeral_file).unwrap();
+
+			quorum_pair.to_hex_file(&quorum_file).unwrap();
+			std::fs::write(
+				&manifest_file,
+				serde_json::to_vec(manifest_envelope).unwrap(),
+			)
+			.unwrap();
+
+			Handles::new(
+				ephemeral_file,
+				quorum_file,
+				manifest_file,
+				"pivot".to_string(),
+			)
+		}
+
+		fn dynamic_mock_document(
+			manifest_envelope: &ManifestEnvelope,
+			eph_pair: &P256Pair,
+		) -> Vec<u8> {
+			let manifest = &manifest_envelope.manifest;
+			let nsm = DynamicMockNsm::new()
+				.with_mock_certificate_chain()
+				.with_pcr(0, manifest.enclave.pcr0.clone())
+				.with_pcr(1, manifest.enclave.pcr1.clone())
+				.with_pcr(2, manifest.enclave.pcr2.clone())
+				.with_pcr(3, manifest.enclave.pcr3.clone());
+
+			let NsmResponse::Attestation { document } = nsm
+				.nsm_process_request(NsmRequest::Attestation {
+					user_data: Some(manifest.qos_hash().to_vec()),
+					nonce: None,
+					public_key: Some(eph_pair.public_key().to_bytes()),
+				})
+			else {
+				panic!("expected attestation response");
+			};
+			document
+		}
+
 		#[test]
 		fn works() {
 			let TestArgs {
@@ -1145,6 +1192,71 @@ mod test {
 					.is_ok()
 			);
 
+			let decrypted_quorum_secret =
+				eph_pair.decrypt(&encrypted_quorum_key).unwrap();
+			let reconstructed_quorum_pair =
+				P256Pair::from_master_seed(&zeroize::Zeroizing::new(
+					decrypted_quorum_secret[..].try_into().unwrap(),
+				))
+				.unwrap();
+			assert!(quorum_pair == reconstructed_quorum_pair);
+		}
+
+		#[test]
+		fn export_key_rejects_mock_chain_without_root_override() {
+			let TestArgs { manifest_envelope, eph_pair, quorum_pair, .. } =
+				get_test_args();
+			let handles = setup_export_key_handles(
+				"export_key_rejects_mock_chain_without_root_override",
+				&manifest_envelope,
+				&quorum_pair,
+			);
+			let mut protocol_state = ProtocolState::new(
+				Box::new(DynamicMockNsm::new().with_mock_certificate_chain()),
+				handles,
+				None,
+			);
+			let document = dynamic_mock_document(&manifest_envelope, &eph_pair);
+
+			let Err(err) =
+				export_key(&mut protocol_state, &manifest_envelope, &document)
+			else {
+				panic!("expected mock chain to fail without root override");
+			};
+
+			assert!(matches!(err, ProtocolError::QosAttestError(_)));
+		}
+
+		#[test]
+		fn export_key_accepts_mock_chain_with_root_override() {
+			let TestArgs { manifest_envelope, eph_pair, quorum_pair, .. } =
+				get_test_args();
+			let handles = setup_export_key_handles(
+				"export_key_accepts_mock_chain_with_root_override",
+				&manifest_envelope,
+				&quorum_pair,
+			);
+			let mut protocol_state =
+				ProtocolState::new_with_attestation_verifier(
+					Box::new(
+						DynamicMockNsm::new().with_mock_certificate_chain(),
+					),
+					handles,
+					None,
+					AttestationVerifierConfig::mock_nsm(),
+				);
+			let document = dynamic_mock_document(&manifest_envelope, &eph_pair);
+
+			let EncryptedQuorumKey { encrypted_quorum_key, signature } =
+				export_key(&mut protocol_state, &manifest_envelope, &document)
+					.unwrap();
+
+			assert!(
+				quorum_pair
+					.public_key()
+					.verify(&encrypted_quorum_key, &signature)
+					.is_ok()
+			);
 			let decrypted_quorum_secret =
 				eph_pair.decrypt(&encrypted_quorum_key).unwrap();
 			let reconstructed_quorum_pair =

--- a/src/qos_core/src/protocol/state.rs
+++ b/src/qos_core/src/protocol/state.rs
@@ -1,5 +1,8 @@
 //! Quorum protocol state machine
-use qos_nsm::NsmProvider;
+use qos_nsm::{
+	NsmProvider,
+	nitro::{AWS_ROOT_CERT_PEM, cert_from_pem},
+};
 
 use super::{
 	error::ProtocolError, msg::ProtocolMsg, services::provision::SecretBuilder,
@@ -187,15 +190,73 @@ impl ProtocolRoute {
 pub(crate) struct ProtocolState {
 	pub provisioner: SecretBuilder,
 	pub attestor: Box<dyn NsmProvider>,
+	pub attestation_verifier: AttestationVerifierConfig,
 	pub handles: Handles,
 	phase: ProtocolPhase,
 }
 
+/// Configuration for attestation document certificate-chain verification.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AttestationVerifierConfig {
+	trusted_root_der: Vec<u8>,
+}
+
+impl AttestationVerifierConfig {
+	/// Use the AWS Nitro root CA for production attestation verification.
+	///
+	/// # Panics
+	///
+	/// Panics if this crate's hardcoded AWS Nitro root certificate is invalid.
+	#[must_use]
+	pub fn aws_nitro() -> Self {
+		Self::from_trusted_root_der(
+			cert_from_pem(AWS_ROOT_CERT_PEM)
+				.expect("hardcoded AWS Nitro root certificate is valid"),
+		)
+	}
+
+	/// Use the provided DER root CA for attestation verification.
+	#[must_use]
+	pub fn from_trusted_root_der(trusted_root_der: Vec<u8>) -> Self {
+		Self { trusted_root_der }
+	}
+
+	/// Use the `qos_nsm` mock root CA for local tests.
+	#[cfg(any(test, feature = "mock"))]
+	#[must_use]
+	pub fn mock_nsm() -> Self {
+		Self::from_trusted_root_der(
+			qos_nsm::mock::mock_root_certificate_der().to_vec(),
+		)
+	}
+
+	/// Return the trusted root CA DER.
+	#[must_use]
+	pub fn trusted_root_der(&self) -> &[u8] {
+		&self.trusted_root_der
+	}
+}
+
 impl ProtocolState {
+	#[allow(dead_code)]
 	pub fn new(
 		attestor: Box<dyn NsmProvider>,
 		handles: Handles,
 		#[allow(unused)] test_only_init_phase_override: Option<ProtocolPhase>,
+	) -> Self {
+		Self::new_with_attestation_verifier(
+			attestor,
+			handles,
+			test_only_init_phase_override,
+			AttestationVerifierConfig::aws_nitro(),
+		)
+	}
+
+	pub fn new_with_attestation_verifier(
+		attestor: Box<dyn NsmProvider>,
+		handles: Handles,
+		#[allow(unused)] test_only_init_phase_override: Option<ProtocolPhase>,
+		attestation_verifier: AttestationVerifierConfig,
 	) -> Self {
 		let provisioner = SecretBuilder::new();
 
@@ -208,7 +269,13 @@ impl ProtocolState {
 		#[cfg(not(any(feature = "mock", test)))]
 		let init_phase = ProtocolPhase::WaitingForBootInstruction;
 
-		Self { attestor, provisioner, phase: init_phase, handles }
+		Self {
+			attestor,
+			attestation_verifier,
+			provisioner,
+			phase: init_phase,
+			handles,
+		}
 	}
 
 	pub fn get_phase(&self) -> ProtocolPhase {

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -21,7 +21,7 @@ use crate::{
 	handles::Handles,
 	io::{HostBridge, IOError, SocketAddress, StreamPool},
 	protocol::{
-		ProtocolPhase, ProtocolState,
+		AttestationVerifierConfig, ProtocolPhase, ProtocolState,
 		processor::ProtocolProcessor,
 		services::boot::{BridgeConfig, RestartPolicy},
 	},
@@ -44,10 +44,15 @@ async fn run_server(
 	nsm: Box<dyn NsmProvider + Send>,
 	core_socket: SocketAddress,
 	test_only_init_phase_override: Option<ProtocolPhase>,
+	attestation_verifier: AttestationVerifierConfig,
 ) {
-	let protocol_state =
-		ProtocolState::new(nsm, handles.clone(), test_only_init_phase_override)
-			.shared();
+	let protocol_state = ProtocolState::new_with_attestation_verifier(
+		nsm,
+		handles.clone(),
+		test_only_init_phase_override,
+		attestation_verifier,
+	)
+	.shared();
 	let core_pool = StreamPool::single(core_socket)
 		.expect("unable to create single socket core pool");
 	// send a shared version of state and the async pool to each processor
@@ -173,6 +178,30 @@ impl Reaper {
 		core_socket: SocketAddress,
 		test_only_init_phase_override: Option<ProtocolPhase>,
 	) {
+		Self::execute_with_attestation_verifier(
+			handles,
+			nsm,
+			core_socket,
+			test_only_init_phase_override,
+			AttestationVerifierConfig::aws_nitro(),
+		)
+		.await;
+	}
+
+	/// Run the Reaper with an explicit attestation verifier configuration.
+	///
+	/// # Panics
+	///
+	/// - If spawning the pivot errors.
+	/// - If waiting for the pivot errors.
+	/// - If the internal server state lock is poisoned.
+	pub async fn execute_with_attestation_verifier(
+		handles: &Handles,
+		nsm: Box<dyn NsmProvider + Send>,
+		core_socket: SocketAddress,
+		test_only_init_phase_override: Option<ProtocolPhase>,
+		attestation_verifier: AttestationVerifierConfig,
+	) {
 		// state switch to communicate between pivot run task (here) and run_server task
 		// we need to establish
 		let inter_state = Arc::new(RwLock::new(InterState::Booting));
@@ -184,6 +213,7 @@ impl Reaper {
 			nsm,
 			core_socket.clone(),
 			test_only_init_phase_override,
+			attestation_verifier,
 		));
 
 		loop {

--- a/src/qos_nsm/README.md
+++ b/src/qos_nsm/README.md
@@ -55,5 +55,6 @@ let nsm = DynamicMockNsm::new().with_mock_certificate_chain();
 // attestation_doc_from_der(&document, mock_root_certificate_der(), now_seconds)?;
 ```
 
-The mock root is not trusted by production code. Production verification must use
-the AWS Nitro root CA unless a caller explicitly opts into a local test override.
+The mock root is not trusted by production code. Production verification defaults
+to the AWS Nitro root CA unless a caller explicitly opts into a local test
+override such as `qos_core --unsafe-attestation-root-ca-der <path>`.


### PR DESCRIPTION
## Stack
- Base: `codex/mock-nsm-cert-chain`
- Head: `codex/configurable-attestation-root`
- Position: PR 3 of 3, stacked on #745

## Summary
- Add AttestationVerifierConfig with AWS Nitro as the default trusted root and explicit DER-root injection for local tests.
- Add qos_core --unsafe-attestation-root-ca-der and thread the config through Reaper into ProtocolState.
- Make key export use fully verified attestation docs and always encrypt to the attested public key; remove the mock-only ephemeral-key fallback.
- Update mock key-forward integration to pass the mock root override and verify full key-forward flow with separate old/new ephemeral keys.
- Update docs for production AWS default and unsafe local mock-root override.

## Verification
- PASS: cargo fmt --all -- --check
- PASS: cargo test -p qos_nsm --features mock
- PARTIAL: cargo test -p qos_core --features mock (91 passed, including new verifier tests; 3 existing io::stream relative Unix socket tests fail on this Modal volume with EOPNOTSUPP: Operation not supported)
- PASS: cargo test -p integration --test key --locked (after building required qos_client/qos_core/qos_host/pivot_loop binaries)
- PASS: cargo clippy -p qos_nsm -p qos_core --features mock -- -D warnings
- PARTIAL: make -C src test (suite reaches qos_core unit tests, then fails on the same 3 io::stream EOPNOTSUPP socket tests)
- PASS: git diff --check

## Known Risks / Follow-ups
- This PR is stacked on #745 and uses base codex/mock-nsm-cert-chain.
- The root override is intentionally named unsafe and is only for local/mock verification; production remains AWS Nitro root by default.
- The Modal volume does not support the relative Unix socket binds used by three existing qos_core unit tests.
