### PR TITLE
fix(qos_client): gate advanced_provision_yubikey re-export behind smartcard feature

### DIFF
--- a/src/qos_client/src/cli/mod.rs
+++ b/src/qos_client/src/cli/mod.rs
@@ -21,7 +21,9 @@ use qos_core::{
 mod services;
 
 pub use services::PairOrYubi;
-pub use services::{advanced_provision_yubikey, generate_file_key};
+#[cfg(feature = "smartcard")]
+pub use services::advanced_provision_yubikey;
+pub use services::generate_file_key;
 
 const HOST_IP: &str = "host-ip";
 const HOST_PORT: &str = "host-port";


### PR DESCRIPTION
## Problem

`qos_client` fails to build with `--no-default-features`:

```
error[E0432]: unresolved import `services::advanced_provision_yubikey`
```

`advanced_provision_yubikey` in `cli::services` is gated behind
`#[cfg(feature = "smartcard")]`, but the re-export in `cli::mod` was
unconditional:

```rust
pub use services::{advanced_provision_yubikey, generate_file_key};
```

So any build without the default `smartcard` feature (e.g. a minimal
build embedding `qos_client` as a library in a non-YubiKey environment)
hits an unresolved import.

## Fix

Gate the re-export behind the same `smartcard` feature. `PairOrYubi` and
`generate_file_key` stay unconditional because they are always compiled.

```rust
pub use services::PairOrYubi;
#[cfg(feature = "smartcard")]
pub use services::advanced_provision_yubikey;
pub use services::generate_file_key;
```

## Verification

- `cargo check -p qos_client --no-default-features` — now builds (was E0432)
- `make -C src lint` — clippy (`-D warnings`) + `cargo fmt --check` pass
- `make -C src test` — full unit + integration suite passes