### PR TITLE
fix(deps): dependabot remediation 2026-06-26 (tkhq/qos)

### DIFF
--- a/src/qos_enclave/Cargo.lock
+++ b/src/qos_enclave/Cargo.lock
@@ -2746,9 +2746,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",


### PR DESCRIPTION
## Dependabot remediation

Lockfile bump for `tar` in `src/qos_enclave/Cargo.lock`.

### tar 0.4.45 → 0.4.46
[#111](https://github.com/tkhq/qos/security/dependabot/111) · [GHSA-3pv8-6f4r-ffg2](https://github.com/advisories/GHSA-3pv8-6f4r-ffg2) · dep_sev medium / actual_sev informational / complexity trivial → **score 60**

**What changed:** Fixes a PAX-header desynchronization bug where a PAX (`x`) extension header was applied to the next *intermediate* entry (e.g. a GNU longname) instead of the following file entry, letting a crafted archive extract differently than other tar parsers. Patch-level; no API change.

**Reachability in qos:** Not affected. `tar` is pulled transitively via `enclave_build` and is only used for creating archives, not extracting them; the desync bug is in the extraction path. We also do not use `nitro-cli` for building. Taking the patch defensively.

_Auto-opened by the Dependabot remediation workflow._