### PR TITLE
fix(deps): dependabot remediation 2026-07-18 (tkhq/qos)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2529,13 +2529,13 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.3.1"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
+checksum = "f3bc4a3dd492cd6974dd3f32d6626ba9f36e5122e3df3b083474b104aebd139b"
 dependencies = [
  "libc",
  "rtoolbox",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3727,6 +3727,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]


### PR DESCRIPTION
Auto-opened by the Dependabot remediation workflow.

## rpassword 7.3.1 → 7.5.0 (lockfile-only)

Covers alerts:
- [#107](https://github.com/tkhq/qos/security/dependabot/107) (`Cargo.lock`)

Advisory: [GHSA-2p6r-x3vv-xqm2](https://github.com/advisories/GHSA-2p6r-x3vv-xqm2) — low severity (CVSS 3.8)

Actual severity: **low** · Complexity: **trivial** · Score: **80**

### What changed

v7.3.1 → v7.5.0 patches [CVE-2025-64170](https://nvd.nist.gov/vuln/detail/CVE-2025-64170): a partial password reveal when the input reading process is killed mid-input (e.g. `SIGKILL`). Fixed by ensuring the terminal input buffer is fully zeroed before yielding. Fully backwards-compatible per upstream release notes: adds new `read_password_with_config(...)` / `ConfigBuilder` APIs and deprecates (but does not remove) `_from_bufread` variants. Also bumps Rust edition to 2024 and updates the `windows-sys` transitive.

### Reachability

qos_client uses rpassword for interactive password prompts. The vulnerable code path requires an attacker to interrupt the process (e.g. `SIGKILL`) at the exact moment the user is mid-input, and to have local access to inspect the resulting terminal state. Low practical risk in operator workflows; taking the patch as defense-in-depth.

### Required by upstream

- `windows-sys` 0.48.0 → 0.61.2 (rpassword 7.5.0's Windows binding; reuses existing `windows-link 0.2.1` already in the lockfile — no new transitive)

`rtoolbox` remains at 0.0.2 (unchanged — rpassword 7.5.0 still depends on the same version).

### Note on bot PR #698

Renovate opened a parallel PR (#698) doing the same bump. Per the Dependabot remediation workflow (§3, revised 2026-07-17), bot PRs are no longer counted as coverage — this PR is opened as our own. Reviewers may close whichever duplicate is not preferred.

<!-- dependabot-remediation-workflow:v1 -->