### PR TITLE
Emit qos_enclave logs as JSON

### DIFF
--- a/src/init/Cargo.lock
+++ b/src/init/Cargo.lock
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "qos_core"
-version = "0.10.0"
+version = "0.13.0"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "borsh",
@@ -1213,6 +1213,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "thiserror",
  "tokio",
  "tokio-vsock",
  "zeroize",
@@ -1220,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "qos_crypto"
-version = "0.10.0"
+version = "0.13.0"
 dependencies = [
  "rand 0.9.4",
  "sha2",
@@ -1231,14 +1232,14 @@ dependencies = [
 
 [[package]]
 name = "qos_hex"
-version = "0.10.0"
+version = "0.13.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "qos_json"
-version = "0.10.0"
+version = "0.13.0"
 dependencies = [
  "qos_hex",
  "serde",
@@ -1248,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "qos_nsm"
-version = "0.10.0"
+version = "0.13.0"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "aws-nitro-enclaves-nsm-api",
@@ -1265,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "qos_p256"
-version = "0.10.0"
+version = "0.13.0"
 dependencies = [
  "aes-gcm",
  "borsh",

--- a/src/qos_enclave/Cargo.lock
+++ b/src/qos_enclave/Cargo.lock
@@ -1837,7 +1837,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1869,6 +1869,15 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -2200,6 +2209,9 @@ version = "1.2.0"
 dependencies = [
  "libc",
  "nitro-cli",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2639,6 +2651,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2824,6 +2845,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2956,9 +2986,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -2967,9 +2997,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2978,11 +3008,40 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -3049,6 +3108,12 @@ name = "uuid"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/src/qos_enclave/Cargo.toml
+++ b/src/qos_enclave/Cargo.toml
@@ -13,6 +13,11 @@ publish = false
 # The pinned commit corresponds to tag "v1.4.3" after https://github.com/aws/aws-nitro-enclaves-cli/issues/705
 nitro-cli = { git = "https://github.com/aws/aws-nitro-enclaves-cli", rev = "82501bb9637e4b41c87ce73f8ffc2ce51ca37a6a" }
 libc = "=0.2.174"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "json", "fmt"] }
+
+[dev-dependencies]
+serde_json = "1"
 
 [features]
 default = []

--- a/src/qos_enclave/src/main.rs
+++ b/src/qos_enclave/src/main.rs
@@ -1,7 +1,6 @@
 use std::{
 	fs::create_dir_all,
-	io::Write,
-	io::stdout,
+	io::{self, Write},
 	mem::MaybeUninit,
 	net::{Shutdown, TcpListener},
 	os::unix::net::UnixStream,
@@ -30,8 +29,64 @@ use nitro_cli::{
 	get_id_by_name,
 	utils::Console,
 };
+use tracing::{error, info};
+use tracing_subscriber::EnvFilter;
 
 const RUN_ENCLAVE_STR: &str = "Run Enclave";
+
+fn init_tracing() {
+	let env_filter = EnvFilter::try_from_default_env()
+		.unwrap_or_else(|_| EnvFilter::new("info"));
+	tracing_subscriber::fmt()
+		.json()
+		.with_env_filter(env_filter)
+		.with_writer(io::stdout)
+		.init();
+}
+
+#[derive(Default)]
+struct TracingLogWriter {
+	buffer: Vec<u8>,
+}
+
+impl TracingLogWriter {
+	fn emit_line(line: &[u8]) {
+		let line = String::from_utf8_lossy(line);
+		let line = line.trim_end_matches('\r');
+		if !line.is_empty() {
+			info!(target: "qos_enclave::console", "{}", line);
+		}
+	}
+}
+
+impl Write for TracingLogWriter {
+	fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+		self.buffer.extend_from_slice(buf);
+
+		let mut consumed = 0;
+		while let Some(newline_offset) =
+			self.buffer[consumed..].iter().position(|byte| *byte == b'\n')
+		{
+			let newline_index = consumed + newline_offset;
+			Self::emit_line(&self.buffer[consumed..newline_index]);
+			consumed = newline_index + 1;
+		}
+
+		if consumed > 0 {
+			self.buffer.drain(..consumed);
+		}
+
+		Ok(buf.len())
+	}
+
+	fn flush(&mut self) -> io::Result<()> {
+		if !self.buffer.is_empty() {
+			Self::emit_line(&self.buffer);
+			self.buffer.clear();
+		}
+		Ok(())
+	}
+}
 
 fn healthy() -> Result<(), Box<dyn std::error::Error>> {
 	let mut replies: Vec<UnixStream> = vec![];
@@ -93,7 +148,7 @@ fn boot() -> (String, Option<Console>) {
 		cpu_count: Some(cpu_count.parse::<u32>().unwrap()),
 		enclave_name: Some(enclave_name.clone()),
 	};
-	println!("{:?}", run_args);
+	info!(?run_args, "Run enclave arguments");
 
 	// Socket directory must exist or Nitro SDK crashes with generic error
 	if !Path::new("/run/nitro_enclaves").is_dir() {
@@ -172,8 +227,8 @@ fn boot() -> (String, Option<Console>) {
 }
 
 fn shutdown(enclave_id: String, sig_num: i32) {
-	println!("Got signal: {}", sig_num);
-	println!("Shutting down Enclave");
+	info!(sig_num, "Got signal");
+	info!("Shutting down Enclave");
 
 	// Best-effort graceful Terminate: if the EnclaveProc IPC socket is
 	// unreachable (e.g. the proc has already exited, or the socket is
@@ -194,9 +249,9 @@ fn shutdown(enclave_id: String, sig_num: i32) {
 			.map_err(|_| "Unable to terminate Enclave");
 		}
 		Err(_) => {
-			eprintln!(
-				"Failed to connect to EnclaveProc for {}; skipping graceful Terminate",
-				enclave_id
+			error!(
+				%enclave_id,
+				"Failed to connect to EnclaveProc; skipping graceful Terminate",
 			);
 		}
 	}
@@ -205,7 +260,7 @@ fn shutdown(enclave_id: String, sig_num: i32) {
 }
 
 fn health_service() {
-	println!("Starting health service");
+	info!("Starting health service");
 	let listener = TcpListener::bind("0.0.0.0:8080").unwrap();
 	for stream in listener.incoming() {
 		thread::spawn(move || {
@@ -217,8 +272,8 @@ fn health_service() {
 				_ => &unhealthy_resp[..],
 			};
 			match stream.write_all(response) {
-				Ok(_) => println!("Health response sent"),
-				Err(e) => println!("Failed sending health response: {}!", e),
+				Ok(_) => info!("Health response sent"),
+				Err(e) => error!(error = %e, "Failed sending health response"),
 			};
 			stream.shutdown(Shutdown::Write).unwrap();
 		});
@@ -239,19 +294,22 @@ fn handle_signals() -> c_int {
 }
 
 fn read_logs(console: Console) {
-	println!("Reading logs to stdout");
+	info!("Reading logs to stdout");
 	let disconnect_timeout_sec: Option<u64> = None;
-	let _ = console.read_to(stdout().by_ref(), disconnect_timeout_sec);
+	let mut writer = TracingLogWriter::default();
+	let _ = console.read_to(&mut writer, disconnect_timeout_sec);
+	let _ = writer.flush();
 }
 
 fn main() {
-	println!("Booting Nitro Enclave:");
+	init_tracing();
+	info!("Booting Nitro Enclave");
 
 	let (enclave_id, maybe_console) = boot();
 
 	match healthy() {
-		Ok(_) => println!("Enclave is healthy"),
-		Err(e) => eprintln!("Enclave is sad: {}", e),
+		Ok(_) => info!("Enclave is healthy"),
+		Err(e) => error!(error = %e, "Enclave is sad"),
 	};
 
 	// TODO: return listener so shutdown() can clean it up properly
@@ -268,4 +326,118 @@ fn main() {
 	let sig_num = handle_signals();
 
 	shutdown(enclave_id.clone(), sig_num);
+}
+
+#[cfg(test)]
+mod tests {
+	use std::{
+		io::{self, Write},
+		sync::{Arc, Mutex},
+	};
+
+	use serde_json::Value;
+	use tracing_subscriber::{EnvFilter, fmt::MakeWriter};
+
+	#[derive(Clone, Default)]
+	struct CapturedOutput(Arc<Mutex<Vec<u8>>>);
+
+	impl Write for CapturedOutput {
+		fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+			self.0.lock().unwrap().write(buf)
+		}
+
+		fn flush(&mut self) -> io::Result<()> {
+			self.0.lock().unwrap().flush()
+		}
+	}
+
+	impl<'writer> MakeWriter<'writer> for CapturedOutput {
+		type Writer = CapturedOutput;
+
+		fn make_writer(&'writer self) -> Self::Writer {
+			self.clone()
+		}
+	}
+
+	fn capture_console_logs(chunks: &[&[u8]], flush: bool) -> Vec<Value> {
+		let writer = CapturedOutput::default();
+		let subscriber = tracing_subscriber::fmt()
+			.json()
+			.with_env_filter(EnvFilter::new("info"))
+			.with_writer(writer.clone())
+			.finish();
+
+		tracing::subscriber::with_default(subscriber, || {
+			let mut console_writer = super::TracingLogWriter::default();
+			for chunk in chunks {
+				console_writer.write_all(chunk).unwrap();
+			}
+			if flush {
+				console_writer.flush().unwrap();
+			}
+		});
+
+		let output =
+			String::from_utf8(writer.0.lock().unwrap().clone()).unwrap();
+		output
+			.lines()
+			.map(|line| serde_json::from_str::<Value>(line).unwrap())
+			.collect()
+	}
+
+	fn messages(logs: &[Value]) -> Vec<&str> {
+		logs.iter()
+			.map(|log| log["fields"]["message"].as_str().unwrap())
+			.collect()
+	}
+
+	#[test]
+	fn tracing_subscriber_emits_json_logs() {
+		let writer = CapturedOutput::default();
+		let subscriber = tracing_subscriber::fmt()
+			.json()
+			.with_env_filter(EnvFilter::new("info"))
+			.with_writer(writer.clone())
+			.finish();
+
+		tracing::subscriber::with_default(subscriber, || {
+			tracing::info!(enclave_id = "nitro", "Enclave is healthy");
+		});
+
+		let output =
+			String::from_utf8(writer.0.lock().unwrap().clone()).unwrap();
+		let log: Value = serde_json::from_str(output.trim()).unwrap();
+
+		assert_eq!(log["level"], "INFO");
+		assert_eq!(log["fields"]["message"], "Enclave is healthy");
+		assert_eq!(log["fields"]["enclave_id"], "nitro");
+	}
+
+	#[test]
+	fn console_log_writer_emits_one_json_log_per_line() {
+		let logs = capture_console_logs(&[b"first\nsecond\n"], false);
+
+		assert_eq!(logs.len(), 2);
+		assert_eq!(logs[0]["fields"]["message"], "first");
+		assert_eq!(logs[1]["fields"]["message"], "second");
+	}
+
+	#[test]
+	fn console_log_writer_handles_arbitrary_write_boundaries() {
+		let input = b"first\nsecond\r\n\nthird";
+
+		for chunk_size in 1..=input.len() {
+			let chunks = input.chunks(chunk_size).collect::<Vec<_>>();
+			let logs = capture_console_logs(&chunks, true);
+			assert_eq!(messages(&logs), ["first", "second", "third"]);
+		}
+	}
+
+	#[test]
+	fn console_log_writer_buffers_incomplete_line_until_flush() {
+		assert!(capture_console_logs(&[b"partial"], false).is_empty());
+
+		let logs = capture_console_logs(&[b"partial"], true);
+		assert_eq!(messages(&logs), ["partial"]);
+	}
 }

--- a/src/qos_enclave/src/main.rs
+++ b/src/qos_enclave/src/main.rs
@@ -44,12 +44,29 @@ fn init_tracing() {
 		.init();
 }
 
+/// A [`Write`] sink that adapts the enclave's serial console output into the
+/// host's structured JSON log stream.
+///
+/// Unlike `qos_enclave`'s own `info!`/`error!` events (emitted straight to JSON
+/// by the subscriber, see [`init_tracing`]), this handles a *foreign* source:
+/// the raw plain-text bytes read off the Nitro serial console via
+/// `Console::read_to` — kernel/init/NSM/app output. It only runs when `LOGS`
+/// attaches the console, and Nitro only emits console output in debug mode
+/// (`DEBUG`), so this is a diagnostics path, not a production-hot one.
+///
+/// We re-emit each console line as a JSON event (`target: "qos_enclave::console"`)
+/// rather than forwarding raw bytes, which would interleave non-JSON text with
+/// the host's JSON events and break Grafana's parser. Framing is line-based
+/// because the newline is the **only** delimiter a raw console stream offers (a
+/// multi-line message thus fragments into several events, as with any log
+/// shipper). Bytes without a trailing newline are buffered until the next
+/// `write` completes the line, or until `flush` emits the remainder.
 #[derive(Default)]
-struct TracingLogWriter {
+struct EnclaveConsoleWriter {
 	buffer: Vec<u8>,
 }
 
-impl TracingLogWriter {
+impl EnclaveConsoleWriter {
 	fn emit_line(line: &[u8]) {
 		let line = String::from_utf8_lossy(line);
 		let line = line.trim_end_matches('\r');
@@ -59,7 +76,7 @@ impl TracingLogWriter {
 	}
 }
 
-impl Write for TracingLogWriter {
+impl Write for EnclaveConsoleWriter {
 	fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
 		self.buffer.extend_from_slice(buf);
 
@@ -296,7 +313,7 @@ fn handle_signals() -> c_int {
 fn read_logs(console: Console) {
 	info!("Reading logs to stdout");
 	let disconnect_timeout_sec: Option<u64> = None;
-	let mut writer = TracingLogWriter::default();
+	let mut writer = EnclaveConsoleWriter::default();
 	let _ = console.read_to(&mut writer, disconnect_timeout_sec);
 	let _ = writer.flush();
 }
@@ -368,7 +385,7 @@ mod tests {
 			.finish();
 
 		tracing::subscriber::with_default(subscriber, || {
-			let mut console_writer = super::TracingLogWriter::default();
+			let mut console_writer = super::EnclaveConsoleWriter::default();
 			for chunk in chunks {
 				console_writer.write_all(chunk).unwrap();
 			}


### PR DESCRIPTION
## Summary
- Emit qos_enclave-owned logs through tracing_subscriber JSON formatting
- Preserve RUST_LOG/env-filter support with an info default
- Convert attached enclave console output into one JSON log event per input line

Linear: [TVC-205](https://linear.app/turnkey/issue/TVC-205/json-delimit-qos-enclave-logs-for-grafana)

## Validation
- cargo test --manifest-path src/qos_enclave/Cargo.toml
- cargo build --manifest-path src/qos_enclave/Cargo.toml
- TODO - deploy in `dev` and see the new logs emit correctly AND be queryable in Grafana - waiting on [Arnaud's work with qos](https://turnkeycrypto.slack.com/archives/C0AV0DWDJP2/p1784749208038789?thread_ts=1784746167.332819&cid=C0AV0DWDJP2)

AI text below: 
___
## Log flow

Two log sources converge at a single tracing subscriber, which formats every
event as JSON and writes it to `io::stdout`. `EnclaveConsoleWriter` is not a
sink — it sits *upstream* of the subscriber, lifting the enclave's raw serial
console bytes into the same event pipeline the host's own logs use, so
everything comes out as one uniform JSON stream.

```
  host's own events         info!("Booting…"), error!(…)          target = "qos_enclave"
  (app / system logs) ──────────────────────────────────────┐
                                                             │
                                                             ▼
                                              ┌───────────────────────────────┐
                                              │  tracing_subscriber            │
                                              │  .json().with_writer(stdout)   │──► io::stdout
                                              └───────────────────────────────┘
                                                             ▲
  guest serial console                                       │
  (kernel/init/NSM/app) ──► EnclaveConsoleWriter ── info!(target:"qos_enclave::console", line) ┘
                             (splits bytes into
                              lines, re-emits each
                              as a tracing event)
```

The app-vs-system distinction is carried by the `target` field, not by which
component logs drain into:

- Host's own logs → default target `qos_enclave` (the module path)
- Guest console lines → explicit target `qos_enclave::console`

That `target` split is the axis Grafana uses to separate qos_enclave's own
app/system logs from the enclave's forwarded console output.

Notes:
- The guest serial console path (`EnclaveConsoleWriter`) only runs when the
  `LOGS` env var attaches the console, and the Nitro serial console only emits
  output for enclaves booted in debug mode (`DEBUG`) — so it's a diagnostics
  path, not a production-hot one.
- Because console lines are re-emitted via `info!`, each line gets the host's
  timestamp/level wrapped around it and the original text lands in the
  `message` field. Line-based framing is used because the newline is the only
  delimiter available in a raw console byte stream.
