### PR TITLE
feat: add dns config to manifest v2

### DIFF
--- a/in/resolv.conf
+++ b/in/resolv.conf
@@ -1,3 +1,0 @@
-nameserver 8.8.4.4
-options edns0 trust-ad
-search lan

--- a/src/images/qemu/Containerfile
+++ b/src/images/qemu/Containerfile
@@ -38,7 +38,6 @@ COPY --from=linux-nitro /nsm.ko .
 COPY --from=iproute2 . /
 COPY --from=musl . /
 COPY --from=build-egress /egress .
-COPY in/resolv.conf resolv.conf
 COPY <<-EOF initramfs.list
 	file /init     init    0700 0 0
 	file /nsm.ko   nsm.ko  0600 0 0
@@ -61,7 +60,6 @@ COPY <<-EOF initramfs.list
 	file /egress   egress 0700 0 0
 	file /usr/sbin/ip      /usr/sbin/ip     0700 0 0
 	file /lib/ld-musl-x86  /usr/lib/ld-musl-x86_64.so.1                   0700 0 0
-	file /etc/resolv.conf  resolv.conf      0644 0 0
 EOF
 ENV CPIO_TIMESTAMP=1
 ENV KBUILD_BUILD_TIMESTAMP=1

--- a/src/images/qos_enclave_egress/Containerfile
+++ b/src/images/qos_enclave_egress/Containerfile
@@ -49,7 +49,6 @@ COPY --from=linux-nitro /nsm.ko .
 COPY --from=iproute2 . /
 COPY --from=musl . /
 COPY --from=build-egress /egress .
-COPY in/resolv.conf resolv.conf
 COPY <<-EOF initramfs.list
 	file /init     init    0755 0 0
 	file /nsm.ko   nsm.ko  0755 0 0
@@ -72,7 +71,6 @@ COPY <<-EOF initramfs.list
 	file /egress           egress           0700 0 0
 	file /usr/sbin/ip      /usr/sbin/ip     0700 0 0
 	file /lib/ld-musl-x86  /usr/lib/ld-musl-x86_64.so.1                   0700 0 0
-	file /etc/resolv.conf  resolv.conf      0644 0 0
 EOF
 ENV CPIO_TIMESTAMP=1
 ENV KBUILD_BUILD_TIMESTAMP=1

--- a/src/integration/examples/boot_enclave.rs
+++ b/src/integration/examples/boot_enclave.rs
@@ -11,9 +11,9 @@ use std::{
 use borsh::BorshDeserialize;
 use integration::{LOCAL_HOST, PCR3_PRE_IMAGE_PATH, QOS_DIST_DIR};
 use qos_core::protocol::{
-	ProtocolPhase, QosHash,
+	ProtocolPhase,
 	services::{
-		boot::{Approval, Manifest, ManifestSet, Namespace, ShareSet},
+		boot::{Approval, ManifestSet, Namespace, ShareSet, VersionedManifest},
 		genesis::{GenesisMemberOutput, GenesisOutput},
 	},
 };
@@ -66,6 +66,8 @@ async fn main() {
 		Command::new(integration::QOS_CLIENT_PATH)
 		.args([
 			"generate-manifest",
+			"--use-manifest-version",
+			"2",
 			"--nonce",
 			"2",
 			"--namespace",
@@ -86,14 +88,14 @@ async fn main() {
 			"./mock/keys/manifest-set",
 			"--share-set-dir",
 			"./mock/keys/share-set",
-			"--patch-set-dir",
-			"./mock/keys/manifest-set",
 			"--quorum-key-path",
 			"./mock/namespaces/quit-coding-to-vape/quorum_key.pub",
 			"--debug-mode",
 			"true",
 			"--bridge-config",
 			&format!("[{{\"type\": \"server\", \"port\": {app_host_port}, \"host\": \"0.0.0.0\"}},{{\"type\": \"client\", \"port\": 0}}]"),
+			"--dns-resolvers",
+			"[8.8.4.4]",
 		])
 		.spawn()
 		.unwrap()
@@ -102,7 +104,7 @@ async fn main() {
 		.success());
 
 	// Check the manifest written to file
-	let manifest: Manifest =
+	let manifest: VersionedManifest =
 		serde_json::from_slice(&fs::read(&cli_manifest_path).unwrap()).unwrap();
 
 	let genesis_output = {
@@ -126,17 +128,19 @@ async fn main() {
 		nonce: 2,
 		quorum_key: genesis_output.quorum_key,
 	};
-	assert_eq!(manifest.namespace, namespace_field);
+	assert_eq!(*manifest.namespace(), namespace_field);
 	let manifest_set = ManifestSet { threshold: 2, members: members.clone() };
-	assert_eq!(manifest.manifest_set, manifest_set);
+	assert_eq!(*manifest.manifest_set(), manifest_set);
 	let share_set = ShareSet { threshold: 2, members };
-	assert_eq!(manifest.share_set, share_set);
+	assert_eq!(*manifest.share_set(), share_set);
 
 	// -- CLIENT make sure each user can run `approve-manifest`
 	for alias in [user1, user2, user3] {
 		let approval_path = boot_dir.join(format!(
 			"{}-{}-{}.approval",
-			alias, namespace, manifest.namespace.nonce,
+			alias,
+			namespace,
+			manifest.namespace().nonce,
 		));
 
 		let secret_path = personal_dir(alias).join(format!("{alias}.secret"));
@@ -160,8 +164,6 @@ async fn main() {
 				"./mock/keys/manifest-set",
 				"--share-set-dir",
 				"./mock/keys/share-set",
-				"--patch-set-dir",
-				"./mock/keys/manifest-set",
 				"--quorum-key-path",
 				"./mock/namespaces/quit-coding-to-vape/quorum_key.pub",
 				"--alias",
@@ -227,7 +229,7 @@ async fn main() {
 		)
 		.unwrap();
 
-		let signature = personal_pair.sign(&manifest.qos_hash()).unwrap();
+		let signature = personal_pair.sign(&manifest.manifest_hash()).unwrap();
 		assert_eq!(approval.signature, signature);
 
 		assert_eq!(approval.member.alias, alias);

--- a/src/qos_client/src/cli/mod.rs
+++ b/src/qos_client/src/cli/mod.rs
@@ -8,7 +8,7 @@
 //! cargo run --bin qos_client <command-name> --help
 //! ```
 
-use std::{collections::HashSet, env};
+use std::{collections::HashSet, env, net::IpAddr};
 
 use qos_core::{
 	parser::{CommandParser, GetParserForCommand, Parser, Token},
@@ -45,6 +45,7 @@ const UNSAFE_AUTO_CONFIRM: &str = "unsafe-auto-confirm";
 const PUB_PATH: &str = "pub-path";
 const DEBUG_MODE: &str = "debug-mode";
 const BRIDGE_CONFIG: &str = "bridge-config";
+const DNS_RESOLVERS: &str = "dns-resolvers";
 const YUBIKEY: &str = "yubikey";
 const SECRET_PATH: &str = "secret-path";
 const SHARE_PATH: &str = "share-path";
@@ -600,6 +601,15 @@ impl Command {
 			.takes_value(true)
 	}
 
+	fn dns_resolvers_token() -> Token {
+		Token::new(
+			DNS_RESOLVERS,
+			"Comma separated, [] wrapped DNS resolver IPs for manifest v2. e.g. `[1.1.1.1,8.8.8.8]`",
+		)
+		.required(false)
+		.takes_value(true)
+	}
+
 	fn base() -> Parser {
 		Parser::new()
 			.token(
@@ -685,6 +695,7 @@ impl Command {
 			.token(Self::quorum_key_path_token())
 			.token(Self::pivot_args_token())
 			.token(Self::bridge_config_token())
+			.token(Self::dns_resolvers_token())
 			.token(Self::debug_mode_token())
 			.token(Self::use_manifest_version_token())
 	}
@@ -1061,6 +1072,37 @@ impl ClientOpts {
 		} else {
 			Vec::new()
 		}
+	}
+
+	fn dns_resolvers(&self) -> Option<Vec<IpAddr>> {
+		self.parsed.single(DNS_RESOLVERS).map(|v| {
+			let mut chars = v.chars();
+
+			assert_eq!(
+				chars.next().unwrap(),
+				'[',
+				"DNS resolvers must start with a \"[\""
+			);
+			assert_eq!(
+				chars.next_back().unwrap(),
+				']',
+				"DNS resolvers must end with a \"]\""
+			);
+
+			if chars.clone().count() > 0 {
+				chars
+					.as_str()
+					.split(',')
+					.map(|resolver| {
+						resolver.parse().expect(
+							"Could not parse DNS resolver as IP address",
+						)
+					})
+					.collect()
+			} else {
+				vec![]
+			}
+		})
 	}
 
 	fn debug_mode(&self) -> bool {
@@ -1624,6 +1666,7 @@ mod handlers {
 			patch_set_dir: opts.patch_set_dir(),
 			quorum_key_path: opts.quorum_key_path(),
 			bridge_config: opts.bridge_config(),
+			dns_resolvers: opts.dns_resolvers(),
 			debug_mode: opts.debug_mode(),
 		};
 		let result = match opts.use_manifest_version() {

--- a/src/qos_client/src/cli/services.rs
+++ b/src/qos_client/src/cli/services.rs
@@ -2,6 +2,7 @@ use std::{
 	fs::{self, File},
 	io::{self, BufRead, BufReader, Write},
 	mem,
+	net::IpAddr,
 	path::{Path, PathBuf},
 };
 
@@ -12,7 +13,7 @@ use qos_core::protocol::{
 	msg::{JsonBytes, ProtocolMsg, ProtocolMsgEncoding},
 	services::{
 		boot::{
-			Approval, BridgeConfig, Manifest as ManifestV1,
+			Approval, BridgeConfig, DnsConfig, Manifest as ManifestV1,
 			ManifestEnvelope as ManifestEnvelopeV1, ManifestEnvelopeV0,
 			ManifestEnvelopeV2, ManifestSet, ManifestV2, ManifestVersion,
 			MemberPubKey, Namespace, NitroConfig, PatchSet,
@@ -157,6 +158,8 @@ pub enum Error {
 	ManifestV2DoesNotSupportPatchSet,
 	/// v1/v0 manifests require patch sets.
 	ManifestV1RequiresPatchSet,
+	/// v1/v0 manifests do not support DNS resolver configuration.
+	ManifestV1DoesNotSupportDnsConfig,
 }
 
 impl From<serde_json::Error> for Error {
@@ -779,6 +782,7 @@ pub(crate) struct GenerateManifestArgs<P: AsRef<Path>> {
 	pub manifest_path: P,
 	pub pivot_args: Vec<String>,
 	pub bridge_config: Vec<BridgeConfig>,
+	pub dns_resolvers: Option<Vec<IpAddr>>,
 	pub debug_mode: bool,
 }
 
@@ -799,8 +803,13 @@ pub(crate) fn generate_manifest<P: AsRef<Path>>(
 		manifest_path,
 		pivot_args,
 		bridge_config,
+		dns_resolvers,
 		debug_mode,
 	} = args;
+
+	if dns_resolvers.is_some() {
+		return Err(Error::ManifestV1DoesNotSupportDnsConfig);
+	}
 
 	let nitro_config =
 		extract_nitro_config(qos_release_dir_path, pcr3_preimage_path);
@@ -864,6 +873,7 @@ pub(crate) fn generate_manifest_v2<P: AsRef<Path>>(
 		manifest_path,
 		pivot_args,
 		bridge_config,
+		dns_resolvers,
 		debug_mode,
 	} = args;
 
@@ -897,6 +907,7 @@ pub(crate) fn generate_manifest_v2<P: AsRef<Path>>(
 		manifest_set,
 		share_set,
 		enclave: nitro_config,
+		dns: dns_resolvers.map(|resolvers| DnsConfig { resolvers }),
 	};
 
 	write_with_msg(
@@ -2759,6 +2770,7 @@ mod tests {
 				manifest_set: manifest.manifest_set,
 				share_set: manifest.share_set,
 				enclave: manifest.enclave,
+				dns: None,
 			},
 			manifest_set_approvals: vec![],
 			share_set_approvals: vec![],
@@ -3569,6 +3581,7 @@ mod tests {
 				manifest_set: manifest.manifest_set,
 				share_set: manifest.share_set,
 				enclave: manifest.enclave,
+				dns: None,
 			};
 			fs::write(&json_path, qos_json::to_vec(&v2).unwrap()).unwrap();
 
@@ -3610,6 +3623,7 @@ mod tests {
 				manifest_set: manifest.manifest_set,
 				share_set: manifest.share_set,
 				enclave: manifest.enclave,
+				dns: None,
 			};
 			let v2_envelope = ManifestEnvelopeV2 {
 				manifest: v2_manifest,

--- a/src/qos_client/tests/golden_artifacts.rs
+++ b/src/qos_client/tests/golden_artifacts.rs
@@ -554,6 +554,8 @@ fn v2_commands_generate_approve_and_envelope_use_json_hash() {
 		"true",
 		"--bridge-config",
 		"[{\"type\":\"server\",\"port\":3000,\"host\":\"0.0.0.0\"}]",
+		"--dns-resolvers",
+		"[1.1.1.1,2606:4700:4700::1111]",
 	]));
 
 	let manifest_json: serde_json::Value =
@@ -561,6 +563,8 @@ fn v2_commands_generate_approve_and_envelope_use_json_hash() {
 			.unwrap();
 	assert_eq!(manifest_json["version"], "v2");
 	assert!(manifest_json.get("patchSet").is_none());
+	assert_eq!(manifest_json["dns"]["resolvers"][0], "1.1.1.1");
+	assert_eq!(manifest_json["dns"]["resolvers"][1], "2606:4700:4700::1111");
 
 	let manifest: ManifestV2 =
 		serde_json::from_value(manifest_json.clone()).unwrap();
@@ -766,4 +770,53 @@ fn v1_generate_manifest_without_patch_set_fails_cleanly() {
 		String::from_utf8_lossy(&output.stderr)
 	);
 	assert!(combined.contains("ManifestV1RequiresPatchSet"));
+}
+
+#[test]
+fn v1_generate_manifest_with_dns_resolvers_fails_cleanly() {
+	let fixture = Fixture::new("v1_dns_resolvers");
+
+	assert_success(&run_qos_client([
+		"pivot-hash",
+		"--output-path",
+		fixture.pivot_hash_path.to_str().unwrap(),
+		"--pivot-path",
+		fixture.pivot_path.to_str().unwrap(),
+	]));
+
+	let output = run_qos_client([
+		"generate-manifest",
+		"--nonce",
+		"31",
+		"--namespace",
+		"production/signer",
+		"--restart-policy",
+		"always",
+		"--manifest-path",
+		fixture.manifest_path.to_str().unwrap(),
+		"--pivot-hash-path",
+		fixture.pivot_hash_path.to_str().unwrap(),
+		"--qos-release-dir",
+		fixture.qos_release_dir.to_str().unwrap(),
+		"--pcr3-preimage-path",
+		fixture.pcr3_preimage_path.to_str().unwrap(),
+		"--pivot-args",
+		"[]",
+		"--manifest-set-dir",
+		fixture.manifest_set.to_str().unwrap(),
+		"--share-set-dir",
+		fixture.share_set.to_str().unwrap(),
+		"--quorum-key-path",
+		fixture.quorum_key_path.to_str().unwrap(),
+		"--dns-resolvers",
+		"[1.1.1.1]",
+	]);
+
+	assert_failure(&output);
+	let combined = format!(
+		"{}{}",
+		String::from_utf8_lossy(&output.stdout),
+		String::from_utf8_lossy(&output.stderr)
+	);
+	assert!(combined.contains("ManifestV1DoesNotSupportDnsConfig"));
 }

--- a/src/qos_core/src/protocol/msg.rs
+++ b/src/qos_core/src/protocol/msg.rs
@@ -557,6 +557,7 @@ mod test {
 				aws_root_certificate: vec![],
 				qos_commit: "commit".to_string(),
 			},
+			dns: None,
 		};
 		let msg = ProtocolMsg::BootStandardRequest {
 			manifest_envelope: Box::new(VersionedManifestEnvelope::V2(
@@ -605,6 +606,7 @@ mod test {
 					aws_root_certificate: vec![],
 					qos_commit: "commit".to_string(),
 				},
+				dns: None,
 			},
 			manifest_set_approvals: vec![],
 			share_set_approvals: vec![],

--- a/src/qos_core/src/protocol/services/boot.rs
+++ b/src/qos_core/src/protocol/services/boot.rs
@@ -16,7 +16,9 @@ pub use env::{
 	MAX_PIVOT_ENV_NAME_LEN, MAX_PIVOT_ENV_VALUE_LEN, MAX_PIVOT_ENV_VARS,
 	PivotEnv, PivotEnvValue, PivotEnvVarName,
 };
-pub use manifest::v2::{ManifestEnvelopeV2, ManifestV2, PivotConfigV2};
+pub use manifest::v2::{
+	DnsConfig, ManifestEnvelopeV2, ManifestV2, PivotConfigV2,
+};
 pub use manifest::{
 	ManifestVersion, VersionedManifest, VersionedManifestEnvelope,
 };

--- a/src/qos_core/src/protocol/services/boot/manifest.rs
+++ b/src/qos_core/src/protocol/services/boot/manifest.rs
@@ -5,6 +5,8 @@ use std::io::Error;
 use borsh::{BorshDeserialize, BorshSerialize};
 
 use crate::protocol::{Hash256, ProtocolError, QosHash};
+#[cfg(test)]
+use std::net::IpAddr;
 
 use super::{
 	Approval, BridgeConfig, Manifest, ManifestEnvelope, ManifestEnvelopeV0,
@@ -13,7 +15,7 @@ use super::{
 
 pub mod v2;
 
-pub use v2::{ManifestEnvelopeV2, ManifestV2};
+pub use v2::{DnsConfig, ManifestEnvelopeV2, ManifestV2};
 
 /// Schema marker included only in v2 manifests.
 #[derive(
@@ -197,6 +199,15 @@ impl VersionedManifest {
 			Self::V2(manifest) => manifest.pivot.debug_mode,
 			Self::V1(manifest) => manifest.pivot.debug_mode,
 			Self::V0(_) => false,
+		}
+	}
+
+	/// Return DNS resolver configuration for v2 manifests.
+	#[must_use]
+	pub fn dns_config(&self) -> Option<&DnsConfig> {
+		match self {
+			Self::V2(manifest) => manifest.dns.as_ref(),
+			Self::V1(_) | Self::V0(_) => None,
 		}
 	}
 
@@ -516,6 +527,7 @@ mod tests {
 				aws_root_certificate: vec![],
 				qos_commit: "commit".to_string(),
 			},
+			dns: None,
 		}
 	}
 
@@ -583,6 +595,71 @@ mod tests {
 				members: vec![MemberPubKey { pub_key: member.pub_key }],
 			},
 		}
+	}
+
+	#[test]
+	fn v2_manifest_omits_dns_when_absent() {
+		let pair = P256Pair::generate().unwrap();
+		let manifest = sample_v2_manifest(sample_member(&pair));
+		let value = serde_json::to_value(&manifest).unwrap();
+
+		assert!(value.get("dns").is_none());
+	}
+
+	#[test]
+	fn v2_manifest_round_trips_dns_resolvers() {
+		let pair = P256Pair::generate().unwrap();
+		let mut manifest = sample_v2_manifest(sample_member(&pair));
+		manifest.dns = Some(DnsConfig {
+			resolvers: vec![
+				"1.1.1.1".parse().unwrap(),
+				"2606:4700:4700::1111".parse().unwrap(),
+			],
+		});
+
+		let value = serde_json::to_value(&manifest).unwrap();
+		assert_eq!(value["dns"]["resolvers"][0], "1.1.1.1");
+		assert_eq!(value["dns"]["resolvers"][1], "2606:4700:4700::1111");
+
+		let decoded: ManifestV2 = serde_json::from_value(value).unwrap();
+		assert_eq!(decoded.dns, manifest.dns);
+	}
+
+	#[test]
+	fn v2_manifest_rejects_invalid_dns_resolver() {
+		let pair = P256Pair::generate().unwrap();
+		let mut value =
+			serde_json::to_value(sample_v2_manifest(sample_member(&pair)))
+				.unwrap();
+		value["dns"] = serde_json::json!({
+			"resolvers": ["not-an-ip"]
+		});
+
+		assert!(serde_json::from_value::<ManifestV2>(value).is_err());
+	}
+
+	#[test]
+	fn versioned_manifest_dns_config_is_v2_only() {
+		let pair = P256Pair::generate().unwrap();
+		let member = sample_member(&pair);
+		let mut v2 = sample_v2_manifest(member.clone());
+		v2.dns =
+			Some(DnsConfig { resolvers: vec!["1.1.1.1".parse().unwrap()] });
+
+		assert_eq!(
+			VersionedManifest::V2(v2).dns_config().unwrap().resolvers,
+			vec!["1.1.1.1".parse::<IpAddr>().unwrap()]
+		);
+		assert!(
+			VersionedManifest::V1(sample_v1_manifest(member.clone()))
+				.dns_config()
+				.is_none()
+		);
+		assert!(
+			VersionedManifest::V0(sample_v0_manifest(member))
+				.dns_config()
+				.is_none()
+		);
 	}
 
 	#[test]

--- a/src/qos_core/src/protocol/services/boot/manifest/v2.rs
+++ b/src/qos_core/src/protocol/services/boot/manifest/v2.rs
@@ -1,5 +1,7 @@
 //! Explicitly versioned JSON manifest schema (v2).
 
+use std::net::IpAddr;
+
 use crate::protocol::{
 	Hash256,
 	services::boot::{
@@ -9,6 +11,14 @@ use crate::protocol::{
 };
 
 use super::ManifestVersion;
+
+/// DNS resolver configuration (v2).
+#[derive(PartialEq, Eq, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DnsConfig {
+	/// Resolver IP addresses to write as `nameserver` entries.
+	pub resolvers: Vec<IpAddr>,
+}
 
 /// JSON-only pivot binary configuration (v2).
 #[derive(PartialEq, Eq, Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -47,6 +57,9 @@ pub struct ManifestV2 {
 	pub share_set: ShareSet,
 	/// Configuration and verifiable values for the enclave hardware.
 	pub enclave: NitroConfig,
+	/// DNS resolver configuration for the enclave.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub dns: Option<DnsConfig>,
 }
 
 /// Explicitly versioned JSON manifest envelope (v2).

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -157,28 +157,18 @@ fn reprint_pivot_output(child: &mut Child) {
 	});
 }
 
-fn resolv_conf_with_nameservers(current: &str, resolvers: &[IpAddr]) -> String {
+fn resolv_conf_with_nameservers(resolvers: &[IpAddr]) -> String {
 	let mut output = String::new();
 	for resolver in resolvers {
 		output.push_str("nameserver ");
 		output.push_str(&resolver.to_string());
 		output.push('\n');
 	}
-	for line in current.lines() {
-		if line.split_whitespace().next() != Some("nameserver") {
-			output.push_str(line);
-			output.push('\n');
-		}
-	}
 	output
 }
 
 fn write_resolv_conf(resolvers: &[IpAddr]) -> std::io::Result<()> {
-	let current = fs::read_to_string(RESOLV_CONF_PATH).unwrap_or_default();
-	fs::write(
-		RESOLV_CONF_PATH,
-		resolv_conf_with_nameservers(&current, resolvers),
-	)
+	fs::write(RESOLV_CONF_PATH, resolv_conf_with_nameservers(resolvers))
 }
 
 /// Primary entry point for running the enclave. Coordinates spawning the server
@@ -312,31 +302,21 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn resolv_conf_rewrite_replaces_nameservers_and_preserves_options() {
+	fn resolv_conf_write_uses_configured_nameservers() {
 		let resolvers = ["1.1.1.1", "2606:4700:4700::1111"]
 			.into_iter()
 			.map(|resolver| resolver.parse().unwrap())
 			.collect::<Vec<IpAddr>>();
-		let current = "# comment\nnameserver 8.8.4.4\noptions edns0 trust-ad\n";
 
 		assert_eq!(
-			resolv_conf_with_nameservers(current, &resolvers),
-			"nameserver 1.1.1.1\nnameserver 2606:4700:4700::1111\n# comment\noptions edns0 trust-ad\n"
+			resolv_conf_with_nameservers(&resolvers),
+			"nameserver 1.1.1.1\nnameserver 2606:4700:4700::1111\n"
 		);
 	}
 
 	#[test]
-	fn resolv_conf_rewrite_preserves_non_nameserver_lines_only() {
-		let resolvers = ["9.9.9.9"]
-			.into_iter()
-			.map(|resolver| resolver.parse().unwrap())
-			.collect::<Vec<IpAddr>>();
-		let current = "  nameserver 8.8.8.8\nsearch example.com\n";
-
-		assert_eq!(
-			resolv_conf_with_nameservers(current, &resolvers),
-			"nameserver 9.9.9.9\nsearch example.com\n"
-		);
+	fn resolv_conf_write_supports_empty_resolver_list() {
+		assert_eq!(resolv_conf_with_nameservers(&[]), "");
 	}
 }
 

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -5,7 +5,8 @@
 //! The pivot is an executable the enclave runs to initialize the secure
 //! applications.
 use std::{
-	net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+	fs,
+	net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4},
 	process::Stdio,
 	sync::{Arc, RwLock},
 	time::Duration,
@@ -35,6 +36,7 @@ pub const REAPER_RESTART_DELAY: Duration = Duration::from_millis(50);
 pub const REAPER_EXIT_DELAY: Duration = Duration::from_secs(3);
 
 const REAPER_STATE_CHECK_DELAY: Duration = Duration::from_millis(100);
+const RESOLV_CONF_PATH: &str = "/etc/resolv.conf";
 
 // runs the enclave vsock setup server for qos_host communication, waiting for manifest/pivot
 // executed as a task from `Reaper::execute`
@@ -155,6 +157,30 @@ fn reprint_pivot_output(child: &mut Child) {
 	});
 }
 
+fn resolv_conf_with_nameservers(current: &str, resolvers: &[IpAddr]) -> String {
+	let mut output = String::new();
+	for resolver in resolvers {
+		output.push_str("nameserver ");
+		output.push_str(&resolver.to_string());
+		output.push('\n');
+	}
+	for line in current.lines() {
+		if line.split_whitespace().next() != Some("nameserver") {
+			output.push_str(line);
+			output.push('\n');
+		}
+	}
+	output
+}
+
+fn write_resolv_conf(resolvers: &[IpAddr]) -> std::io::Result<()> {
+	let current = fs::read_to_string(RESOLV_CONF_PATH).unwrap_or_default();
+	fs::write(
+		RESOLV_CONF_PATH,
+		resolv_conf_with_nameservers(&current, resolvers),
+	)
+}
+
 /// Primary entry point for running the enclave. Coordinates spawning the server
 /// and pivot binary.
 pub struct Reaper;
@@ -216,6 +242,12 @@ impl Reaper {
 		let args = manifest.args().to_vec();
 		let restart = manifest.restart();
 		let host_config = manifest.bridge_config().to_vec();
+		let dns_config = manifest.dns_config().cloned();
+
+		if let Some(dns_config) = dns_config {
+			write_resolv_conf(&dns_config.resolvers)
+				.expect("failed to write /etc/resolv.conf");
+		}
 
 		// if the app indicates the need for the VSOCK -> TCP bridge, run it as another task
 		run_bridges(&core_socket, &host_config)
@@ -273,6 +305,39 @@ enum InterState {
 	Booting,
 	// We're quitting (ctrl+c for tests and such)
 	Quitting,
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn resolv_conf_rewrite_replaces_nameservers_and_preserves_options() {
+		let resolvers = ["1.1.1.1", "2606:4700:4700::1111"]
+			.into_iter()
+			.map(|resolver| resolver.parse().unwrap())
+			.collect::<Vec<IpAddr>>();
+		let current = "# comment\nnameserver 8.8.4.4\noptions edns0 trust-ad\n";
+
+		assert_eq!(
+			resolv_conf_with_nameservers(current, &resolvers),
+			"nameserver 1.1.1.1\nnameserver 2606:4700:4700::1111\n# comment\noptions edns0 trust-ad\n"
+		);
+	}
+
+	#[test]
+	fn resolv_conf_rewrite_preserves_non_nameserver_lines_only() {
+		let resolvers = ["9.9.9.9"]
+			.into_iter()
+			.map(|resolver| resolver.parse().unwrap())
+			.collect::<Vec<IpAddr>>();
+		let current = "  nameserver 8.8.8.8\nsearch example.com\n";
+
+		assert_eq!(
+			resolv_conf_with_nameservers(current, &resolvers),
+			"nameserver 9.9.9.9\nsearch example.com\n"
+		);
+	}
 }
 
 // See qos_test/tests/async_reaper for more tests


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

Add the ability to configure dns, remove default

## How I Tested These Changes

I have not

## Pre merge check list

- [x] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
