### PR TITLE
fix(qos_net): pin LookupIpStrategy to Ipv4thenIpv6 (hickory 0.26 default regression)

### DIFF
--- a/src/qos_net/src/proxy_connection.rs
+++ b/src/qos_net/src/proxy_connection.rs
@@ -10,7 +10,8 @@ use std::{
 use hickory_resolver::{
 	TokioResolver,
 	config::{
-		ConnectionConfig, NameServerConfig, ResolverConfig, ResolverOpts,
+		ConnectionConfig, LookupIpStrategy, NameServerConfig, ResolverConfig,
+		ResolverOpts,
 	},
 	net::runtime::TokioRuntimeProvider,
 };
@@ -193,6 +194,9 @@ fn build_resolver(
 	resolver_opts.attempts = 1;
 	// Clamp long-lived records so cached answers do not stay stale too long.
 	resolver_opts.positive_max_ttl = Some(Duration::from_secs(300));
+	// Currently we only check the first address and downstream code assumes its Ipv4;
+	// this setting ensures that the resolver always resolves an Ipv4 address first.
+	resolver_opts.ip_strategy = LookupIpStrategy::Ipv4thenIpv6;
 
 	TokioResolver::builder_with_config(
 		resolver_config,
@@ -287,5 +291,6 @@ mod test {
 		assert_eq!(opts.timeout, Duration::from_secs(1));
 		assert_eq!(opts.attempts, 1);
 		assert_eq!(opts.positive_max_ttl, Some(Duration::from_secs(300)));
+		assert_eq!(opts.ip_strategy, LookupIpStrategy::Ipv4thenIpv6);
 	}
 }


### PR DESCRIPTION
## Summary

qos net `ProxyStream::connect_by_name` failed to connect to dual-stack hostnames with errno 101 `NetworkUnreachable`

## Mechanism

- PR #691 bumped hickory-resolver 0.25.2 → 0.26.1 (shipped in qos_net 0.12.1).
- hickory 0.26 changed the default [`LookupIpStrategy`](https://docs.rs/hickory-resolver/0.26.1/hickory_resolver/config/enum.LookupIpStrategy.html) from `Ipv4thenIpv6` to `Ipv6AndIpv4`, which queries AAAA+A in parallel and orders AAAA records first.
- qos_net's `resolve_hostname` takes exactly one IP (`response.iter().next()`) and `ProxyConnection::new_from_name` connects to it with **no fallback**.
- On IPv4-only hosts (Turnkey tls_fetcher proxy pods), dual-stack hostnames now resolve to an IPv6 address first → `TcpStream::connect` fails with `NetworkUnreachable`.

## Fix

Explicitly set `resolver_opts.ip_strategy = LookupIpStrategy::Ipv4thenIpv6` in `build_resolver`, restoring the pre-0.26 behavior (prefer A records). One-line fix plus a comment explaining why, and a test assertion pinning the strategy so a future default change can't silently regress this again.

## Potential follow up work

A more robust fix would be multi-IP connect fallback: iterate all resolved IPs (IPv4 first) in `new_from_name` and try each until one connects, instead of connecting to only the first resolved address.
