### PR TITLE
Improve cli output prompts

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -266,11 +266,13 @@ qos_client approve-manifest \
 ```
 
 **Prompts** (answer 'y' to each):
+- Is this the correct manifest schema version: v1?
 - Is this the correct namespace name: production-v1?
 - Is this the correct namespace nonce: 1?
 - Is this the correct pivot restart policy: RestartPolicy::Never?
 - Are these the correct pivot args: []?
-- Is this the correct socket pool size: 1?
+- Is this the correct pivot debug mode: false?
+- Is this the correct pivot bridge configuration: []?
 
 **Output**: `member1-production-v1-1.approval`
 
@@ -535,11 +537,13 @@ qos_client approve-manifest \
 ```
 
 **Prompts** (answer 'y' to each):
+- Is this the correct manifest schema version: v1?
 - Is this the correct namespace name: production-v1?
 - Is this the correct namespace nonce: 2?
 - Is this the correct pivot restart policy: RestartPolicy::Never?
 - Are these the correct pivot args: []?
-- Is this the correct socket pool size: 1?
+- Is this the correct pivot debug mode: false?
+- Is this the correct pivot bridge configuration: []?
 
 **Output**: `member1-production-v1-2.approval`
 

--- a/src/integration/examples/boot_enclave.rs
+++ b/src/integration/examples/boot_enclave.rs
@@ -184,6 +184,12 @@ async fn main() {
 
 		assert_eq!(
 			&stdout.next().unwrap().unwrap(),
+			"Is this the correct manifest schema version: v2? (y/n)"
+		);
+		stdin.write_all("y\n".as_bytes()).expect("Failed to write to stdin");
+
+		assert_eq!(
+			&stdout.next().unwrap().unwrap(),
 			"Is this the correct namespace name: quit-coding-to-vape? (y/n)"
 		);
 		stdin.write_all("y\n".as_bytes()).expect("Failed to write to stdin");
@@ -215,6 +221,28 @@ async fn main() {
 			"Are these the correct pivot args:"
 		);
 		stdout.next().unwrap().unwrap(); // pivot args confirm msg
+		assert_eq!(&stdout.next().unwrap().unwrap(), "(y/n)");
+		stdin.write_all("y\n".as_bytes()).expect("Failed to write to stdin");
+
+		assert_eq!(
+			&stdout.next().unwrap().unwrap(),
+			"Is this the correct pivot debug mode: true? (y/n)"
+		);
+		stdin.write_all("y\n".as_bytes()).expect("Failed to write to stdin");
+
+		assert_eq!(
+			&stdout.next().unwrap().unwrap(),
+			"Is this the correct pivot bridge configuration:"
+		);
+		stdout.next().unwrap().unwrap(); // bridge config confirm msg
+		assert_eq!(&stdout.next().unwrap().unwrap(), "(y/n)");
+		stdin.write_all("y\n".as_bytes()).expect("Failed to write to stdin");
+
+		assert_eq!(
+			&stdout.next().unwrap().unwrap(),
+			"Are these the correct DNS resolvers:"
+		);
+		assert_eq!(&stdout.next().unwrap().unwrap(), "[8.8.4.4]?");
 		assert_eq!(&stdout.next().unwrap().unwrap(), "(y/n)");
 		stdin.write_all("y\n".as_bytes()).expect("Failed to write to stdin");
 

--- a/src/integration/tests/boot.rs
+++ b/src/integration/tests/boot.rs
@@ -192,6 +192,12 @@ async fn standard_boot_e2e() {
 
 		assert_eq!(
 			&stdout.next().unwrap().unwrap(),
+			"Is this the correct manifest schema version: v1? (y/n)"
+		);
+		stdin.write_all("y\n".as_bytes()).expect("Failed to write to stdin");
+
+		assert_eq!(
+			&stdout.next().unwrap().unwrap(),
 			"Is this the correct namespace name: quit-coding-to-vape? (y/n)"
 		);
 		stdin.write_all("y\n".as_bytes()).expect("Failed to write to stdin");
@@ -226,6 +232,20 @@ async fn standard_boot_e2e() {
 			&stdout.next().unwrap().unwrap(),
 			"[\"--msg\", \"testing420\"]?"
 		);
+		assert_eq!(&stdout.next().unwrap().unwrap(), "(y/n)");
+		stdin.write_all("y\n".as_bytes()).expect("Failed to write to stdin");
+
+		assert_eq!(
+			&stdout.next().unwrap().unwrap(),
+			"Is this the correct pivot debug mode: false? (y/n)"
+		);
+		stdin.write_all("y\n".as_bytes()).expect("Failed to write to stdin");
+
+		assert_eq!(
+			&stdout.next().unwrap().unwrap(),
+			"Is this the correct pivot bridge configuration:"
+		);
+		assert_eq!(&stdout.next().unwrap().unwrap(), "[]?");
 		assert_eq!(&stdout.next().unwrap().unwrap(), "(y/n)");
 		stdin.write_all("y\n".as_bytes()).expect("Failed to write to stdin");
 

--- a/src/integration/tests/qos_bridge.rs
+++ b/src/integration/tests/qos_bridge.rs
@@ -244,6 +244,12 @@ async fn qos_bridge_works() {
 
 		assert_eq!(
 			&stdout.next().unwrap().unwrap(),
+			"Is this the correct manifest schema version: v1? (y/n)"
+		);
+		stdin.write_all("y\n".as_bytes()).expect("Failed to write to stdin");
+
+		assert_eq!(
+			&stdout.next().unwrap().unwrap(),
 			"Is this the correct namespace name: quit-coding-to-vape? (y/n)"
 		);
 		stdin.write_all("y\n".as_bytes()).expect("Failed to write to stdin");
@@ -278,6 +284,25 @@ async fn qos_bridge_works() {
 			&stdout.next().unwrap().unwrap(),
 			&format!(
 				"[\"/tmp/qos_host_bridge/qos_host_bridge.sock.{app_host_port}.appsock\"]?"
+			)
+		);
+		assert_eq!(&stdout.next().unwrap().unwrap(), "(y/n)");
+		stdin.write_all("y\n".as_bytes()).expect("Failed to write to stdin");
+
+		assert_eq!(
+			&stdout.next().unwrap().unwrap(),
+			"Is this the correct pivot debug mode: false? (y/n)"
+		);
+		stdin.write_all("y\n".as_bytes()).expect("Failed to write to stdin");
+
+		assert_eq!(
+			&stdout.next().unwrap().unwrap(),
+			"Is this the correct pivot bridge configuration:"
+		);
+		assert_eq!(
+			&stdout.next().unwrap().unwrap(),
+			&format!(
+				"[Server {{ port: {app_host_port}, host: \"0.0.0.0\" }}]?"
 			)
 		);
 		assert_eq!(&stdout.next().unwrap().unwrap(), "(y/n)");

--- a/src/qos_client/src/cli/services.rs
+++ b/src/qos_client/src/cli/services.rs
@@ -1121,6 +1121,17 @@ where
 	R: BufRead,
 	W: Write,
 {
+	// Check the manifest schema version
+	{
+		let prompt = format!(
+			"Is this the correct manifest schema version: {}? (y/n)",
+			manifest.version_label()
+		);
+		if !prompter.prompt_is_yes(&prompt) {
+			return false;
+		}
+	}
+
 	// Check the namespace name
 	{
 		let prompt = format!(
@@ -1160,6 +1171,46 @@ where
 			"Are these the correct pivot args:\n{:?}?\n(y/n)",
 			manifest.args()
 		);
+		if !prompter.prompt_is_yes(&prompt) {
+			return false;
+		}
+	}
+
+	// Check pivot debug mode
+	{
+		let prompt = format!(
+			"Is this the correct pivot debug mode: {}? (y/n)",
+			manifest.debug_mode()
+		);
+		if !prompter.prompt_is_yes(&prompt) {
+			return false;
+		}
+	}
+
+	// Check pivot bridge configuration
+	{
+		let prompt = format!(
+			"Is this the correct pivot bridge configuration:\n{:?}?\n(y/n)",
+			manifest.bridge_config()
+		);
+		if !prompter.prompt_is_yes(&prompt) {
+			return false;
+		}
+	}
+
+	// Check DNS resolvers for manifests that support DNS configuration
+	if let VersionedManifest::V2(v2_manifest) = manifest {
+		let prompt = match &v2_manifest.dns {
+			None =>
+				"Is this the correct DNS configuration: absent? (y/n)".to_string(),
+			Some(dns) if dns.resolvers.is_empty() =>
+				"Is this the correct DNS configuration: configured with no resolvers? (y/n)"
+					.to_string(),
+			Some(dns) => format!(
+				"Are these the correct DNS resolvers:\n{:?}?\n(y/n)",
+				dns.resolvers
+			),
+		};
 		if !prompter.prompt_is_yes(&prompt) {
 			return false;
 		}
@@ -2617,11 +2668,11 @@ mod tests {
 		QosHash,
 		msg::ProtocolMsgEncoding,
 		services::boot::{
-			Approval, Manifest, ManifestEnvelope, ManifestEnvelopeV2,
-			ManifestSet, ManifestV2, ManifestVersion, MemberPubKey, Namespace,
-			NitroConfig, PatchSet, PivotConfig, PivotConfigV2, PivotEnv,
-			QuorumMember, RestartPolicy, ShareSet, VersionedManifest,
-			VersionedManifestEnvelope,
+			Approval, DnsConfig, Manifest, ManifestEnvelope,
+			ManifestEnvelopeV2, ManifestSet, ManifestV2, ManifestVersion,
+			MemberPubKey, Namespace, NitroConfig, PatchSet, PivotConfig,
+			PivotConfigV2, PivotEnv, QuorumMember, RestartPolicy, ShareSet,
+			VersionedManifest, VersionedManifestEnvelope,
 		},
 	};
 	use qos_nsm::nitro::{AWS_ROOT_CERT_PEM, cert_from_pem};
@@ -2737,6 +2788,35 @@ mod tests {
 			VersionedManifest::V1(manifest) => manifest,
 			_ => panic!("expected v1 manifest in test setup"),
 		}
+	}
+
+	/// Build a v2 manifest mirroring the v1 test fixture, with optional DNS
+	/// resolver configuration.
+	///
+	/// # Panics
+	///
+	/// Panics if the fixture is not a v1 manifest.
+	fn v2_manifest_from(
+		manifest: &VersionedManifest,
+		dns: Option<DnsConfig>,
+	) -> VersionedManifest {
+		let manifest = v1_manifest(manifest).clone();
+		VersionedManifest::V2(ManifestV2 {
+			version: ManifestVersion::V2,
+			namespace: manifest.namespace,
+			pivot: PivotConfigV2 {
+				hash: manifest.pivot.hash,
+				restart: manifest.pivot.restart,
+				bridge_config: manifest.pivot.bridge_config,
+				debug_mode: manifest.pivot.debug_mode,
+				args: manifest.pivot.args,
+				env: PivotEnv::new(),
+			},
+			manifest_set: manifest.manifest_set,
+			share_set: manifest.share_set,
+			enclave: manifest.enclave,
+			dns,
+		})
 	}
 
 	/// Return the v1 manifest envelope for tests that intentionally build v1 fixtures.
@@ -3103,7 +3183,7 @@ mod tests {
 			let Setup { manifest, .. } = setup();
 
 			let mut vec_out = Vec::<u8>::new();
-			let vec_in = "yes\nyes\nyes\nyes\nyes\n".as_bytes();
+			let vec_in = "yes\nyes\nyes\nyes\nyes\nyes\nyes\n".as_bytes();
 
 			let mut prompter =
 				Prompter { reader: vec_in, writer: &mut vec_out };
@@ -3119,29 +3199,7 @@ mod tests {
 			let Setup { manifest, .. } = setup();
 
 			let mut vec_out: Vec<u8> = vec![];
-			let vec_in = "No\n".as_bytes();
-
-			let mut prompter =
-				Prompter { reader: vec_in, writer: &mut vec_out };
-
-			assert!(!super::approve_manifest_human_verifications(
-				&manifest,
-				&mut prompter
-			));
-
-			let output = String::from_utf8(vec_out).unwrap();
-			assert_eq!(
-				&output,
-				"Is this the correct namespace name: test-namespace? (y/n)\n"
-			);
-		}
-
-		#[test]
-		fn exits_early_with_bad_namespace_nonce() {
-			let Setup { manifest, .. } = setup();
-
-			let mut vec_out: Vec<u8> = vec![];
-			let vec_in = "yes\nye".as_bytes();
+			let vec_in = "yes\nNo\n".as_bytes();
 
 			let mut prompter =
 				Prompter { reader: vec_in, writer: &mut vec_out };
@@ -3156,16 +3214,16 @@ mod tests {
 
 			assert_eq!(
 				output[1],
-				"Is this the correct namespace nonce: 2? (y/n)"
+				"Is this the correct namespace name: test-namespace? (y/n)"
 			);
 		}
 
 		#[test]
-		fn exits_early_with_bad_restart_policy() {
+		fn exits_early_with_bad_namespace_nonce() {
 			let Setup { manifest, .. } = setup();
 
 			let mut vec_out: Vec<u8> = vec![];
-			let vec_in = "yes\nyes\ny".as_bytes();
+			let vec_in = "yes\nyes\nye".as_bytes();
 
 			let mut prompter =
 				Prompter { reader: vec_in, writer: &mut vec_out };
@@ -3180,12 +3238,12 @@ mod tests {
 
 			assert_eq!(
 				output[2],
-				"Is this the correct pivot restart policy: RestartPolicy::Never? (y/n)"
+				"Is this the correct namespace nonce: 2? (y/n)"
 			);
 		}
 
 		#[test]
-		fn exits_early_with_bad_pivot_args() {
+		fn exits_early_with_bad_restart_policy() {
 			let Setup { manifest, .. } = setup();
 
 			let mut vec_out: Vec<u8> = vec![];
@@ -3202,9 +3260,145 @@ mod tests {
 			let output = String::from_utf8(vec_out).unwrap();
 			let output: Vec<_> = output.split('\n').collect();
 
-			assert_eq!(output[3], "Are these the correct pivot args:");
-			assert_eq!(output[4], "[\"--option1\", \"argument\"]?");
-			assert_eq!(output[5], "(y/n)");
+			assert_eq!(
+				output[3],
+				"Is this the correct pivot restart policy: RestartPolicy::Never? (y/n)"
+			);
+		}
+
+		#[test]
+		fn exits_early_with_bad_pivot_args() {
+			let Setup { manifest, .. } = setup();
+
+			let mut vec_out: Vec<u8> = vec![];
+			let vec_in = "yes\nyes\nyes\nyes\nno".as_bytes();
+
+			let mut prompter =
+				Prompter { reader: vec_in, writer: &mut vec_out };
+
+			assert!(!super::approve_manifest_human_verifications(
+				&manifest,
+				&mut prompter
+			));
+
+			let output = String::from_utf8(vec_out).unwrap();
+			let output: Vec<_> = output.split('\n').collect();
+
+			assert_eq!(output[4], "Are these the correct pivot args:");
+			assert_eq!(output[5], "[\"--option1\", \"argument\"]?");
+			assert_eq!(output[6], "(y/n)");
+		}
+
+		#[test]
+		fn exits_early_with_bad_manifest_schema_version() {
+			let Setup { manifest, .. } = setup();
+
+			let mut vec_out: Vec<u8> = vec![];
+			let vec_in = "no\n".as_bytes();
+
+			let mut prompter =
+				Prompter { reader: vec_in, writer: &mut vec_out };
+
+			assert!(!super::approve_manifest_human_verifications(
+				&manifest,
+				&mut prompter
+			));
+
+			let output = String::from_utf8(vec_out).unwrap();
+			let output: Vec<_> = output.split('\n').collect();
+
+			assert_eq!(
+				output[0],
+				"Is this the correct manifest schema version: v1? (y/n)"
+			);
+		}
+
+		#[test]
+		fn exits_early_with_bad_debug_mode() {
+			let Setup { manifest, .. } = setup();
+
+			let mut vec_out: Vec<u8> = vec![];
+			let vec_in = "yes\nyes\nyes\nyes\nyes\nno".as_bytes();
+
+			let mut prompter =
+				Prompter { reader: vec_in, writer: &mut vec_out };
+
+			assert!(!super::approve_manifest_human_verifications(
+				&manifest,
+				&mut prompter
+			));
+
+			let output = String::from_utf8(vec_out).unwrap();
+			let output: Vec<_> = output.split('\n').collect();
+
+			assert_eq!(
+				output[7],
+				"Is this the correct pivot debug mode: false? (y/n)"
+			);
+		}
+
+		#[test]
+		fn exits_early_with_bad_bridge_config() {
+			let Setup { manifest, .. } = setup();
+
+			let mut vec_out: Vec<u8> = vec![];
+			let vec_in = "yes\nyes\nyes\nyes\nyes\nyes\nno".as_bytes();
+
+			let mut prompter =
+				Prompter { reader: vec_in, writer: &mut vec_out };
+
+			assert!(!super::approve_manifest_human_verifications(
+				&manifest,
+				&mut prompter
+			));
+
+			let output = String::from_utf8(vec_out).unwrap();
+			let output: Vec<_> = output.split('\n').collect();
+
+			assert_eq!(
+				output[8],
+				"Is this the correct pivot bridge configuration:"
+			);
+			assert_eq!(output[9], "[]?");
+			assert_eq!(output[10], "(y/n)");
+		}
+
+		#[test]
+		fn prompts_each_v2_dns_configuration() {
+			for (dns, expected) in [
+				(None, "Is this the correct DNS configuration: absent? (y/n)"),
+				(
+					Some(DnsConfig { resolvers: vec![] }),
+					"Is this the correct DNS configuration: configured with no resolvers? (y/n)",
+				),
+				(
+					Some(DnsConfig {
+						resolvers: vec!["1.1.1.1".parse().unwrap()],
+					}),
+					"Are these the correct DNS resolvers:",
+				),
+			] {
+				let Setup { manifest, .. } = setup();
+				let manifest = v2_manifest_from(&manifest, dns);
+
+				let mut vec_out: Vec<u8> = vec![];
+				let vec_in = "yes\nyes\nyes\nyes\nyes\nyes\nyes\nno".as_bytes();
+				let mut prompter =
+					Prompter { reader: vec_in, writer: &mut vec_out };
+
+				assert!(!approve_manifest_human_verifications(
+					&manifest,
+					&mut prompter
+				));
+
+				let output = String::from_utf8(vec_out).unwrap();
+				let output: Vec<_> = output.split('\n').collect();
+				assert_eq!(
+					output[0],
+					"Is this the correct manifest schema version: v2? (y/n)"
+				);
+				assert_eq!(output[11], expected);
+			}
 		}
 	}
 

--- a/src/qos_core/src/protocol/services/boot/manifest.rs
+++ b/src/qos_core/src/protocol/services/boot/manifest.rs
@@ -241,6 +241,16 @@ impl VersionedManifest {
 		}
 	}
 
+	/// Return the human readable schema version label for this manifest.
+	#[must_use]
+	pub const fn version_label(&self) -> &'static str {
+		match self {
+			Self::V2(_) => "v2",
+			Self::V1(_) => "v1",
+			Self::V0(_) => "v0",
+		}
+	}
+
 	/// Read a manifest while preserving the recognized schema version.
 	///
 	/// The older schemas are recognized by shape, so a manifest that declares


### PR DESCRIPTION
Works towards https://linear.app/turnkey/issue/ENG-4582

Stacked on #785.

## Problem

`approve_manifest_human_verifications` prompts for the namespace name, nonce, restart policy, and pivot args. It does not show the schema version, debug mode, bridge configuration, or DNS resolvers — all of which the reaper applies at boot. A quorum member can sign a manifest that opens egress, binds an ingress port, rewrites `/etc/resolv.conf`, or pipes pivot output, without ever being shown any of it.

## Change

Four more prompts, in the order the manifest declares them:

- Manifest schema version, via a new `VersionedManifest::version_label`. This is the schema the enclave will execute, so it also tells the approver which of the following controls are live.
- Pivot debug mode.
- Pivot bridge configuration.
- DNS resolvers, for v2 manifests only. Absent, configured-but-empty, and populated are distinct prompts, because an empty resolver list truncates `/etc/resolv.conf` rather than leaving it alone.

The programmatic verifications are unchanged: they still check the manifest/share/patch sets, PCRs, pivot hash, and quorum key. Approving takes no new CLI arguments, so existing invocations keep working.

`GUIDE.md` gains the new prompts and drops a stale `socket pool size` line that no longer corresponds to a prompt.

## Tests

- `exits_early_with_bad_manifest_schema_version`, `exits_early_with_bad_debug_mode`, `exits_early_with_bad_bridge_config` — one per new prompt.
- `prompts_each_v2_dns_configuration` — all three DNS states.
- The `boot`, `qos_bridge`, and `boot_enclave` drivers answer the new prompts.


