### PR TITLE
Bump rpassword for mac build fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2547,9 +2547,9 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.5.0"
+version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3bc4a3dd492cd6974dd3f32d6626ba9f36e5122e3df3b083474b104aebd139b"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
 dependencies = [
  "libc",
  "rtoolbox",


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

I have reviewed this dependency update

```
Root cause: The dependabot commit 9b639b74 ("dependabot remediation 2026-07-18") bumped rpassword from 7.3.1 to 7.5.0 in Cargo.lock. rpassword 7.5.0 has a macOS bug: its src/unix.rs:26 calls libc::__errno_location() unconditionally, but that symbol only exists on Linux/glibc (macOS uses __error instead), so the crate fails to compile on Mac

Upstream patched this almost immediately — 7.5.1 shipped the day after 7.5.0. I ran cargo update -p rpassword, which moved the lockfile to 7.5.4, and the full workspace now builds cleanly
```


## How I Tested These Changes

Built QOS on a new mac


