### PR TITLE
ci: check feature combinations of publishable crates with cargo-hack

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,6 +65,20 @@ jobs:
         # Check one selected package at a time so unrelated workspace members
         # cannot hide missing direct dependency features through unification.
         run: cargo check --locked -p ${{ matrix.package }}
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
+        with:
+          tool: cargo-hack
+      - name: Check feature combinations
+        # Catches feature-gate bugs (e.g. cfg-gated items re-exported
+        # unconditionally, see PR #758): checks every feature combination
+        # of each publishable crate standalone, including no-default-features.
+        # --no-dev-deps temporarily strips dev-dependencies from Cargo.toml,
+        # which is incompatible with --locked; `cargo fetch --locked` +
+        # --offline pins dependency versions to the lock file instead.
+        run: |
+          cargo fetch --locked
+          cargo hack check --offline --feature-powerset --no-dev-deps -p ${{ matrix.package }}
 
   build-linux-only-crates:
     name: build-linux-only-crates

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -70,12 +70,6 @@ jobs:
         with:
           tool: cargo-hack
       - name: Check feature combinations
-        # Catches feature-gate bugs (e.g. cfg-gated items re-exported
-        # unconditionally, see PR #758): checks every feature combination
-        # of each publishable crate standalone, including no-default-features.
-        # --no-dev-deps temporarily strips dev-dependencies from Cargo.toml,
-        # which is incompatible with --locked; `cargo fetch --locked` +
-        # --offline pins dependency versions to the lock file instead.
         run: |
           cargo fetch --locked
           cargo hack check --offline --feature-powerset --no-dev-deps -p ${{ matrix.package }}

--- a/src/qos_client/src/cli/mod.rs
+++ b/src/qos_client/src/cli/mod.rs
@@ -21,7 +21,9 @@ use qos_core::{
 mod services;
 
 pub use services::PairOrYubi;
-pub use services::{advanced_provision_yubikey, generate_file_key};
+#[cfg(feature = "smartcard")]
+pub use services::advanced_provision_yubikey;
+pub use services::generate_file_key;
 
 const HOST_IP: &str = "host-ip";
 const HOST_PORT: &str = "host-port";

--- a/src/qos_hex/Cargo.toml
+++ b/src/qos_hex/Cargo.toml
@@ -16,7 +16,4 @@ workspace = true
 serde = { workspace = true, optional = true }
 
 [features]
-# serde/alloc is required for the String impls used by our serializers; without
-# it, building with only `--features serde` (no unification from other
-# workspace crates enabling serde/std) fails.
 serde = ["dep:serde", "serde/alloc"]

--- a/src/qos_hex/Cargo.toml
+++ b/src/qos_hex/Cargo.toml
@@ -16,4 +16,7 @@ workspace = true
 serde = { workspace = true, optional = true }
 
 [features]
-serde = ["dep:serde"]
+# serde/alloc is required for the String impls used by our serializers; without
+# it, building with only `--features serde` (no unification from other
+# workspace crates enabling serde/std) fails.
+serde = ["dep:serde", "serde/alloc"]


### PR DESCRIPTION
Adds a `cargo hack check --feature-powerset --no-dev-deps` step to `check-publishable-crates-standalone`, so every feature combination of each publishable crate is checked — including `--no-default-features`, which existing default-features-only checks miss (the #758 regression class).

The check immediately caught two real bugs, fixed here: the #758 `qos_client` bug itself (cherry-picked from the still-open #758) and `qos_hex --features serde` standalone missing `serde/alloc`.