### PR TITLE
docs: add READMEs for published crates

### DIFF
--- a/src/qos_client/Cargo.toml
+++ b/src/qos_client/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 description = "Multipurpose CLI client for interacting with QuorumOS enclaves and related operations"
 repository = "https://github.com/tkhq/qos"
+readme = "README.md"
 keywords = ["quorumos", "enclave", "nitro", "attestation", "client"]
 categories = ["command-line-utilities"]
 

--- a/src/qos_client/README.md
+++ b/src/qos_client/README.md
@@ -1,0 +1,3 @@
+# qos_client
+
+Multipurpose CLI client for interacting with QuorumOS enclaves and related operations.

--- a/src/qos_client/README.md
+++ b/src/qos_client/README.md
@@ -1,3 +1,3 @@
-# qos_client
+# `qos_client`
 
-Multipurpose CLI client for interacting with QuorumOS enclaves and related operations.
+Multipurpose CLI client for interacting with `QuorumOS` enclaves and related operations.

--- a/src/qos_client/src/lib.rs
+++ b/src/qos_client/src/lib.rs
@@ -1,7 +1,5 @@
 #![doc = include_str!("../README.md")]
 
-//! CLI Client for interacting with `QuorumOS` enclave and host.
-
 pub mod cli;
 #[cfg(feature = "smartcard")]
 pub mod yubikey;

--- a/src/qos_client/src/lib.rs
+++ b/src/qos_client/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 //! CLI Client for interacting with `QuorumOS` enclave and host.
 
 pub mod cli;

--- a/src/qos_core/Cargo.toml
+++ b/src/qos_core/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 description = "Core components and logic for QuorumOS applications"
 repository = "https://github.com/tkhq/qos"
+readme = "README.md"
 keywords = ["quorumos", "enclave", "nitro", "tee", "quorum"]
 categories = ["os"]
 

--- a/src/qos_core/README.md
+++ b/src/qos_core/README.md
@@ -1,0 +1,3 @@
+# qos_core
+
+Core components and protocol logic for QuorumOS applications.

--- a/src/qos_core/README.md
+++ b/src/qos_core/README.md
@@ -1,3 +1,3 @@
-# qos_core
+# `qos_core`
 
 Core components and protocol logic for QuorumOS, this includes the logic for the Reaper and QOS Control Task as well as utilities that may be useful for interaction with QuorumOS generally.

--- a/src/qos_core/README.md
+++ b/src/qos_core/README.md
@@ -1,3 +1,3 @@
 # qos_core
 
-Core components and protocol logic for QuorumOS applications.
+Core components and protocol logic for QuorumOS, this includes the logic for the Reaper and QOS Control Task as well as utilities that may be useful for interaction with QuorumOS generally.

--- a/src/qos_core/src/lib.rs
+++ b/src/qos_core/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![allow(clippy::doc_markdown)]
 
 pub mod cli;
 pub mod client;

--- a/src/qos_core/src/lib.rs
+++ b/src/qos_core/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 //! Core components and logic for QOS. This contains both the logic for the
 //! process running in the enclave and exports for use by secure apps and QOS
 //! clients

--- a/src/qos_core/src/lib.rs
+++ b/src/qos_core/src/lib.rs
@@ -1,14 +1,5 @@
 #![doc = include_str!("../README.md")]
 
-//! Core components and logic for QOS. This contains both the logic for the
-//! process running in the enclave and exports for use by secure apps and QOS
-//! clients
-//!
-//! # Maintainers Notes
-//!
-//! This crate should have as minimal dependencies as possible to decrease
-//! supply chain attack vectors and audit burden
-
 pub mod cli;
 pub mod client;
 pub mod handles;

--- a/src/qos_crypto/Cargo.toml
+++ b/src/qos_crypto/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 description = "Cryptographic primitives for use with QuorumOS"
 repository = "https://github.com/tkhq/qos"
+readme = "README.md"
 keywords = ["quorumos", "shamir", "secret-sharing", "threshold", "cryptography"]
 categories = ["cryptography"]
 

--- a/src/qos_crypto/README.md
+++ b/src/qos_crypto/README.md
@@ -1,0 +1,3 @@
+# qos_crypto
+
+Cryptographic primitives used by QuorumOS crates.

--- a/src/qos_crypto/README.md
+++ b/src/qos_crypto/README.md
@@ -1,3 +1,3 @@
-# qos_crypto
+# `qos_crypto`
 
-Cryptographic primitives used by QuorumOS crates.
+Cryptographic primitives used by `QuorumOS` crates.

--- a/src/qos_crypto/src/lib.rs
+++ b/src/qos_crypto/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 //! Cryptographic primitves for use with `QuorumOS`.
 
 use std::fmt;

--- a/src/qos_crypto/src/lib.rs
+++ b/src/qos_crypto/src/lib.rs
@@ -1,7 +1,5 @@
 #![doc = include_str!("../README.md")]
 
-//! Cryptographic primitves for use with `QuorumOS`.
-
 use std::fmt;
 
 use sha2::Digest;

--- a/src/qos_hex/Cargo.toml
+++ b/src/qos_hex/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 description = "Utilities for encoding and decoding hex strings"
 repository = "https://github.com/tkhq/qos"
+readme = "README.md"
 keywords = ["quorumos", "hex", "encoding"]
 categories = ["encoding"]
 

--- a/src/qos_hex/README.md
+++ b/src/qos_hex/README.md
@@ -1,3 +1,7 @@
 # qos_hex
 
 Utilities for encoding and decoding hex strings in QuorumOS crates.
+
+Use `encode` and `encode_to_vec` to produce lowercase hex, and `decode`, `decode_to_buf`, `decode_from_vec`, or `FromHex` to decode hex into byte buffers, arrays, or vectors.
+
+Enable the `serde` feature for `#[serde(with = "qos_hex::serde")]` helpers, including optional hex-encoded fields through `qos_hex::serde::option`.

--- a/src/qos_hex/README.md
+++ b/src/qos_hex/README.md
@@ -1,0 +1,3 @@
+# qos_hex
+
+Utilities for encoding and decoding hex strings in QuorumOS crates.

--- a/src/qos_hex/README.md
+++ b/src/qos_hex/README.md
@@ -1,6 +1,6 @@
-# qos_hex
+# `qos_hex`
 
-Utilities for encoding and decoding hex strings in QuorumOS crates.
+Utilities for encoding and decoding hex strings in `QuorumOS` crates.
 
 Use `encode` and `encode_to_vec` to produce lowercase hex, and `decode`, `decode_to_buf`, `decode_from_vec`, or `FromHex` to decode hex into byte buffers, arrays, or vectors.
 

--- a/src/qos_hex/src/lib.rs
+++ b/src/qos_hex/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 //! Utilities for encoding and decoding hex strings.
 //!
 //! To encode a `&[u8]` you can use:

--- a/src/qos_hex/src/lib.rs
+++ b/src/qos_hex/src/lib.rs
@@ -1,28 +1,5 @@
 #![doc = include_str!("../README.md")]
 
-//! Utilities for encoding and decoding hex strings.
-//!
-//! To encode a `&[u8]` you can use:
-//!
-//! - [`encode`]
-//! - [`encode_to_vec`]
-//!
-//! To decode you can use:
-//!
-//! - [`decode`] for `&str`
-//! - [`decode_from_vec`] for `Vec<u8>`
-//! - [`FromHex::from_hex`] for `Vec<u8>` and some `u8` array sizes.
-//! - [`decode_to_buf`] for decoding a `&str` into a `&mut [u8]` with the exact
-//!   size.
-//!
-//! # Features
-//!
-//! ## `serde`
-//!
-//! With the serde feature enabled you can use [`crate::serde`] to serialize any
-//! `u8` array or `Vec<u8>` to hex and deserialize hex string to a `Vec<u8>` and
-//! a fixed selection of `u8` arrays.
-
 use std::{convert::Into, num::ParseIntError, string::FromUtf8Error};
 
 const MEGABYTE: usize = 1024 * 1024;

--- a/src/qos_json/Cargo.toml
+++ b/src/qos_json/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 description = "Canonical JSON encoding for deterministic JSON"
 repository = "https://github.com/tkhq/qos"
+readme = "README.md"
 keywords = ["quorumos", "serde", "encoding"]
 categories = ["encoding"]
 

--- a/src/qos_json/README.md
+++ b/src/qos_json/README.md
@@ -1,0 +1,3 @@
+# qos_json
+
+Canonical JSON encoding for deterministic JSON used by QuorumOS.

--- a/src/qos_json/README.md
+++ b/src/qos_json/README.md
@@ -1,3 +1,3 @@
-# qos_json
+# `qos_json`
 
-Canonical JSON encoding for deterministic JSON used by QuorumOS.
+Canonical JSON encoding for deterministic JSON used by `QuorumOS`.

--- a/src/qos_json/src/lib.rs
+++ b/src/qos_json/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc = include_str!("../README.md")]
 #![doc = include_str!("../SPEC.md")]
 
 use serde::{Serialize, de::DeserializeOwned};

--- a/src/qos_net/Cargo.toml
+++ b/src/qos_net/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 description = "Socket to TCP proxy for QuorumOS enclave network access"
 repository = "https://github.com/tkhq/qos"
+readme = "README.md"
 keywords = ["quorumos", "enclave", "nitro", "proxy", "vsock"]
 categories = ["network-programming"]
 

--- a/src/qos_net/README.md
+++ b/src/qos_net/README.md
@@ -1,3 +1,3 @@
-# qos_net
+# `qos_net`
 
-Socket-to-TCP proxy utilities for QuorumOS enclave network access.
+Socket-to-TCP proxy utilities for `QuorumOS` enclave network access.

--- a/src/qos_net/README.md
+++ b/src/qos_net/README.md
@@ -1,0 +1,3 @@
+# qos_net
+
+Socket-to-TCP proxy utilities for QuorumOS enclave network access.

--- a/src/qos_net/src/lib.rs
+++ b/src/qos_net/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 //! This crate contains a simple proxy server which binds to a local socket and
 //! opens TCP connection.
 //! It exposes a simple protocol for remote clients who

--- a/src/qos_net/src/lib.rs
+++ b/src/qos_net/src/lib.rs
@@ -1,10 +1,5 @@
 #![doc = include_str!("../README.md")]
 
-//! This crate contains a simple proxy server which binds to a local socket and
-//! opens TCP connection.
-//! It exposes a simple protocol for remote clients who
-//! connect to let them manipulate these connections (read/write/flush)
-
 /// Error types for the qos_net crate.
 pub mod error;
 /// Protocol messages for the proxy.

--- a/src/qos_nsm/Cargo.toml
+++ b/src/qos_nsm/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 description = "AWS Nitro Secure Module attestation endpoints and types"
 repository = "https://github.com/tkhq/qos"
+readme = "README.md"
 keywords = ["quorumos", "nitro", "enclave", "attestation", "aws"]
 categories = ["cryptography"]
 

--- a/src/qos_nsm/README.md
+++ b/src/qos_nsm/README.md
@@ -1,3 +1,3 @@
-# qos_nsm
+# `qos_nsm`
 
-AWS Nitro Secure Module attestation endpoints and types for QuorumOS.
+AWS Nitro Secure Module attestation endpoints and types for `QuorumOS`.

--- a/src/qos_nsm/README.md
+++ b/src/qos_nsm/README.md
@@ -1,0 +1,3 @@
+# qos_nsm
+
+AWS Nitro Secure Module attestation endpoints and types for QuorumOS.

--- a/src/qos_nsm/src/lib.rs
+++ b/src/qos_nsm/src/lib.rs
@@ -1,7 +1,5 @@
 #![doc = include_str!("../README.md")]
 
-//! Endpoints and types for an enclaves attestation flow.
-
 pub mod nitro;
 mod nsm;
 pub mod types;

--- a/src/qos_nsm/src/lib.rs
+++ b/src/qos_nsm/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 //! Endpoints and types for an enclaves attestation flow.
 
 pub mod nitro;

--- a/src/qos_p256/Cargo.toml
+++ b/src/qos_p256/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 description = "Signing and encryption utilities for P-256 keys"
 repository = "https://github.com/tkhq/qos"
+readme = "README.md"
 keywords = ["quorumos", "p256", "ecdsa", "ecdh", "encryption"]
 categories = ["cryptography"]
 

--- a/src/qos_p256/README.md
+++ b/src/qos_p256/README.md
@@ -1,0 +1,3 @@
+# qos_p256
+
+Signing and encryption utilities for P-256 keys used by QuorumOS.

--- a/src/qos_p256/README.md
+++ b/src/qos_p256/README.md
@@ -1,3 +1,3 @@
-# qos_p256
+# `qos_p256`
 
-Signing and encryption utilities for P-256 keys used by QuorumOS.
+Signing and encryption utilities for P-256 keys used by `QuorumOS`.

--- a/src/qos_p256/src/lib.rs
+++ b/src/qos_p256/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc = include_str!("../README.md")]
 #![doc = include_str!("../SPEC.md")]
 
 use std::path::Path;

--- a/src/qos_test_primitives/Cargo.toml
+++ b/src/qos_test_primitives/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 description = "Test utilities and helper primitives for QuorumOS crates"
 repository = "https://github.com/tkhq/qos"
+readme = "README.md"
 
 # Override workspace lints for this test crate
 [lints.rust]

--- a/src/qos_test_primitives/README.md
+++ b/src/qos_test_primitives/README.md
@@ -1,3 +1,3 @@
-# qos_test_primitives
+# `qos_test_primitives`
 
-Test utilities and helper primitives shared by QuorumOS crates.
+Test utilities and helper primitives shared by `QuorumOS` crates.

--- a/src/qos_test_primitives/README.md
+++ b/src/qos_test_primitives/README.md
@@ -1,0 +1,3 @@
+# qos_test_primitives
+
+Test utilities and helper primitives shared by QuorumOS crates.

--- a/src/qos_test_primitives/src/lib.rs
+++ b/src/qos_test_primitives/src/lib.rs
@@ -1,7 +1,5 @@
 #![doc = include_str!("../README.md")]
 
-//! Primitive types for test setup.
-
 use std::{
 	net::{Ipv4Addr, SocketAddrV4, TcpListener, TcpStream},
 	ops::{Deref, DerefMut},

--- a/src/qos_test_primitives/src/lib.rs
+++ b/src/qos_test_primitives/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 //! Primitive types for test setup.
 
 use std::{


### PR DESCRIPTION
## Summary
- add short README files for each release-plz-published Rust crate
- set each published crate manifest to use its local README
- include each README in the library crate root docs so docs.rs/crates.io pages are not blank

