### PR TITLE
feat!: A small qos manifest builder api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2176,6 +2176,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-vsock",
  "webpki-roots",

--- a/src/qos_client/src/cli/services.rs
+++ b/src/qos_client/src/cli/services.rs
@@ -14,10 +14,10 @@ use qos_core::protocol::{
 	services::{
 		boot::{
 			Approval, BridgeConfig, DnsConfig, Manifest as ManifestV1,
+			ManifestBuilder, ManifestBuilderError,
 			ManifestEnvelope as ManifestEnvelopeV1, ManifestEnvelopeV0,
-			ManifestEnvelopeV2, ManifestSet, ManifestV2, ManifestVersion,
-			MemberPubKey, Namespace, NitroConfig, PatchSet,
-			PivotConfig as PivotConfigV1, PivotConfigV2, PivotEnv,
+			ManifestEnvelopeV2, ManifestSet, ManifestVersion, MemberPubKey,
+			Namespace, NitroConfig, PatchSet, PivotConfig as PivotConfigV1,
 			QuorumMember, RestartPolicy, ShareSet, VersionedManifest,
 			VersionedManifestEnvelope,
 		},
@@ -160,6 +160,10 @@ pub enum Error {
 	ManifestV1RequiresPatchSet,
 	/// v1/v0 manifests do not support DNS resolver configuration.
 	ManifestV1DoesNotSupportDnsConfig,
+	/// Failed to construct a manifest from the supplied configuration.
+	ManifestBuilder(ManifestBuilderError),
+	/// The manifest schema is not supported by this client operation.
+	UnsupportedManifestVersion,
 }
 
 impl From<serde_json::Error> for Error {
@@ -171,6 +175,12 @@ impl From<serde_json::Error> for Error {
 impl From<borsh::io::Error> for Error {
 	fn from(err: borsh::io::Error) -> Self {
 		Self::Deserialize(err.to_string())
+	}
+}
+
+impl From<ManifestBuilderError> for Error {
+	fn from(err: ManifestBuilderError) -> Self {
+		Self::ManifestBuilder(err)
 	}
 }
 
@@ -827,26 +837,23 @@ pub(crate) fn generate_manifest<P: AsRef<Path>>(
 	let quorum_key = P256Public::from_hex_file(&quorum_key_path)
 		.map_err(Error::FailedToReadQuorumPublicKey)?;
 
-	let manifest = ManifestV1 {
-		namespace: Namespace {
+	let manifest = ManifestBuilder::new()
+		.with_version(ManifestVersion::V1)
+		.namespace(Namespace {
 			name: namespace,
 			nonce,
 			quorum_key: quorum_key.to_bytes(),
-		},
-		pivot: PivotConfigV1 {
-			hash: pivot_hash.try_into().expect("pivot hash was not 256 bits"),
-			restart: restart_policy,
-			args: pivot_args,
-			bridge_config,
-			debug_mode,
-		},
-		manifest_set,
-		share_set,
-		patch_set,
-		enclave: nitro_config,
-	};
-
-	let manifest = VersionedManifest::V1(manifest);
+		})
+		.pivot_hash(pivot_hash.try_into().expect("pivot hash was not 256 bits"))
+		.restart_policy(restart_policy)
+		.pivot_args(pivot_args)
+		.bridge_config(bridge_config)
+		.debug_mode(debug_mode)
+		.manifest_set(manifest_set)
+		.share_set(share_set)
+		.patch_set(patch_set)
+		.enclave(nitro_config)
+		.build()?;
 	write_with_msg(
 		manifest_path.as_ref(),
 		&manifest.to_storage_vec().expect("failed to serialize manifest"),
@@ -889,26 +896,26 @@ pub(crate) fn generate_manifest_v2<P: AsRef<Path>>(
 	let quorum_key = P256Public::from_hex_file(&quorum_key_path)
 		.map_err(Error::FailedToReadQuorumPublicKey)?;
 
-	let manifest = ManifestV2 {
-		version: ManifestVersion::V2,
-		namespace: Namespace {
+	let manifest = ManifestBuilder::new()
+		.with_version(ManifestVersion::V2)
+		.namespace(Namespace {
 			name: namespace,
 			nonce,
 			quorum_key: quorum_key.to_bytes(),
-		},
-		pivot: PivotConfigV2 {
-			hash: pivot_hash.try_into().expect("pivot hash was not 256 bits"),
-			restart: restart_policy,
-			args: pivot_args,
-			env: PivotEnv::default(),
-			bridge_config,
-			debug_mode,
-		},
-		manifest_set,
-		share_set,
-		enclave: nitro_config,
-		dns: dns_resolvers.map(|resolvers| DnsConfig { resolvers }),
-	};
+		})
+		.pivot_hash(pivot_hash.try_into().expect("pivot hash was not 256 bits"))
+		.restart_policy(restart_policy)
+		.pivot_args(pivot_args)
+		.bridge_config(bridge_config)
+		.debug_mode(debug_mode)
+		.manifest_set(manifest_set)
+		.share_set(share_set)
+		.enclave(nitro_config);
+	let manifest = match dns_resolvers {
+		Some(resolvers) => manifest.dns(DnsConfig { resolvers }),
+		None => manifest,
+	}
+	.build()?;
 
 	write_with_msg(
 		manifest_path.as_ref(),
@@ -1068,6 +1075,10 @@ fn approve_manifest_programmatic_verifications(
 				return false;
 			}
 		}
+		_ => {
+			eprintln!("Manifest version is not supported");
+			return false;
+		}
 	}
 
 	// Verify pcrs 0, 1, 2, 3.
@@ -1177,6 +1188,7 @@ pub(crate) fn generate_manifest_envelope<P: AsRef<Path>>(
 				share_set_approvals: vec![],
 			})
 		}
+		_ => return Err(Error::UnsupportedManifestVersion),
 	};
 
 	if let Err(e) = manifest_envelope.check_approvals() {
@@ -2361,6 +2373,7 @@ fn read_manifest_v1_compat<P: AsRef<Path>>(
 		VersionedManifest::V2(_) => Err(Error::ManifestV2NotConvertibleToBorsh),
 		VersionedManifest::V1(manifest) => Ok(manifest),
 		VersionedManifest::V0(manifest) => Ok(manifest.into()),
+		_ => Err(Error::UnsupportedManifestVersion),
 	}
 }
 

--- a/src/qos_core/Cargo.toml
+++ b/src/qos_core/Cargo.toml
@@ -31,6 +31,7 @@ aws-nitro-enclaves-nsm-api = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true }
+thiserror = { workspace = true }
 zeroize = { workspace = true, features = ["alloc"] }
 
 futures = { workspace = true }

--- a/src/qos_core/src/protocol/services/boot.rs
+++ b/src/qos_core/src/protocol/services/boot.rs
@@ -20,7 +20,8 @@ pub use manifest::v2::{
 	DnsConfig, ManifestEnvelopeV2, ManifestV2, PivotConfigV2,
 };
 pub use manifest::{
-	ManifestVersion, VersionedManifest, VersionedManifestEnvelope,
+	ManifestBuilder, ManifestBuilderError, ManifestVersion, VersionedManifest,
+	VersionedManifestEnvelope,
 };
 
 /// Enclave configuration specific to AWS Nitro.

--- a/src/qos_core/src/protocol/services/boot/manifest.rs
+++ b/src/qos_core/src/protocol/services/boot/manifest.rs
@@ -13,17 +13,30 @@ use super::{
 	ManifestSet, ManifestV0, Namespace, NitroConfig, RestartPolicy, ShareSet,
 };
 
+mod builder;
 pub mod v2;
 
+pub use builder::{ManifestBuilder, ManifestBuilderError};
 pub use v2::{DnsConfig, ManifestEnvelopeV2, ManifestV2};
 
-/// Schema marker included only in v2 manifests.
+/// Schema version used by versioned manifest tooling.
 #[derive(
-	PartialEq, Eq, Debug, Clone, Copy, serde::Serialize, serde::Deserialize,
+	PartialEq,
+	Eq,
+	Debug,
+	Clone,
+	Copy,
+	Default,
+	serde::Serialize,
+	serde::Deserialize,
 )]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub enum ManifestVersion {
+	/// Backwards-compatible manifest schema.
+	V1,
 	/// Explicitly versioned JSON manifest schema.
+	#[default]
 	V2,
 }
 
@@ -41,6 +54,7 @@ pub fn canonical_json_hash<T: serde::Serialize>(value: &T) -> Hash256 {
 /// A manifest decoded with schema version preserved.
 #[derive(PartialEq, Eq, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum VersionedManifest {
 	/// Explicitly versioned JSON manifest schema.
 	V2(ManifestV2),

--- a/src/qos_core/src/protocol/services/boot/manifest/builder.rs
+++ b/src/qos_core/src/protocol/services/boot/manifest/builder.rs
@@ -1,7 +1,5 @@
 //! Builder for v2 manifests.
 
-use std::{error::Error, fmt};
-
 use crate::protocol::{
 	Hash256,
 	services::boot::{
@@ -13,59 +11,36 @@ use crate::protocol::{
 use super::{DnsConfig, ManifestV2, ManifestVersion, VersionedManifest};
 
 /// An error returned when a required manifest value was not provided.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum ManifestBuilderError {
 	/// The manifest namespace was not provided.
+	#[error("missing required manifest field: namespace")]
 	MissingNamespace,
 	/// The pivot binary hash was not provided.
+	#[error("missing required manifest field: pivot hash")]
 	MissingPivotHash,
 	/// The manifest approval set was not provided.
+	#[error("missing required manifest field: manifest set")]
 	MissingManifestSet,
 	/// The share approval set was not provided.
+	#[error("missing required manifest field: share set")]
 	MissingShareSet,
 	/// The enclave configuration was not provided.
+	#[error("missing required manifest field: enclave configuration")]
 	MissingEnclave,
 	/// The patch approval set was not provided for a v1 manifest.
+	#[error("missing required manifest field: patch set")]
 	MissingPatchSet,
 	/// A v1 manifest cannot contain pivot environment configuration.
+	#[error("manifest v1 does not support pivot environment configuration")]
 	V1DoesNotSupportPivotEnv,
 	/// A v1 manifest cannot contain DNS configuration.
+	#[error("manifest v1 does not support DNS configuration")]
 	V1DoesNotSupportDns,
 	/// A v2 manifest cannot contain a patch approval set.
+	#[error("manifest v2 does not support a patch set")]
 	V2DoesNotSupportPatchSet,
 }
-
-impl fmt::Display for ManifestBuilderError {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		let field = match self {
-			Self::MissingNamespace => "namespace",
-			Self::MissingPivotHash => "pivot hash",
-			Self::MissingManifestSet => "manifest set",
-			Self::MissingShareSet => "share set",
-			Self::MissingEnclave => "enclave configuration",
-			Self::MissingPatchSet => "patch set",
-			Self::V1DoesNotSupportPivotEnv => {
-				return write!(
-					f,
-					"manifest v1 does not support pivot environment configuration"
-				);
-			}
-			Self::V1DoesNotSupportDns => {
-				return write!(
-					f,
-					"manifest v1 does not support DNS configuration"
-				);
-			}
-			Self::V2DoesNotSupportPatchSet => {
-				return write!(f, "manifest v2 does not support a patch set");
-			}
-		};
-
-		write!(f, "missing required manifest field: {field}")
-	}
-}
-
-impl Error for ManifestBuilderError {}
 
 /// Builds a versioned manifest using either the v1 or v2 schema.
 ///
@@ -115,6 +90,18 @@ impl ManifestBuilder {
 			patch_set: None,
 			dns: None,
 		}
+	}
+
+	/// Create an empty v1 manifest builder.
+	#[must_use]
+	pub fn v1() -> Self {
+		Self::new().with_version(ManifestVersion::V1)
+	}
+
+	/// Create an empty v2 manifest builder.
+	#[must_use]
+	pub fn v2() -> Self {
+		Self::new().with_version(ManifestVersion::V2)
 	}
 
 	/// Select the manifest schema version to build.

--- a/src/qos_core/src/protocol/services/boot/manifest/builder.rs
+++ b/src/qos_core/src/protocol/services/boot/manifest/builder.rs
@@ -1,0 +1,294 @@
+//! Builder for v2 manifests.
+
+use std::{error::Error, fmt};
+
+use crate::protocol::{
+	Hash256,
+	services::boot::{
+		BridgeConfig, Manifest, ManifestSet, Namespace, NitroConfig, PatchSet,
+		PivotConfig, PivotConfigV2, PivotEnv, RestartPolicy, ShareSet,
+	},
+};
+
+use super::{DnsConfig, ManifestV2, ManifestVersion, VersionedManifest};
+
+/// An error returned when a required manifest value was not provided.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ManifestBuilderError {
+	/// The manifest namespace was not provided.
+	MissingNamespace,
+	/// The pivot binary hash was not provided.
+	MissingPivotHash,
+	/// The manifest approval set was not provided.
+	MissingManifestSet,
+	/// The share approval set was not provided.
+	MissingShareSet,
+	/// The enclave configuration was not provided.
+	MissingEnclave,
+	/// The patch approval set was not provided for a v1 manifest.
+	MissingPatchSet,
+	/// A v1 manifest cannot contain pivot environment configuration.
+	V1DoesNotSupportPivotEnv,
+	/// A v1 manifest cannot contain DNS configuration.
+	V1DoesNotSupportDns,
+	/// A v2 manifest cannot contain a patch approval set.
+	V2DoesNotSupportPatchSet,
+}
+
+impl fmt::Display for ManifestBuilderError {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		let field = match self {
+			Self::MissingNamespace => "namespace",
+			Self::MissingPivotHash => "pivot hash",
+			Self::MissingManifestSet => "manifest set",
+			Self::MissingShareSet => "share set",
+			Self::MissingEnclave => "enclave configuration",
+			Self::MissingPatchSet => "patch set",
+			Self::V1DoesNotSupportPivotEnv => {
+				return write!(
+					f,
+					"manifest v1 does not support pivot environment configuration"
+				);
+			}
+			Self::V1DoesNotSupportDns => {
+				return write!(
+					f,
+					"manifest v1 does not support DNS configuration"
+				);
+			}
+			Self::V2DoesNotSupportPatchSet => {
+				return write!(f, "manifest v2 does not support a patch set");
+			}
+		};
+
+		write!(f, "missing required manifest field: {field}")
+	}
+}
+
+impl Error for ManifestBuilderError {}
+
+/// Builds a versioned manifest using either the v1 or v2 schema.
+///
+/// Identity and trust inputs are required. Runtime options use conservative
+/// defaults when omitted: the pivot is never restarted, bridge rules and
+/// arguments are empty, debug mode is disabled, the environment is empty,
+/// and DNS is not configured.
+#[derive(Debug, Clone)]
+pub struct ManifestBuilder {
+	version: Option<ManifestVersion>,
+	namespace: Option<Namespace>,
+	pivot_hash: Option<Hash256>,
+	restart_policy: Option<RestartPolicy>,
+	bridge_config: Option<Vec<BridgeConfig>>,
+	debug_mode: Option<bool>,
+	pivot_args: Option<Vec<String>>,
+	pivot_env: Option<PivotEnv>,
+	manifest_set: Option<ManifestSet>,
+	share_set: Option<ShareSet>,
+	enclave: Option<NitroConfig>,
+	patch_set: Option<PatchSet>,
+	dns: Option<DnsConfig>,
+}
+
+impl Default for ManifestBuilder {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+impl ManifestBuilder {
+	/// Create an empty v2 manifest builder.
+	#[must_use]
+	pub fn new() -> Self {
+		Self {
+			version: None,
+			namespace: None,
+			pivot_hash: None,
+			restart_policy: None,
+			bridge_config: None,
+			debug_mode: None,
+			pivot_args: None,
+			pivot_env: None,
+			manifest_set: None,
+			share_set: None,
+			enclave: None,
+			patch_set: None,
+			dns: None,
+		}
+	}
+
+	/// Select the manifest schema version to build.
+	#[must_use]
+	pub fn with_version(mut self, version: ManifestVersion) -> Self {
+		self.version = Some(version);
+		self
+	}
+
+	/// Set the namespace configuration.
+	#[must_use]
+	pub fn namespace(mut self, namespace: Namespace) -> Self {
+		self.namespace = Some(namespace);
+		self
+	}
+
+	/// Set the pivot binary hash.
+	#[must_use]
+	pub fn pivot_hash(mut self, pivot_hash: Hash256) -> Self {
+		self.pivot_hash = Some(pivot_hash);
+		self
+	}
+
+	/// Set the pivot restart policy.
+	#[must_use]
+	pub fn restart_policy(mut self, restart_policy: RestartPolicy) -> Self {
+		self.restart_policy = Some(restart_policy);
+		self
+	}
+
+	/// Set the pivot bridge rules.
+	#[must_use]
+	pub fn bridge_config(mut self, bridge_config: Vec<BridgeConfig>) -> Self {
+		self.bridge_config = Some(bridge_config);
+		self
+	}
+
+	/// Set whether the pivot runs in debug mode.
+	#[must_use]
+	pub fn debug_mode(mut self, debug_mode: bool) -> Self {
+		self.debug_mode = Some(debug_mode);
+		self
+	}
+
+	/// Set the arguments passed to the pivot binary.
+	#[must_use]
+	pub fn pivot_args(mut self, pivot_args: Vec<String>) -> Self {
+		self.pivot_args = Some(pivot_args);
+		self
+	}
+
+	/// Set the environment passed to the pivot binary.
+	#[must_use]
+	pub fn pivot_env(mut self, pivot_env: PivotEnv) -> Self {
+		self.pivot_env = Some(pivot_env);
+		self
+	}
+
+	/// Set the manifest approval set.
+	#[must_use]
+	pub fn manifest_set(mut self, manifest_set: ManifestSet) -> Self {
+		self.manifest_set = Some(manifest_set);
+		self
+	}
+
+	/// Set the share approval set.
+	#[must_use]
+	pub fn share_set(mut self, share_set: ShareSet) -> Self {
+		self.share_set = Some(share_set);
+		self
+	}
+
+	/// Set the enclave configuration.
+	#[must_use]
+	pub fn enclave(mut self, enclave: NitroConfig) -> Self {
+		self.enclave = Some(enclave);
+		self
+	}
+
+	/// Set the patch approval set required by v1 manifests.
+	#[must_use]
+	pub fn patch_set(mut self, patch_set: PatchSet) -> Self {
+		self.patch_set = Some(patch_set);
+		self
+	}
+
+	/// Set the DNS configuration.
+	#[must_use]
+	pub fn dns(mut self, dns: DnsConfig) -> Self {
+		self.dns = Some(dns);
+		self
+	}
+
+	/// Build the manifest in its version-preserving wrapper.
+	///
+	/// # Errors
+	///
+	/// Returns [`ManifestBuilderError`] when required configuration is omitted
+	/// or supplied for an incompatible schema.
+	pub fn build(self) -> Result<VersionedManifest, ManifestBuilderError> {
+		let namespace =
+			self.namespace.ok_or(ManifestBuilderError::MissingNamespace)?;
+		let pivot_hash =
+			self.pivot_hash.ok_or(ManifestBuilderError::MissingPivotHash)?;
+		let manifest_set = self
+			.manifest_set
+			.ok_or(ManifestBuilderError::MissingManifestSet)?;
+		let share_set =
+			self.share_set.ok_or(ManifestBuilderError::MissingShareSet)?;
+		let enclave =
+			self.enclave.ok_or(ManifestBuilderError::MissingEnclave)?;
+
+		let restart = self.restart_policy.unwrap_or(RestartPolicy::Never);
+		let bridge_config = self.bridge_config.unwrap_or_default();
+		let debug_mode = self.debug_mode.unwrap_or(false);
+		let args = self.pivot_args.unwrap_or_default();
+
+		match self.version.unwrap_or_default() {
+			ManifestVersion::V1 => {
+				if self.pivot_env.is_some() {
+					return Err(ManifestBuilderError::V1DoesNotSupportPivotEnv);
+				}
+				if self.dns.is_some() {
+					return Err(ManifestBuilderError::V1DoesNotSupportDns);
+				}
+				let patch_set = self
+					.patch_set
+					.ok_or(ManifestBuilderError::MissingPatchSet)?;
+
+				Ok(VersionedManifest::V1(Manifest {
+					namespace,
+					pivot: PivotConfig {
+						hash: pivot_hash,
+						restart,
+						bridge_config,
+						debug_mode,
+						args,
+					},
+					manifest_set,
+					share_set,
+					enclave,
+					patch_set,
+				}))
+			}
+			ManifestVersion::V2 => {
+				if self.patch_set.is_some() {
+					return Err(ManifestBuilderError::V2DoesNotSupportPatchSet);
+				}
+
+				Ok(VersionedManifest::V2(ManifestV2 {
+					version: ManifestVersion::V2,
+					namespace,
+					pivot: PivotConfigV2 {
+						hash: pivot_hash,
+						restart,
+						bridge_config,
+						debug_mode,
+						args,
+						env: self.pivot_env.unwrap_or_default(),
+					},
+					manifest_set,
+					share_set,
+					enclave,
+					dns: self.dns,
+				}))
+			}
+		}
+	}
+}
+
+impl TryFrom<ManifestBuilder> for VersionedManifest {
+	type Error = ManifestBuilderError;
+
+	fn try_from(builder: ManifestBuilder) -> Result<Self, Self::Error> {
+		builder.build()
+	}
+}


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

This is a pretty simple change I am just implementing the builder pattern for manifests and using it in qos client.
I want this for the testing lib and tvc cli.

Think flat nullable map -> structured types that's all this code is.

## How I Tested These Changes

I did not, in fact I deleted the tests that codex wrote.

## Pre merge check list

- [x] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
