### PR TITLE
qos_core: use link local egress tunnel addresses

### DIFF
--- a/src/qos_core/src/egress.rs
+++ b/src/qos_core/src/egress.rs
@@ -76,14 +76,14 @@ pub fn host_egress(cid: u32, port: u32, flags: u8) {
 	copy_bidirectional(sock_fd, proxy_fd);
 }
 
-/// sets up new tuntap tun interface `enclave_egress` with localhost routing using `172.29.107.65/32` mask and default gw
+/// sets up new tuntap tun interface `enclave_egress` with localhost routing using `169.254.0.1/32` mask and default gw
 /// expects `/usr/sbin/ip` and `/lib/ld-musl-x86` to be present
 /// # Panics
 /// panics if the program executions fail
 pub fn init_egress_tun() {
 	run_ip("tuntap add enclave_egress mode tun", "tuntap add failed");
 	run_ip("link set lo up", "unable to bring up lo");
-	run_ip("address add 172.29.107.65/32 dev lo", "ip assign to lo failed");
+	run_ip("address add 169.254.0.1/32 dev lo", "ip assign to lo failed"); // use link-local ip
 	run_ip("link set mtu 1320 dev enclave_egress", "unable to set MTU size"); // MTU 1340 is max for calico wg-v6-cali so we need <= to that
 	run_ip("link set enclave_egress up", "unable to bring up egress");
 	run_ip("route add default dev enclave_egress", "unable to route");

--- a/src/scripts/enclave_egress_interfaces.sh
+++ b/src/scripts/enclave_egress_interfaces.sh
@@ -8,8 +8,8 @@ DEFINT="${1:-eth0}"
 # create egress from host tun interface
 sudo ip tuntap add host_egress mode tun
 
-# assign 10.0.0.2/28 to host_egress to mask the martians
-sudo ip address add 172.29.107.66/28 dev host_egress
+# assign 169.254.0.2/28 to host_egress to mask the martians
+sudo ip address add 169.254.0.2/28 dev host_egress
 
 # set MTU size to match calico limits in prod
 sudo ip link set mtu 1320 dev host_egress
@@ -22,7 +22,7 @@ echo 1 | sudo tee /proc/sys/net/ipv4/ip_forward > /dev/null
 sudo iptables -P FORWARD ACCEPT
 
 # masquerade nat for egress
-sudo iptables -t nat -I POSTROUTING -s 172.29.107.65 -j MASQUERADE -o "$DEFINT"
+sudo iptables -t nat -I POSTROUTING -s 169.254.0.1 -j MASQUERADE -o "$DEFINT"
 
 # check it
 ip a show dev host_egress


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

Switches egress addresses to be link-local to prevent conflicts.

## How I Tested These Changes
Qemu
