### PR TITLE
refactor: mark error enums non exhaustive

### DIFF
--- a/src/qos_core/src/protocol/error.rs
+++ b/src/qos_core/src/protocol/error.rs
@@ -19,6 +19,7 @@ use crate::{
 	serde::Serialize,
 	serde::Deserialize,
 )]
+#[non_exhaustive]
 pub enum ProtocolError {
 	/// A encrypted quorum key share sent to the enclave was invalid.
 	InvalidShare,

--- a/src/qos_nsm/src/nitro/error.rs
+++ b/src/qos_nsm/src/nitro/error.rs
@@ -4,6 +4,7 @@ use crate::types;
 
 /// Attestation error.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum AttestError {
 	/// `webpki::Error` wrapper.
 	WebPki(webpki::Error),


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

## How I Tested These Changes

## Pre merge check list

- [x] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
