### PR TITLE
fix(qos_enclave): close leaked Nitro CLI communication descriptors

### DIFF
--- a/src/images/qos_enclave/Containerfile
+++ b/src/images/qos_enclave/Containerfile
@@ -78,6 +78,8 @@ FROM scratch AS package
 COPY --from=build-eif /nitro.eif .
 COPY --from=build-eif /nitro.pcrs .
 COPY --from=build-qos_enclave /qos_enclave .
+COPY src/qos_enclave/LICENSES/Apache-2.0.txt /licenses/Apache-2.0.txt
+COPY src/qos_enclave/NOTICE /licenses/qos_enclave-NOTICE
 ENTRYPOINT ["/qos_enclave"]
 ENV EIF_PATH=/nitro.eif
 ENV ENCLAVE_NAME=qos

--- a/src/images/qos_enclave_egress/Containerfile
+++ b/src/images/qos_enclave_egress/Containerfile
@@ -95,6 +95,8 @@ FROM scratch AS package
 COPY --from=build-eif /nitro.eif .
 COPY --from=build-eif /nitro.pcrs .
 COPY --from=build-qos_enclave /qos_enclave .
+COPY src/qos_enclave/LICENSES/Apache-2.0.txt /licenses/Apache-2.0.txt
+COPY src/qos_enclave/NOTICE /licenses/qos_enclave-NOTICE
 ENTRYPOINT ["/qos_enclave"]
 ENV EIF_PATH=/nitro.eif
 ENV ENCLAVE_NAME=qos

--- a/src/qos_enclave/Cargo.lock
+++ b/src/qos_enclave/Cargo.lock
@@ -2236,7 +2236,10 @@ name = "qos_enclave"
 version = "1.2.0"
 dependencies = [
  "libc",
+ "log",
  "nitro-cli",
+ "nix 0.26.4",
+ "serde",
  "serde_json",
  "tracing",
  "tracing-subscriber",

--- a/src/qos_enclave/Cargo.lock
+++ b/src/qos_enclave/Cargo.lock
@@ -2241,6 +2241,7 @@ dependencies = [
  "nix 0.26.4",
  "serde",
  "serde_json",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
 ]

--- a/src/qos_enclave/Cargo.toml
+++ b/src/qos_enclave/Cargo.toml
@@ -22,6 +22,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = ["e
 
 [dev-dependencies]
 serde_json = "1"
+tempfile = "3"
 
 [features]
 default = []

--- a/src/qos_enclave/Cargo.toml
+++ b/src/qos_enclave/Cargo.toml
@@ -14,6 +14,9 @@ publish = false
 # pinned commit corresponds to git tag "v1.4.5"
 nitro-cli = { git = "https://github.com/aws/aws-nitro-enclaves-cli", rev = "18a5f6f35f110c0f235f193ae3caff9434d64ee1" }
 libc = "=0.2.174"
+log = "0.4"
+nix = "=0.26.4"
+serde = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "json", "fmt"] }
 

--- a/src/qos_enclave/LICENSES/Apache-2.0.txt
+++ b/src/qos_enclave/LICENSES/Apache-2.0.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/qos_enclave/NOTICE
+++ b/src/qos_enclave/NOTICE
@@ -1,0 +1,5 @@
+qos_enclave includes code derived from aws-nitro-enclaves-cli v1.4.5:
+https://github.com/aws/aws-nitro-enclaves-cli/tree/v1.4.5
+
+aws-nitro-enclaves-cli
+Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/src/qos_enclave/src/main.rs
+++ b/src/qos_enclave/src/main.rs
@@ -23,14 +23,18 @@ use nitro_cli::{
 		logger::init_logger,
 	},
 	enclave_proc_comm::{
-		enclave_proc_command_send_all, enclave_proc_connect_to_single,
-		enclave_proc_spawn, enclave_process_handle_all_replies,
+		enclave_proc_connect_to_single, enclave_proc_spawn,
+		enclave_process_handle_all_replies,
 	},
 	get_id_by_name,
 	utils::Console,
 };
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
+
+use crate::nitro_cli_compat::enclave_proc_command_send_all;
+
+mod nitro_cli_compat;
 
 const RUN_ENCLAVE_STR: &str = "Run Enclave";
 

--- a/src/qos_enclave/src/nitro_cli_compat.rs
+++ b/src/qos_enclave/src/nitro_cli_compat.rs
@@ -1,0 +1,132 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Compatibility code copied from AWS Nitro CLI v1.4.5.
+//!
+//! Source: <https://github.com/aws/aws-nitro-enclaves-cli/blob/18a5f6f35f110c0f235f193ae3caff9434d64ee1/src/enclave_proc_comm.rs#L142-L258>
+
+use log::debug;
+use nitro_cli::{
+	common::{
+		ENCLAVE_PROC_WAIT_TIMEOUT_MSEC, EnclaveProcessCommandType,
+		MSG_ENCLAVE_CONFIRM, NitroCliErrorEnum, NitroCliFailure,
+		NitroCliResult, enclave_proc_command_send_single, read_u64_le,
+	},
+	enclave_proc_comm::enclave_proc_connect_to_all,
+	new_nitro_cli_failure,
+};
+use nix::sys::epoll;
+use nix::sys::epoll::{EpollEvent, EpollFlags, EpollOp};
+use serde::Serialize;
+use std::borrow::BorrowMut;
+use std::os::unix::io::{FromRawFd, IntoRawFd, RawFd};
+use std::os::unix::net::UnixStream;
+
+/// Broadcast a command to all available enclave processes.
+#[rustfmt::skip]
+pub fn enclave_proc_command_send_all<T>(
+    cmd: EnclaveProcessCommandType,
+    args: Option<&T>,
+) -> NitroCliResult<(Vec<UnixStream>, usize)>
+where
+    T: Serialize,
+{
+    // Open a connection to each valid socket.
+    let mut replies: Vec<UnixStream> = vec![];
+    let epoll_fd = epoll::epoll_create().map_err(|e| {
+        new_nitro_cli_failure!(
+            &format!("Failed to create epoll: {e:?}"),
+            NitroCliErrorEnum::EpollError
+        )
+    })?;
+    let comms: Vec<NitroCliResult<()>> = enclave_proc_connect_to_all()
+        .map_err(|e| {
+            e.add_subaction("Failed to send command to all enclave processes".to_string())
+        })?
+        .into_iter()
+        .map(|mut socket| {
+            // Send the command.
+            enclave_proc_command_send_single(cmd, args, socket.borrow_mut())?;
+
+            let raw_fd = socket.into_raw_fd();
+            let mut process_evt = EpollEvent::new(EpollFlags::EPOLLIN, raw_fd as u64);
+
+            // Add each valid connection to epoll.
+            epoll::epoll_ctl(epoll_fd, EpollOp::EpollCtlAdd, raw_fd, &mut process_evt).map_err(
+                |e| {
+                    new_nitro_cli_failure!(
+                        &format!("Failed to register socket with epoll: {e:?}"),
+                        NitroCliErrorEnum::EpollError
+                    )
+                },
+            )?;
+
+            Ok(())
+        })
+        .collect();
+
+    // Don't proceed unless at least one connection has been established.
+    if comms.is_empty() {
+        return Ok((vec![], 0));
+    }
+
+    // Get the number of transmission errors.
+    let mut num_errors = comms.iter().filter(|result| result.is_err()).count();
+
+    // Get the number of expected replies.
+    let mut num_replies_expected = comms.len() - num_errors;
+    let mut events = [EpollEvent::empty(); 1];
+
+    while num_replies_expected > 0 {
+        let num_events = loop {
+            match epoll::epoll_wait(epoll_fd, &mut events[..], ENCLAVE_PROC_WAIT_TIMEOUT_MSEC) {
+                Ok(num_events) => break num_events,
+                Err(nix::errno::Errno::EINTR) => continue,
+                // TODO: Handle bad descriptors (closed remote connections).
+                Err(e) => {
+                    return Err(new_nitro_cli_failure!(
+                        &format!("Failed to wait on epoll: {e:?}"),
+                        NitroCliErrorEnum::EpollError
+                    ))
+                }
+            }
+        };
+
+        // We will handle this reply, irrespective of its status (successful or failed).
+        num_replies_expected -= 1;
+
+        // Check if a time-out has occurred.
+        if num_events == 0 {
+            continue;
+        }
+
+        let input_stream_raw_fd = events[0].data() as RawFd;
+        let mut input_stream = unsafe { UnixStream::from_raw_fd(input_stream_raw_fd) };
+
+        // Handle the reply we received.
+        if let Ok(reply) = read_u64_le(&mut input_stream) {
+            if reply == MSG_ENCLAVE_CONFIRM {
+                debug!("Got confirmation from {:?}", input_stream);
+                replies.push(input_stream);
+            }
+        }
+
+        epoll::epoll_ctl(
+            epoll_fd,
+            EpollOp::EpollCtlDel,
+            input_stream_raw_fd,
+            Option::None,
+        )
+        .map_err(|e| {
+            new_nitro_cli_failure!(
+                &format!("Failed to remove socket from epoll: {e:?}"),
+                NitroCliErrorEnum::EpollError
+            )
+        })?;
+    }
+
+    // Update the number of connections that have yielded errors.
+    num_errors = comms.len() - replies.len();
+
+    Ok((replies, num_errors))
+}

--- a/src/qos_enclave/src/nitro_cli_compat.rs
+++ b/src/qos_enclave/src/nitro_cli_compat.rs
@@ -1,5 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+// Modified by Turnkey on 2026-08-05 to close epoll and connection file
+// descriptors on every return path.
 
 //! Compatibility code copied from AWS Nitro CLI v1.4.5.
 //!
@@ -17,6 +19,7 @@ use nitro_cli::{
 };
 use nix::sys::epoll;
 use nix::sys::epoll::{EpollEvent, EpollFlags, EpollOp};
+use nix::unistd::close;
 use serde::Serialize;
 use std::borrow::BorrowMut;
 use std::os::unix::io::{FromRawFd, IntoRawFd, RawFd};
@@ -33,12 +36,46 @@ where
 {
     // Open a connection to each valid socket.
     let mut replies: Vec<UnixStream> = vec![];
-    let epoll_fd = epoll::epoll_create().map_err(|e| {
-        new_nitro_cli_failure!(
-            &format!("Failed to create epoll: {e:?}"),
-            NitroCliErrorEnum::EpollError
-        )
-    })?;
+
+    // RAII guard that owns the epoll instance and every per-connection
+    // descriptor that has been detached from its `UnixStream` via
+    // `into_raw_fd` but not yet handed back to the caller. It closes all of
+    // those descriptors on every return path, including the early `?`
+    // propagations below and the `epoll_wait` timeout branch.
+    //
+    // This is required because `nix::sys::epoll::epoll_create` returns a bare
+    // `RawFd` that is not closed when it goes out of scope, and the connection
+    // descriptors are detached from their `UnixStream`s by `into_raw_fd`.
+    // Without this guard the function leaks one epoll descriptor on every call
+    // (plus one connection descriptor for every socket that does not reply
+    // before `epoll_wait` times out), which eventually exhausts the process
+    // file-descriptor limit (EMFILE) for any long-running caller that polls
+    // enclave state periodically.
+    struct EpollConns {
+        epoll_fd: RawFd,
+        pending_fds: std::collections::HashSet<RawFd>,
+    }
+
+    impl Drop for EpollConns {
+        fn drop(&mut self) {
+            for fd in self.pending_fds.drain() {
+                let _ = close(fd);
+            }
+            let _ = close(self.epoll_fd);
+        }
+    }
+
+    let mut conns = EpollConns {
+        epoll_fd: epoll::epoll_create().map_err(|e| {
+            new_nitro_cli_failure!(
+                &format!("Failed to create epoll: {e:?}"),
+                NitroCliErrorEnum::EpollError
+            )
+        })?,
+        pending_fds: std::collections::HashSet::new(),
+    };
+    let epoll_fd = conns.epoll_fd;
+
     let comms: Vec<NitroCliResult<()>> = enclave_proc_connect_to_all()
         .map_err(|e| {
             e.add_subaction("Failed to send command to all enclave processes".to_string())
@@ -49,6 +86,10 @@ where
             enclave_proc_command_send_single(cmd, args, socket.borrow_mut())?;
 
             let raw_fd = socket.into_raw_fd();
+            // Track the detached descriptor so it is still closed if it never
+            // gets returned by `epoll_wait` (e.g. on a timeout) or if the
+            // registration below fails.
+            conns.pending_fds.insert(raw_fd);
             let mut process_evt = EpollEvent::new(EpollFlags::EPOLLIN, raw_fd as u64);
 
             // Add each valid connection to epoll.
@@ -95,13 +136,19 @@ where
         // We will handle this reply, irrespective of its status (successful or failed).
         num_replies_expected -= 1;
 
-        // Check if a time-out has occurred.
+        // Check if a time-out has occurred. Any descriptor that did not reply
+        // stays tracked in `conns.pending_fds` and is closed when `conns` is
+        // dropped, instead of being leaked.
         if num_events == 0 {
             continue;
         }
 
         let input_stream_raw_fd = events[0].data() as RawFd;
         let mut input_stream = unsafe { UnixStream::from_raw_fd(input_stream_raw_fd) };
+        // Ownership of this descriptor now belongs to `input_stream` (and, if
+        // confirmed, to the `UnixStream` returned to the caller), so stop
+        // tracking it here to avoid a double close.
+        conns.pending_fds.remove(&input_stream_raw_fd);
 
         // Handle the reply we received.
         if let Ok(reply) = read_u64_le(&mut input_stream) {
@@ -129,4 +176,76 @@ where
     num_errors = comms.len() - replies.len();
 
     Ok((replies, num_errors))
+}
+
+#[cfg(test)]
+mod tests {
+	use std::{
+		env, ffi::OsString, fs, os::unix::net::UnixListener, path::Path,
+		thread, time::Duration,
+	};
+
+	use nitro_cli::common::{
+		EnclaveProcessCommandType, SOCKETS_DIR_PATH_ENV_VAR,
+		commands_parser::EmptyArgs,
+	};
+
+	struct SocketPathEnv(Option<OsString>);
+
+	impl SocketPathEnv {
+		fn set(path: &Path) -> Self {
+			let previous = env::var_os(SOCKETS_DIR_PATH_ENV_VAR);
+			unsafe { env::set_var(SOCKETS_DIR_PATH_ENV_VAR, path) };
+			Self(previous)
+		}
+	}
+
+	impl Drop for SocketPathEnv {
+		fn drop(&mut self) {
+			match self.0.take() {
+				Some(previous) => unsafe {
+					env::set_var(SOCKETS_DIR_PATH_ENV_VAR, previous)
+				},
+				None => unsafe { env::remove_var(SOCKETS_DIR_PATH_ENV_VAR) },
+			}
+		}
+	}
+
+	fn open_fd_count() -> usize {
+		fs::read_dir("/proc/self/fd").unwrap().count()
+	}
+
+	#[test]
+	fn command_send_all_closes_descriptors() {
+		let socket_dir = tempfile::tempdir().unwrap();
+		let _socket_path = SocketPathEnv::set(socket_dir.path());
+		let baseline = open_fd_count();
+
+		for _ in 0..16 {
+			super::enclave_proc_command_send_all::<EmptyArgs>(
+				EnclaveProcessCommandType::Describe,
+				None,
+			)
+			.unwrap();
+		}
+
+		assert_eq!(open_fd_count(), baseline);
+
+		let listener =
+			UnixListener::bind(socket_dir.path().join("test.sock")).unwrap();
+		let server = thread::spawn(move || {
+			let (_stream, _) = listener.accept().unwrap();
+			thread::sleep(Duration::from_millis(3_500));
+		});
+
+		let (_, errors) = super::enclave_proc_command_send_all::<EmptyArgs>(
+			EnclaveProcessCommandType::Describe,
+			None,
+		)
+		.unwrap();
+		assert_eq!(errors, 1);
+		server.join().unwrap();
+
+		assert_eq!(open_fd_count(), baseline);
+	}
 }


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

`qos_enclave` periodically calls the Nitro CLI broadcast helper while polling enclave state. Nitro CLI v1.4.5 creates an epoll descriptor on every call without closing it and can also leak detached connection descriptors when a socket times out. Long-lived workers can therefore exhaust their file-descriptor limit and begin failing in unrelated-looking ways.

This PR:

- copies only the pinned Nitro CLI v1.4.5 broadcast helper into a local compatibility module, preserving its Apache-2.0 attribution and provenance;
- packages the Apache license and NOTICE in both final enclave images;
- adds an RAII guard that closes the epoll descriptor and all pending connection descriptors on every return path; and
- adds a Linux regression test covering repeated empty broadcasts and the socket-timeout path.

Reported upstream: https://github.com/aws/aws-nitro-enclaves-cli/pull/754

## How I Tested These Changes

- `cargo fmt --check`
- `git diff --check`
- `make out/qos_enclave/index.json` (release `x86_64-unknown-linux-musl` build and static-PIE check)
- `cargo test --locked --target x86_64-unknown-linux-musl command_send_all_closes_descriptors` in the project Linux build image

## Pre merge check list

- [x] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Communicate verification flow breaking changes especially thoroughly. This is not a verification-flow breaking change:
    - Enclaves in a previous QOS version can still key forward to this version.
    - Previous QOS versions can still verify attestations from this version.
    - Manifests generated by a previous version can still be parsed by this version.
    - Previous approvals can still be verified against a manifest.
    - A previous QOS version can still perform a boot standard on an enclave of this version.