### PR TITLE
Improve quorum validation

### DIFF
--- a/src/qos_core/src/protocol/error.rs
+++ b/src/qos_core/src/protocol/error.rs
@@ -194,6 +194,9 @@ pub enum ProtocolError {
 	InvalidPivotEnv(String),
 	/// The precommitted live ephemeral key is missing from protocol state.
 	MissingLiveEphemeralKey,
+	/// A set of quorum members contains the same alias, signing public key,
+	/// or encryption public key more than once.
+	DuplicateQuorumMember,
 }
 
 impl From<std::io::Error> for ProtocolError {
@@ -391,6 +394,12 @@ impl std::fmt::Display for ProtocolError {
 			}
 			Self::QosCrypto(e) => write!(f, "crypto error: {e}"),
 			Self::PoolExpandError => write!(f, "pool expand error"),
+			Self::DuplicateQuorumMember => {
+				write!(
+					f,
+					"duplicate quorum member alias or public key component"
+				)
+			}
 		}
 	}
 }

--- a/src/qos_core/src/protocol/services/boot.rs
+++ b/src/qos_core/src/protocol/services/boot.rs
@@ -279,6 +279,33 @@ impl fmt::Debug for QuorumMember {
 	}
 }
 
+/// Ensure that every member has a unique alias, signing public key, and
+/// encryption public key. A duplicate of any of these is a red flag that a
+/// single party controls multiple members.
+///
+/// # Errors
+///
+/// Returns [`ProtocolError::DuplicateQuorumMember`] if any alias or public
+/// key component appears more than once, or an error if a member's public
+/// key cannot be decoded.
+pub(crate) fn ensure_unique_members(
+	members: &[QuorumMember],
+) -> Result<(), ProtocolError> {
+	let mut aliases = HashSet::new();
+	let mut signing_keys = HashSet::new();
+	let mut encryption_keys = HashSet::new();
+	for member in members {
+		let pub_key = P256Public::from_bytes(&member.pub_key)?;
+		if !aliases.insert(&member.alias)
+			|| !signing_keys.insert(pub_key.signing_public_key_bytes())
+			|| !encryption_keys.insert(pub_key.encryption_public_key_bytes())
+		{
+			return Err(ProtocolError::DuplicateQuorumMember);
+		}
+	}
+	Ok(())
+}
+
 /// The Manifest Set.
 #[derive(
 	PartialEq,
@@ -622,6 +649,8 @@ impl ManifestEnvelope {
 	/// [`ProtocolError::NotEnoughApprovals`] if fewer than the threshold
 	/// number of members approved.
 	pub fn check_approvals(&self) -> Result<(), ProtocolError> {
+		ensure_unique_members(&self.manifest.manifest_set.members)?;
+
 		let manifest_hash = self.manifest.qos_hash();
 		let mut uniq_members = HashSet::new();
 		for approval in &self.manifest_set_approvals {
@@ -643,10 +672,12 @@ impl ManifestEnvelope {
 				return Err(ProtocolError::NotManifestSetMember);
 			}
 
-			// Ensure that the member only has 1 approval. Note that we don't
-			// include the signature in this check because the signature is
-			// malleable. i.e. there could be two different signatures per
-			// member.
+			// Ensure that the member only has 1 approval. We already checked
+			// at the top of this function that each member has a unique
+			// signing key, so hashing the full member record is sufficient.
+			// Note that we don't include the signature in this check because
+			// the signature is malleable. i.e. there could be two different
+			// signatures per member.
 			if !uniq_members.insert(approval.member.qos_hash()) {
 				return Err(ProtocolError::DuplicateApproval);
 			}
@@ -855,6 +886,21 @@ mod test {
 
 	fn stable_quorum_member(alias: &str, byte: u8) -> QuorumMember {
 		QuorumMember { alias: alias.to_string(), pub_key: vec![byte; 33] }
+	}
+
+	fn mixed_public_key(
+		encryption_pair: &P256Pair,
+		signing_pair: &P256Pair,
+	) -> Vec<u8> {
+		let encryption_key = encryption_pair.public_key().to_bytes();
+		let signing_key = signing_pair.public_key().to_bytes();
+		let component_len = encryption_key.len() / 2;
+
+		encryption_key[..component_len]
+			.iter()
+			.chain(&signing_key[component_len..])
+			.copied()
+			.collect()
 	}
 
 	fn stable_pivot_config_v0() -> PivotConfigV0 {
@@ -1344,6 +1390,86 @@ mod test {
 
 		let err = manifest_envelope.check_approvals().unwrap_err();
 		assert_eq!(err, ProtocolError::DuplicateApproval);
+	}
+
+	#[test]
+	fn ensure_unique_members_rejects_shared_components() {
+		let pair_a = P256Pair::generate().unwrap();
+		let pair_b = P256Pair::generate().unwrap();
+		let pair_c = P256Pair::generate().unwrap();
+		let member = |alias: &str, pub_key: Vec<u8>| QuorumMember {
+			alias: alias.to_string(),
+			pub_key,
+		};
+
+		let distinct = vec![
+			member("a", pair_a.public_key().to_bytes()),
+			member("b", pair_b.public_key().to_bytes()),
+		];
+		assert!(ensure_unique_members(&distinct).is_ok());
+
+		let duplicate_sets = [
+			// Same alias
+			vec![
+				member("a", pair_a.public_key().to_bytes()),
+				member("a", pair_b.public_key().to_bytes()),
+			],
+			// Same public key under different aliases
+			vec![
+				member("a", pair_a.public_key().to_bytes()),
+				member("b", pair_a.public_key().to_bytes()),
+			],
+			// Same signing component
+			vec![
+				member("a", mixed_public_key(&pair_b, &pair_a)),
+				member("b", mixed_public_key(&pair_c, &pair_a)),
+			],
+			// Same encryption component
+			vec![
+				member("a", mixed_public_key(&pair_a, &pair_b)),
+				member("b", mixed_public_key(&pair_a, &pair_c)),
+			],
+		];
+		for members in duplicate_sets {
+			assert_eq!(
+				ensure_unique_members(&members).unwrap_err(),
+				ProtocolError::DuplicateQuorumMember
+			);
+		}
+	}
+
+	#[test]
+	fn check_approvals_rejects_same_key_under_different_aliases() {
+		let (mut manifest, members, ..) = get_manifest();
+
+		let (pair, member) = &members[0];
+		let alias_a = QuorumMember {
+			alias: "alias-a".to_string(),
+			pub_key: member.pub_key.clone(),
+		};
+		let alias_b = QuorumMember {
+			alias: "alias-b".to_string(),
+			pub_key: member.pub_key.clone(),
+		};
+		manifest.manifest_set = ManifestSet {
+			threshold: 2,
+			members: vec![alias_a.clone(), alias_b.clone()],
+		};
+
+		let manifest_hash = manifest.qos_hash();
+		let signature = pair.sign(&manifest_hash).unwrap();
+
+		let manifest_envelope = ManifestEnvelope {
+			manifest,
+			manifest_set_approvals: vec![
+				Approval { signature: signature.clone(), member: alias_a },
+				Approval { signature, member: alias_b },
+			],
+			share_set_approvals: vec![],
+		};
+
+		let err = manifest_envelope.check_approvals().unwrap_err();
+		assert_eq!(err, ProtocolError::DuplicateQuorumMember);
 	}
 
 	#[test]

--- a/src/qos_core/src/protocol/services/boot/manifest.rs
+++ b/src/qos_core/src/protocol/services/boot/manifest.rs
@@ -419,6 +419,8 @@ impl VersionedManifestEnvelope {
 	/// Returns a [`ProtocolError`] when signatures are invalid, members are
 	/// unauthorized, duplicate approvals exist, or the threshold is not met.
 	pub fn check_approvals(&self) -> Result<(), ProtocolError> {
+		super::ensure_unique_members(&self.manifest_set().members)?;
+
 		let manifest_hash = self.manifest_hash();
 		let mut uniq_members = std::collections::HashSet::new();
 
@@ -436,6 +438,9 @@ impl VersionedManifestEnvelope {
 			if !self.manifest_set().members.contains(&approval.member) {
 				return Err(ProtocolError::NotManifestSetMember);
 			}
+			// Ensure that the member only has 1 approval. We already checked
+			// at the top of this function that each member has a unique
+			// signing key, so hashing the full member record is sufficient.
 			if !uniq_members.insert(approval.member.qos_hash()) {
 				return Err(ProtocolError::DuplicateApproval);
 			}
@@ -708,6 +713,39 @@ mod tests {
 		assert!(matches!(decoded, VersionedManifestEnvelope::V2(_)));
 		assert_eq!(decoded.manifest_hash(), manifest_hash);
 		assert!(decoded.check_approvals().is_ok());
+	}
+
+	#[test]
+	fn versioned_check_approvals_rejects_same_key_under_different_aliases() {
+		let pair = P256Pair::generate().unwrap();
+		let alias_a = QuorumMember {
+			alias: "alias-a".to_string(),
+			pub_key: pair.public_key().to_bytes(),
+		};
+		let alias_b = QuorumMember {
+			alias: "alias-b".to_string(),
+			pub_key: pair.public_key().to_bytes(),
+		};
+
+		let mut manifest = sample_v2_manifest(alias_a.clone());
+		manifest.manifest_set = ManifestSet {
+			threshold: 2,
+			members: vec![alias_a.clone(), alias_b.clone()],
+		};
+
+		let manifest_hash = canonical_json_hash(&manifest);
+		let signature = pair.sign(&manifest_hash).unwrap();
+		let envelope = VersionedManifestEnvelope::V2(ManifestEnvelopeV2 {
+			manifest,
+			manifest_set_approvals: vec![
+				Approval { signature: signature.clone(), member: alias_a },
+				Approval { signature, member: alias_b },
+			],
+			share_set_approvals: vec![],
+		});
+
+		let err = envelope.check_approvals().unwrap_err();
+		assert_eq!(err, ProtocolError::DuplicateQuorumMember);
 	}
 
 	#[test]

--- a/src/qos_core/src/protocol/services/genesis.rs
+++ b/src/qos_core/src/protocol/services/genesis.rs
@@ -170,6 +170,8 @@ pub(in crate::protocol) fn boot_genesis(
 	genesis_set: &GenesisSet,
 	maybe_dr_key: Option<Vec<u8>>,
 ) -> Result<(GenesisOutput, NsmResponse), ProtocolError> {
+	super::boot::ensure_unique_members(&genesis_set.members)?;
+
 	let quorum_pair = P256Pair::generate()?;
 	let master_seed = &quorum_pair.to_master_seed()[..];
 
@@ -321,5 +323,37 @@ mod test {
 		let quorum_key_hash =
 			sha_512(qos_hex::encode(&reconstructed[..]).as_bytes());
 		assert_eq!(quorum_key_hash, output.quorum_key_hash);
+	}
+
+	#[test]
+	fn boot_genesis_rejects_duplicate_members() {
+		let handles = Handles::new(
+			"EPH2".to_string(),
+			"QUO2".to_string(),
+			"MAN2".to_string(),
+			"PIV2".to_string(),
+		);
+		let mut protocol_state =
+			ProtocolState::new(Box::new(MockNsm::new()), handles, None);
+		let member_pair = P256Pair::generate().unwrap();
+
+		// The same public key under two different aliases must be rejected.
+		let genesis_set = GenesisSet {
+			members: vec![
+				QuorumMember {
+					alias: "alias-a".to_string(),
+					pub_key: member_pair.public_key().to_bytes(),
+				},
+				QuorumMember {
+					alias: "alias-b".to_string(),
+					pub_key: member_pair.public_key().to_bytes(),
+				},
+			],
+			threshold: 2,
+		};
+
+		let err =
+			boot_genesis(&mut protocol_state, &genesis_set, None).unwrap_err();
+		assert_eq!(err, ProtocolError::DuplicateQuorumMember);
 	}
 }

--- a/src/qos_p256/src/lib.rs
+++ b/src/qos_p256/src/lib.rs
@@ -374,6 +374,18 @@ impl P256Public {
 			.collect()
 	}
 
+	/// Serialize the encryption public key as an uncompressed SEC1 point.
+	#[must_use]
+	pub fn encryption_public_key_bytes(&self) -> Box<[u8]> {
+		self.encrypt_public.to_bytes()
+	}
+
+	/// Serialize the signing public key as an uncompressed SEC1 point.
+	#[must_use]
+	pub fn signing_public_key_bytes(&self) -> Box<[u8]> {
+		self.sign_public.to_bytes()
+	}
+
 	/// Deserialize each public key from a SEC1 encoded point, not compressed.
 	/// Expects encoding as `encrypt_public||sign_public`.
 	///
@@ -457,6 +469,19 @@ mod test {
 	use qos_test_primitives::PathWrapper;
 
 	use super::*;
+
+	#[test]
+	fn public_key_component_bytes_match_combined_encoding() {
+		let public_key = P256Pair::generate().unwrap().public_key();
+		let component_bytes: Vec<_> = public_key
+			.encryption_public_key_bytes()
+			.iter()
+			.chain(public_key.signing_public_key_bytes().iter())
+			.copied()
+			.collect();
+
+		assert_eq!(component_bytes, public_key.to_bytes());
+	}
 
 	#[test]
 	fn signatures_are_deterministic() {


### PR DESCRIPTION
Adds `ensure_unique_members`, which rejects any quorum member set containing a duplicate alias, signing public key, or encryption public key. It is enforced in both `check_approvals` implementations (legacy and versioned manifest envelopes) and in `boot_genesis`. `P256Public` gains accessors for the individual signing/encryption key components so duplicates of either component are caught even when the combined key bytes differ.