### PR TITLE
Fix: don't allow stale bridge configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2101,13 +2101,7 @@ name = "qos_bridge"
 version = "0.13.0"
 dependencies = [
  "qos_core 0.13.0",
- "qos_hex 0.13.0",
- "qos_host",
- "qos_nsm 0.13.0",
- "serde",
- "serde_json",
  "tokio",
- "ureq",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ stop:
 	rm -f /tmp/vhost4.socket
 
 /tmp/vhost4.socket:
-	vhost-device-vsock --vm guest-cid=4,forward-cid=1,forward-listen=3000+9001+9002,socket=/tmp/vhost4.socket &
+	vhost-device-vsock --vm guest-cid=4,forward-cid=1,forward-listen=3000+9001+9002+65536,socket=/tmp/vhost4.socket &
 
 .PHONY: host
 host:
@@ -67,7 +67,6 @@ host:
 bridge: target/x86_64-unknown-linux-musl/release-panic-abort/egress
 	cargo run -p qos_bridge --locked --bin ingress --features egress,qemu -- \
 		--cid 1 \
-		--control-url http://127.0.0.1:3001/qos \
 		--vsock-to-host false \
 		--egress-bin-path target/x86_64-unknown-linux-musl/release-panic-abort/egress
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -120,11 +120,19 @@ flowchart LR
     Localhost --> App
 ```
 
-The bridge is deliberately protocol-agnostic. Once both sides have connected,
-QOS uses `tokio::io::copy_bidirectional` to pipe bytes in both directions. The
-bridge does not inspect, wrap, unwrap, or multiplex application messages. The
-kernel creates a separate stream for each accepted connection, so one VSOCK port
-can support multiple simultaneous connection streams.
+Before carrying application data, the bridge performs a QOS admission
+exchange. The host sends an `Open` message containing the hash of the approved
+server-bridge policy. The in-enclave QOS bridge sends `Accepted` only when that
+hash matches its policy, and includes the same hash in the response. The host
+requires that exact acknowledgment before it starts copying application bytes.
+A timeout, malformed response, `Rejected` response, or mismatched
+acknowledgment closes the connection without forwarding data.
+
+After admission, the bridge is protocol-agnostic. QOS uses
+`tokio::io::copy_bidirectional` to pipe bytes in both directions and does not
+inspect, wrap, unwrap, or multiplex application messages. The kernel creates a
+separate stream for each accepted connection, so one VSOCK port can support
+multiple simultaneous connection streams.
 
 This is the main difference from the older internal-app model, where an app host
 translated an external protocol into QOS-specific messages and the app had to
@@ -163,6 +171,13 @@ into the app's VSOCK protocol and translate responses back to the caller.
 Without that host-side process, callers will not have a normal HTTP, HTTPS, or
 gRPC endpoint to talk to.
 
+Direct-VSOCK applications must not send the bridge `Accepted` message. That
+message is reserved for the QOS ingress bridge. If a stale host bridge connects
+to a direct-VSOCK application, the application should not acknowledge the
+bridge admission exchange; the host then fails closed and does not forward the
+external connection's application bytes. TLS or another app protocol may begin
+normally after an application-specific direct-VSOCK connection is established.
+
 ## Bridge Configuration
 
 Bridge configuration lives in the manifest under `pivot.bridge_config`. The
@@ -187,13 +202,12 @@ The `port` is used on both sides by default:
 The `host` field is only the host-side bind address. Inside the enclave, the
 reaper currently connects to `127.0.0.1:<port>`.
 
-`qos_bridge` learns this configuration from `qos_host`. It polls the
-`/qos/enclave-info` endpoint until the enclave has a manifest, reads the
-manifest envelope, and starts the configured host-side bridges.
+`qos_bridge` receives the server-bridge policy from the enclave over the
+bridge-control VSOCK connection, hashes it with QOS JSON, and starts the
+configured host-side bridges only after the policy is received.
 
 ```bash
 qos_bridge \
-  --control-url http://127.0.0.1:3001/qos \
   --cid 16
 ```
 
@@ -201,7 +215,6 @@ For local development, use `--usock` instead of `--cid`.
 
 ```bash
 qos_bridge \
-  --control-url http://127.0.0.1:3001/qos \
   --usock /tmp/enclave-example/example.sock
 ```
 

--- a/src/integration/tests/qos_bridge.rs
+++ b/src/integration/tests/qos_bridge.rs
@@ -7,8 +7,8 @@ use std::{
 
 use borsh::de::BorshDeserialize;
 use integration::{
-	LOCAL_HOST, PCR3_PRE_IMAGE_PATH, PIVOT_SOCKET_STRESS_PATH,
-	PivotSocketStressMsg, QOS_DIST_DIR, wait_for_tcp_sock,
+	LOCAL_HOST, PCR3_PRE_IMAGE_PATH, PIVOT_TCP_PATH, QOS_DIST_DIR,
+	wait_for_tcp_sock,
 };
 use qos_core::protocol::{
 	ProtocolPhase, QosHash,
@@ -29,33 +29,29 @@ use tokio::{
 	net::TcpStream,
 };
 
-async fn bridge_roundtrip(
-	bridge_addr: &str,
-) -> Result<PivotSocketStressMsg, String> {
+const BRIDGE_ROUNDTRIP_MESSAGE: &[u8] = b"bridge roundtrip";
+
+async fn bridge_roundtrip(bridge_addr: &str) -> Result<(), String> {
 	let mut tcp_stream =
 		TcpStream::connect(bridge_addr).await.map_err(|e| e.to_string())?;
-
-	let msg = PivotSocketStressMsg::OkRequest(42);
-	let msg_bytes = borsh::to_vec(&msg).map_err(|e| e.to_string())?;
-	let mut header = (msg_bytes.len() as u64).to_le_bytes();
-
-	tcp_stream.write_all(&header).await.map_err(|e| e.to_string())?;
-	tcp_stream.write_all(&msg_bytes).await.map_err(|e| e.to_string())?;
-
-	tcp_stream.read_exact(&mut header).await.map_err(|e| e.to_string())?;
-	let reply_size = usize::from_le_bytes(header);
-	let mut reply_bytes = vec![0u8; reply_size];
-	tcp_stream.read_exact(&mut reply_bytes).await.map_err(|e| e.to_string())?;
-
-	borsh::from_slice(&reply_bytes).map_err(|e| e.to_string())
+	tcp_stream
+		.write_all(BRIDGE_ROUNDTRIP_MESSAGE)
+		.await
+		.map_err(|e| e.to_string())?;
+	let mut reply = vec![0; BRIDGE_ROUNDTRIP_MESSAGE.len()];
+	tcp_stream.read_exact(&mut reply).await.map_err(|e| e.to_string())?;
+	if reply == BRIDGE_ROUNDTRIP_MESSAGE {
+		Ok(())
+	} else {
+		Err("invalid pivot reply".into())
+	}
 }
 
 async fn wait_for_bridge_roundtrip(bridge_addr: &str) {
 	let mut last_err = String::new();
 	for _ in 0..100 {
 		match bridge_roundtrip(bridge_addr).await {
-			Ok(PivotSocketStressMsg::OkResponse(42)) => return,
-			Ok(reply) => panic!("invalid pivot response: {reply:?}"),
+			Ok(()) => return,
 			Err(err) => last_err = err,
 		}
 
@@ -106,15 +102,13 @@ async fn qos_bridge_works() {
 	let user3 = "user3";
 
 	// -- Create pivot-build-fingerprints.txt
-	let pivot = fs::read(PIVOT_SOCKET_STRESS_PATH).unwrap();
+	let pivot = fs::read(PIVOT_TCP_PATH).unwrap();
 	let mock_pivot_hash = sha_256(&pivot);
 	let pivot_hash = qos_hex::encode_to_vec(&mock_pivot_hash);
 	std::fs::write(PIVOT_HASH_PATH, pivot_hash).unwrap();
 
 	// -- CLIENT create manifest.
-	let pivot_app_sock_path =
-		usock_path + "." + &app_host_port.to_string() + ".appsock";
-	let pivot_args = format!("[{pivot_app_sock_path}]");
+	let pivot_args = format!("[{app_host_port}]");
 	let cli_manifest_path = boot_dir.join("manifest");
 
 	assert!(Command::new(integration::QOS_CLIENT_PATH)
@@ -181,7 +175,7 @@ async fn qos_bridge_works() {
 	let pivot = PivotConfig {
 		hash: mock_pivot_hash,
 		restart: RestartPolicy::Never,
-		args: vec![pivot_app_sock_path.to_string()],
+		args: vec![app_host_port.to_string()],
 		debug_mode: false,
 		bridge_config: vec![BridgeConfig::Server {
 			port: app_host_port,
@@ -276,9 +270,7 @@ async fn qos_bridge_works() {
 		);
 		assert_eq!(
 			&stdout.next().unwrap().unwrap(),
-			&format!(
-				"[\"/tmp/qos_host_bridge/qos_host_bridge.sock.{app_host_port}.appsock\"]?"
-			)
+			&format!("[\"{app_host_port}\"]?")
 		);
 		assert_eq!(&stdout.next().unwrap().unwrap(), "(y/n)");
 		stdin.write_all("y\n".as_bytes()).expect("Failed to write to stdin");
@@ -342,7 +334,6 @@ async fn qos_bridge_works() {
 	// -- Make sure the enclave and host have time to boot
 	qos_test_primitives::wait_until_port_is_bound(host_port);
 
-	let control_url = format!("http://localhost:{host_port}/qos");
 	// -- BRIDGE start bridge
 	let mut bridge_child_process: ChildWrapper =
 		Command::new(integration::QOS_BRIDGE_PATH)
@@ -351,8 +342,6 @@ async fn qos_bridge_works() {
 				&app_host_port_override.to_string(),
 				"--usock",
 				usock.to_str().unwrap(),
-				"--control-url",
-				&control_url,
 			])
 			.spawn()
 			.unwrap()
@@ -384,7 +373,7 @@ async fn qos_bridge_works() {
 				"--manifest-envelope-path",
 				manifest_envelope_path.to_str().unwrap(),
 				"--pivot-path",
-				PIVOT_SOCKET_STRESS_PATH,
+				PIVOT_TCP_PATH,
 				"--host-port",
 				&host_port.to_string(),
 				"--host-ip",
@@ -549,8 +538,6 @@ async fn qos_bridge_works() {
 				&app_host_port_override.to_string(),
 				"--usock",
 				usock.to_str().unwrap(),
-				"--control-url",
-				&control_url,
 			])
 			.spawn()
 			.unwrap()

--- a/src/integration/tests/reaper.rs
+++ b/src/integration/tests/reaper.rs
@@ -328,22 +328,28 @@ async fn reaper_handles_bridge() {
 		PIVOT_TCP_PATH.to_string(),
 	);
 
-	// start the tcp -> vsock bridge on host_port
-	let host_addr: SocketAddr =
-		SocketAddrV4::new(Ipv4Addr::LOCALHOST, host_port).into();
-	let app_pool =
-		StreamPool::single(SocketAddress::new_unix(&app_usock)).unwrap();
-	HostBridge::new(app_pool, host_addr).tcp_to_vsock();
-
 	// Make sure we have written everything necessary to pivot, except the
 	// quorum key
 	let mut manifest_envelope = ManifestEnvelope::default();
 	manifest_envelope.manifest.pivot.args = vec![format!("{pivot_port}")];
-	manifest_envelope.manifest.pivot.bridge_config =
-		vec![BridgeConfig::Server {
-			port: pivot_port,
-			host: "127.0.0.1".into(),
-		}];
+	let bridge_config = vec![BridgeConfig::Server {
+		port: pivot_port,
+		host: "127.0.0.1".into(),
+	}];
+	manifest_envelope.manifest.pivot.bridge_config = bridge_config.clone();
+
+	// Start the admitted TCP -> VSOCK bridge on host_port.
+	let host_addr: SocketAddr =
+		SocketAddrV4::new(Ipv4Addr::LOCALHOST, host_port).into();
+	let app_pool =
+		StreamPool::single(SocketAddress::new_unix(&app_usock)).unwrap();
+	let policy_hash =
+		qos_core::io::ingress_policy_hash(&bridge_config).unwrap();
+	let (stale_tx, _stale_rx) = tokio::sync::mpsc::unbounded_channel();
+	let host_bridge = HostBridge::new(app_pool, host_addr)
+		.tcp_to_vsock(policy_hash, stale_tx)
+		.await
+		.unwrap();
 
 	handles.put_manifest_envelope(&manifest_envelope).unwrap();
 	assert!(handles.pivot_exists());
@@ -421,4 +427,5 @@ async fn reaper_handles_bridge() {
 	let contents = fs::read(integration::PIVOT_TCP_SUCCESS_FILE).unwrap();
 	assert_eq!(&contents, b"finished"); // expects the finished msg
 	assert!(fs::remove_file(integration::PIVOT_TCP_SUCCESS_FILE).is_ok());
+	host_bridge.abort();
 }

--- a/src/qos_bridge/Cargo.toml
+++ b/src/qos_bridge/Cargo.toml
@@ -9,16 +9,10 @@ publish = false
 workspace = true
 
 [dependencies]
-qos_host = { workspace = true, default-features = false }
 qos_core = { workspace = true, default-features = false }
-qos_hex = { workspace = true, features = ["serde"], default-features = false }
-qos_nsm = { workspace = true, default-features = false }
 
 # Third party
-serde_json = { workspace = true }
-serde = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-ureq = { workspace = true, features = ["json"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 
 [features]
 qemu = ["qos_core/qemu"]

--- a/src/qos_bridge/README.md
+++ b/src/qos_bridge/README.md
@@ -1,6 +1,6 @@
 # QOS app host bridge
 
-QOS Host Bridge bridges TCP traffic from the host to the enclave's application by establishing a TCP → VSOCK connection. It fetches the enclave's manifest via qos_host and constructs the host-side bridge according to the configuration specified by the manifest. The enclave independently constructs the corresponding VSOCK → TCP half from the same manifest, completing the full bridge.
+QOS Host Bridge bridges TCP traffic from the host to the enclave's application by establishing a TCP → VSOCK connection. It receives the active server-bridge policy from the enclave over the bridge-control VSOCK connection, hashes that policy with QOS JSON, and constructs the host-side bridge only after the policy is received. The enclave independently constructs the corresponding VSOCK → TCP half from the same policy, completing the full bridge.
 
 ## Local Dev
 
@@ -18,6 +18,16 @@ Provided a bridge configuration of
 }
 ```
 
-`cargo run -- --control-url http://localhost:3001/qos --usock /tmp/enclave-example/example.sock --host-port-override 4000`
+For local development, `--usock` selects a Unix-domain socket, which lets the
+host-side bridge and a local test reaper use filesystem socket paths instead of
+VSOCK. A real Nitro enclave is reached over VSOCK with `--cid`:
+
+```bash
+cargo run -- --usock /tmp/enclave-example/example.sock --host-port-override 4000
+```
+
+```bash
+cargo run -- --cid 16 --host-port-override 4000
+```
 
 The pivot app will be available on `localhost:4000` via the bridge, and `localhost:3000` directly.

--- a/src/qos_bridge/src/bin/ingress.rs
+++ b/src/qos_bridge/src/bin/ingress.rs
@@ -8,7 +8,6 @@ async fn main() {
 	// ```
 	// cargo run --bin ingress -- \
 	//      --usock /tmp/usock.sock \
-	//      --control-url http://localhost:3001/qos
 	// ```
 	cli::Cli::execute_ingress().await;
 }

--- a/src/qos_bridge/src/cli.rs
+++ b/src/qos_bridge/src/cli.rs
@@ -8,7 +8,6 @@ use qos_core::{
 	parser::{GetParserForOptions, OptionsParser, Parser, Token},
 };
 
-const CONTROL_URL: &str = "control-url";
 const HOST_PORT_OVERRIDE: &str = "host-port-override";
 const VSOCK_TO_HOST: &str = "vsock-to-host";
 const EGRESS_HOST: &str = "egress-host";
@@ -17,41 +16,46 @@ const EGRESS_BIN_PATH: &str = "egress-bin-path";
 struct HostParser;
 impl GetParserForOptions for HostParser {
 	fn parser() -> Parser {
-		Parser::new().token(
-			Token::new(
-				CONTROL_URL,
-				"full url of qos-host to get manifest information from, including the base path, e.g. http://localhost:3001/qos",
-			)
-			.takes_value(true)
-			.required(false),
-		)
+		Parser::new()
 			.token(
-				Token::new(CID, "context identifier for the enclave socket (only for VSOCK)")
-					.takes_value(true)
-					.forbids(vec![USOCK])
+				Token::new(
+					CID,
+					"context identifier for the enclave socket (only for VSOCK)",
+				)
+				.takes_value(true)
+				.forbids(vec![USOCK]),
 			)
 			.token(
-				Token::new(USOCK, "name of the socket file (ex: `dev.sock`) (only for unix sockets)")
-					.takes_value(true)
-					.forbids(vec![CID])
+				Token::new(
+					USOCK,
+					"name of the socket file (ex: `dev.sock`) (only for unix sockets)",
+				)
+				.takes_value(true)
+				.forbids(vec![CID]),
 			)
 			.token(
-				Token::new(HOST_PORT_OVERRIDE, "override for manifest value of host port, mostly for localhost testing")
-					.takes_value(true)
+				Token::new(
+					HOST_PORT_OVERRIDE,
+					"override for manifest value of host port, mostly for localhost testing",
+				)
+				.takes_value(true),
 			)
 			.token(
-				Token::new(VSOCK_TO_HOST, "override for manifest value of host port, mostly for localhost testing")
-					.takes_value(true)
-					.required(false)
-					.forbids(vec![USOCK])
+				Token::new(
+					VSOCK_TO_HOST,
+					"override for manifest value of host port, mostly for localhost testing",
+				)
+				.takes_value(true)
+				.required(false)
+				.forbids(vec![USOCK]),
 			)
 			.token(
 				Token::new(EGRESS_HOST, "run in enclave egress in host mode")
-					.takes_value(false)
+					.takes_value(false),
 			)
 			.token(
 				Token::new(EGRESS_BIN_PATH, "path to the egress binary")
-					.takes_value(true)
+					.takes_value(true),
 			)
 	}
 }
@@ -69,17 +73,6 @@ impl HostOpts {
 			.expect("Entered invalid CLI args");
 
 		Self { parsed }
-	}
-
-	/// The qos-host URL
-	/// # Panics
-	/// Panics if no control-url is provided
-	#[must_use]
-	pub fn control_url(&self) -> String {
-		self.parsed
-			.single(CONTROL_URL)
-			.expect("no control-url provided")
-			.clone()
 	}
 
 	/// Wether to run in egress host mode (e.g. in qos bridge on the host)
@@ -109,7 +102,7 @@ impl HostOpts {
 			(Some(c), None) => {
 				let c =
 					c.parse().map_err(|_| IOError::ConnectAddressInvalid)?;
-				let p = 3001; // placeholder port, overridden when we read the manifest
+				let p = 3001; // placeholder port; the control port is derived separately
 
 				Ok(SocketAddress::new_vsock(c, p, self.to_host_flag()))
 			}
@@ -210,15 +203,11 @@ impl Cli {
 				options
 					.enclave_socket()
 					.expect("failed to create enclave socket placeholder"),
-				options.control_url(),
 				options.host_port_override(),
 				options.egress_bin_path(),
 			)
 			.serve()
 			.await;
-
-			eprintln!("qos_bridge: bridge running, press ctrl+c to quit");
-			let _ = tokio::signal::ctrl_c().await;
 		}
 	}
 }

--- a/src/qos_bridge/src/host.rs
+++ b/src/qos_bridge/src/host.rs
@@ -1,4 +1,4 @@
-//! qos-bridge host server
+//! `qos_bridge` host ingress supervisor.
 
 use std::{
 	net::{Ipv4Addr, SocketAddr},
@@ -6,110 +6,190 @@ use std::{
 };
 
 use qos_core::{
-	io::{HostBridge, SocketAddress, StreamPool},
+	io::{
+		BRIDGE_CONTROL_VSOCK_PORT, HostBridge, IOError, PolicyHash,
+		SocketAddress, Stream, StreamPool, ingress_policy_hash,
+		open_bridge_control,
+	},
 	protocol::services::boot::BridgeConfig,
 };
-use qos_host::{ENCLAVE_INFO, EnclaveInfo};
+use tokio::{sync::mpsc, task::JoinHandle};
 
-/// Host server implementation using `HostBridge::tcp_to_vsock`
+const BRIDGE_CONTROL_RETRY_DELAY: Duration = Duration::from_secs(5);
+
+/// Host server which reconciles ingress against the current enclave lifecycle.
 pub struct BridgeServer {
 	socket_placeholder: SocketAddress,
-	info_url: String,
 	host_port_override: Option<u16>,
 	#[allow(unused)]
 	egress_bin_path: Option<String>,
 }
 
+struct ActiveIngress {
+	control_stream: Stream,
+	listener_handles: Vec<JoinHandle<Result<(), IOError>>>,
+	_stale_tx: mpsc::UnboundedSender<()>,
+	stale_rx: mpsc::UnboundedReceiver<()>,
+}
+
+impl ActiveIngress {
+	async fn run_until_stale(mut self) {
+		tokio::select! {
+			biased;
+			reason = self.stale_rx.recv() => {
+				println!("revoking ingress after data admission failure: {reason:?}");
+			}
+			result = self.control_stream.recv() => {
+				println!("revoking ingress after control lease ended: {result:?}");
+			}
+		}
+
+		for handle in &self.listener_handles {
+			handle.abort();
+		}
+		for handle in self.listener_handles {
+			let _ = handle.await;
+		}
+	}
+}
+
 impl BridgeServer {
-	/// Create a new `BridgeServer` with  the given core socket placeholder, `control_url` and override port for local running
+	/// Create a host ingress supervisor.
 	#[must_use]
 	pub fn new(
 		socket_placeholder: SocketAddress,
-		control_url: String,
 		host_port_override: Option<u16>,
 		egress_bin_path: Option<String>,
 	) -> Self {
-		Self {
-			socket_placeholder,
-			info_url: control_url + ENCLAVE_INFO,
-			host_port_override,
-			egress_bin_path,
-		}
+		Self { socket_placeholder, host_port_override, egress_bin_path }
 	}
 
-	/// Start the host side of the bridge, taking configuration from the enclave
+	/// Receive the current policy and supervise its ingress for the enclave
+	/// lifecycle. No manifest endpoint is polled.
+	///
 	/// # Panics
-	/// Panics if enclave info response fails to parse
+	///
 	pub async fn serve(&self) {
+		let mut egress_started = false;
+		let control_address = match self
+			.socket_placeholder
+			.with_system_port(BRIDGE_CONTROL_VSOCK_PORT)
+		{
+			Ok(address) => address,
+			Err(err) => {
+				eprintln!("unable to derive bridge control address: {err:?}");
+				return;
+			}
+		};
+
 		loop {
-			match tokio::task::block_in_place(|| {
-				ureq::get(&self.info_url)
-					.timeout(Duration::from_secs(1))
-					.call()
-					.map_err(Box::new)
-			}) {
-				Ok(info) => {
-					if let Some(me) = info
-						.into_json::<EnclaveInfo>()
-						.expect("unable to parse enclave info response")
-						.manifest_envelope
-					{
-						let manifest = me.manifest();
-						break self.run_bridges(manifest.bridge_config());
+			let (control_stream, configs, egress_enabled) =
+				match open_bridge_control(&control_address).await {
+					Ok(policy) => policy,
+					Err(err) => {
+						eprintln!(
+							"unable to open bridge control lease: {err:?}"
+						);
+						self.wait_to_retry().await;
+						continue;
 					}
+				};
+
+			let policy_hash = match ingress_policy_hash(&configs) {
+				Ok(hash) => hash,
+				Err(err) => {
+					eprintln!("unable to hash ingress policy: {err}");
+					self.wait_to_retry().await;
+					continue;
 				}
-				Err(err) => eprintln!("unable to query enclave: {err}"),
+			};
+
+			if egress_enabled && !egress_started {
+				self.run_egress_host_bridge();
+				egress_started = true;
 			}
 
-			println!("retrying enclave info query in 5s");
-			tokio::time::sleep(Duration::from_secs(5)).await;
+			match self
+				.activate_ingress(control_stream, &configs, policy_hash)
+				.await
+			{
+				Ok(active) => active.run_until_stale().await,
+				Err(err) => {
+					eprintln!("unable to activate ingress: {err:?}");
+					self.wait_to_retry().await;
+				}
+			}
 		}
 	}
 
-	// overrides `port` with `Self::host_port_override` if set
+	async fn wait_to_retry(&self) {
+		println!("retrying bridge control connection in 5s");
+		tokio::time::sleep(BRIDGE_CONTROL_RETRY_DELAY).await;
+	}
+
+	async fn activate_ingress(
+		&self,
+		control_stream: Stream,
+		configs: &[BridgeConfig],
+		policy_hash: PolicyHash,
+	) -> Result<ActiveIngress, IOError> {
+		let (stale_tx, stale_rx) = mpsc::unbounded_channel();
+		let mut listener_handles = Vec::new();
+
+		for config in configs {
+			let BridgeConfig::Server { port, host } = config else {
+				continue;
+			};
+			match self
+				.run_ingress_bridge(
+					*port,
+					self.host_port(*port),
+					host,
+					policy_hash,
+					stale_tx.clone(),
+				)
+				.await
+			{
+				Ok(handle) => listener_handles.push(handle),
+				Err(err) => {
+					for handle in &listener_handles {
+						handle.abort();
+					}
+					for handle in listener_handles {
+						let _ = handle.await;
+					}
+					return Err(err);
+				}
+			}
+		}
+
+		println!(
+			"activated ingress with {} listener(s)",
+			listener_handles.len()
+		);
+		Ok(ActiveIngress {
+			control_stream,
+			listener_handles,
+			_stale_tx: stale_tx,
+			stale_rx,
+		})
+	}
+
 	fn host_port(&self, port: u16) -> u16 {
 		self.host_port_override.unwrap_or(port)
 	}
 
-	fn run_bridges(&self, configs: &[BridgeConfig]) {
-		let mut egress_enabled = false;
-
-		for config in configs {
-			match config {
-				BridgeConfig::Client { port: _, host: _ } => {
-					// NOTE: we ignore the host and port here as they are meant for firewall rules
-					// TODO: figure out how to actually handle the firewall rules, see TVC-25
-
-					// only run one instance as it covers ALL ports, the others are for firewalls
-					if !egress_enabled {
-						egress_enabled = true;
-						self.run_egress_host_bridge();
-					}
-				}
-				BridgeConfig::Server { port, host } => {
-					self.run_ingress_bridge(
-						config.port(),
-						self.host_port(*port),
-						host,
-					);
-				}
-			}
-		}
-	}
-
-	// dummy placeholder
 	#[cfg(not(feature = "egress"))]
 	#[allow(clippy::unused_self)]
 	fn run_egress_host_bridge(&self) {
 		panic!("unable to run egress without vm feature and vsock support");
 	}
 
-	// run the transparent host egress as separate binary, non-blocking
 	#[cfg(feature = "egress")]
 	fn run_egress_host_bridge(&self) {
 		let vsock = self.socket_placeholder.vsock();
 		let cid = vsock.cid();
-		let flags = qos_core::io::vsock_svm_flags(vsock); // ensure we copy the flags as set
+		let flags = qos_core::io::vsock_svm_flags(vsock);
 		let vsock_to_host = flags == qos_core::io::VMADDR_FLAG_TO_HOST;
 		let egress_bin_path: &str =
 			self.egress_bin_path.as_deref().unwrap_or("/qos_egress");
@@ -121,42 +201,194 @@ impl BridgeServer {
 		qos_core::egress::run_looping(egress_bin_path, &args);
 	}
 
-	fn run_ingress_bridge(
+	async fn run_ingress_bridge(
 		&self,
 		core_port: u16,
 		host_port: u16,
 		host_ip_str: &str,
-	) {
-		// derive the app socket, for vsock just use the app host port with same CID as the enclave socket,
-		// with usock just add "<port>.appsock" suffix
-		let app_socket = match self.socket_placeholder.with_port(core_port) {
-			Ok(value) => value,
-			Err(err) => {
-				eprintln!(
-					"unable to derive app socket from enclave socket: {err:?}, tcp to vsock bridge will not start"
-				);
-				return;
-			}
-		};
-
-		let app_pool = match StreamPool::single(app_socket) {
-			Ok(value) => value,
-			Err(err) => {
-				eprintln!(
-					"unable to create new app socket pool: {err:?}, tcp to vsock bridge will not start"
-				);
-				return;
-			}
-		};
-
-		let Ok(host_ip) = host_ip_str.parse::<Ipv4Addr>() else {
-			eprintln!(
-				"unable to parse host ip for bridge configuration: {host_ip_str}"
-			);
-			return;
-		};
+		policy_hash: PolicyHash,
+		stale_tx: mpsc::UnboundedSender<()>,
+	) -> Result<JoinHandle<Result<(), IOError>>, IOError> {
+		let app_socket = self.socket_placeholder.with_port(core_port)?;
+		let app_pool = StreamPool::single(app_socket)?;
+		let host_ip = host_ip_str
+			.parse::<Ipv4Addr>()
+			.map_err(|_| IOError::ConnectAddressInvalid)?;
 		let host_addr = SocketAddr::new(host_ip.into(), host_port);
 
-		HostBridge::new(app_pool, host_addr).tcp_to_vsock();
+		HostBridge::new(app_pool, host_addr)
+			.tcp_to_vsock(policy_hash, stale_tx)
+			.await
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::{
+		net::UdpSocket,
+		sync::atomic::{AtomicUsize, Ordering},
+	};
+
+	use qos_core::io::serve_bridge_control;
+	use tokio::net::{TcpListener, TcpStream};
+
+	use super::*;
+
+	static NEXT_SOCKET: AtomicUsize = AtomicUsize::new(0);
+
+	fn socket_placeholder() -> SocketAddress {
+		let id = NEXT_SOCKET.fetch_add(1, Ordering::Relaxed);
+		SocketAddress::new_unix(format!(
+			"/tmp/qos_bridge_lifecycle_{}_{}.sock",
+			std::process::id(),
+			id
+		))
+	}
+
+	async fn free_port() -> u16 {
+		TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+			.await
+			.unwrap()
+			.local_addr()
+			.unwrap()
+			.port()
+	}
+
+	fn non_loopback_ipv4() -> Option<Ipv4Addr> {
+		let socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).ok()?;
+		socket.connect((Ipv4Addr::new(192, 0, 2, 1), 9)).ok()?;
+		match socket.local_addr().ok()?.ip() {
+			std::net::IpAddr::V4(ip) if !ip.is_loopback() => Some(ip),
+			_ => None,
+		}
+	}
+
+	fn start_enclave_bridges(
+		placeholder: &SocketAddress,
+		configs: &[BridgeConfig],
+	) -> Vec<JoinHandle<Result<(), IOError>>> {
+		let server_bridges = configs.to_vec();
+		let hash = ingress_policy_hash(&server_bridges).unwrap();
+		let mut workers = Vec::new();
+		for config in configs {
+			let BridgeConfig::Server { port, .. } = config else {
+				continue;
+			};
+			let app_address = placeholder.with_port(*port).unwrap();
+			let app_pool = StreamPool::single(app_address).unwrap();
+			let pivot_address =
+				SocketAddr::new(Ipv4Addr::LOCALHOST.into(), *port);
+			workers.push(
+				HostBridge::new(app_pool, pivot_address)
+					.vsock_to_tcp_admitted(hash)
+					.unwrap(),
+			);
+		}
+		let control_address =
+			placeholder.with_system_port(BRIDGE_CONTROL_VSOCK_PORT).unwrap();
+		workers.push(
+			serve_bridge_control(&control_address, &server_bridges, false)
+				.unwrap(),
+		);
+		workers
+	}
+
+	async fn activate_for(
+		server: &BridgeServer,
+		placeholder: &SocketAddress,
+		configs: &[BridgeConfig],
+	) -> ActiveIngress {
+		let control_address =
+			placeholder.with_system_port(BRIDGE_CONTROL_VSOCK_PORT).unwrap();
+		let (control_stream, announced, egress_enabled) =
+			open_bridge_control(&control_address).await.unwrap();
+		assert_eq!(announced, configs);
+		assert!(!egress_enabled);
+		let hash = ingress_policy_hash(&announced).unwrap();
+		server.activate_ingress(control_stream, &announced, hash).await.unwrap()
+	}
+
+	async fn stop_workers(workers: Vec<JoinHandle<Result<(), IOError>>>) {
+		for worker in &workers {
+			worker.abort();
+		}
+		for worker in workers {
+			let _ = worker.await;
+		}
+	}
+
+	async fn wait_for_revocation(active: ActiveIngress) {
+		tokio::time::timeout(Duration::from_secs(1), active.run_until_stale())
+			.await
+			.expect("ingress did not revoke after enclave shutdown");
+	}
+
+	#[tokio::test(flavor = "multi_thread")]
+	async fn same_socket_replacement_narrows_then_removes_listener() {
+		let placeholder = socket_placeholder();
+		let app_port = free_port().await;
+		let host_port = free_port().await;
+		let external_ip = non_loopback_ipv4();
+		let server =
+			BridgeServer::new(placeholder.clone(), Some(host_port), None);
+
+		let public = vec![BridgeConfig::Server {
+			port: app_port,
+			host: "0.0.0.0".into(),
+		}];
+		let public_workers = start_enclave_bridges(&placeholder, &public);
+		let public_active = activate_for(&server, &placeholder, &public).await;
+		if let Some(external_ip) = external_ip {
+			assert!(
+				tokio::time::timeout(
+					Duration::from_secs(1),
+					TcpStream::connect((external_ip, host_port))
+				)
+				.await
+				.expect("public listener connection timed out")
+				.is_ok(),
+				"public listener did not accept on the external address"
+			);
+		}
+
+		stop_workers(public_workers).await;
+		wait_for_revocation(public_active).await;
+
+		let narrowed = vec![BridgeConfig::Server {
+			port: app_port,
+			host: "127.0.0.1".into(),
+		}];
+		let narrowed_workers = start_enclave_bridges(&placeholder, &narrowed);
+		let narrowed_active =
+			activate_for(&server, &placeholder, &narrowed).await;
+		assert!(
+			TcpStream::connect((Ipv4Addr::LOCALHOST, host_port)).await.is_ok()
+		);
+		if let Some(external_ip) = external_ip {
+			assert!(
+				tokio::time::timeout(
+					Duration::from_millis(200),
+					TcpStream::connect((external_ip, host_port))
+				)
+				.await
+				.expect("narrowed listener connection timed out")
+				.is_err(),
+				"narrowed listener accepted on the external address"
+			);
+		}
+
+		stop_workers(narrowed_workers).await;
+		wait_for_revocation(narrowed_active).await;
+
+		let removed = Vec::new();
+		let removed_workers = start_enclave_bridges(&placeholder, &removed);
+		let removed_active =
+			activate_for(&server, &placeholder, &removed).await;
+		assert!(
+			TcpStream::connect((Ipv4Addr::LOCALHOST, host_port)).await.is_err()
+		);
+
+		stop_workers(removed_workers).await;
+		wait_for_revocation(removed_active).await;
 	}
 }

--- a/src/qos_core/src/io/bridge_protocol.rs
+++ b/src/qos_core/src/io/bridge_protocol.rs
@@ -1,0 +1,297 @@
+//! Admission protocol for manifest-authorized ingress bridges.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+use tokio::task::{JoinHandle, JoinSet};
+
+use crate::{
+	io::{IOError, Listener, SocketAddress, Stream},
+	protocol::services::boot::BridgeConfig,
+};
+
+/// VSOCK port reserved for the bridge lifecycle control connection.
+///
+/// Application bridge ports are `u16`, so `65_536` is the first VSOCK port that
+/// cannot collide with a configured application bridge. The egress bridge uses
+/// a separate reserved port (`EGRESS_VSOCK_PORT`) for transparent networking;
+/// these are different protocols and must not share a port.
+pub const BRIDGE_CONTROL_VSOCK_PORT: u32 = 65_536;
+
+/// Maximum time allowed for a bridge admission exchange.
+pub const BRIDGE_ADMISSION_TIMEOUT: std::time::Duration =
+	std::time::Duration::from_secs(3);
+
+/// A typed hash of the effective host-ingress policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct PolicyHash(#[serde(with = "qos_hex::serde")] [u8; 32]);
+
+impl PolicyHash {
+	/// Wrap a SHA-256 digest as an ingress policy hash.
+	#[must_use]
+	pub const fn new(bytes: [u8; 32]) -> Self {
+		Self(bytes)
+	}
+}
+
+fn canonicalize_bridge_config(
+	bridge_config: &[BridgeConfig],
+) -> Vec<BridgeConfig> {
+	bridge_config.iter().cloned().collect::<BTreeSet<_>>().into_iter().collect()
+}
+
+/// Hash the effective host-ingress policy.
+///
+/// The input must contain only the `BridgeConfig::Server` entries announced on
+/// the control connection. Entries are canonically ordered by port and host, so
+/// equivalent policies hash identically even if their manifest order differs.
+///
+/// # Errors
+///
+/// Returns an error if QOS canonical JSON serialization fails.
+pub fn ingress_policy_hash(
+	server_bridges: &[BridgeConfig],
+) -> Result<PolicyHash, serde_json::Error> {
+	let canonical = canonicalize_bridge_config(server_bridges);
+	qos_json::hash(&canonical).map(PolicyHash::new)
+}
+
+/// Messages exchanged on the persistent bridge-control connection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "type")]
+pub enum BridgeControlMessage {
+	/// Announce the policy for this enclave lifecycle.
+	Policy {
+		/// Ordered server bridge entries. Client entries are not included.
+		server_bridges: Vec<BridgeConfig>,
+		/// Whether the manifest also enables transparent client egress.
+		egress_enabled: bool,
+	},
+}
+
+/// Messages exchanged before a data VSOCK becomes a raw application stream.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "type")]
+pub enum BridgeDataMessage {
+	/// Request admission under one ingress policy.
+	Open {
+		/// Hash of the effective server bridge policy.
+		policy_hash: PolicyHash,
+	},
+	/// The enclave accepted the connection.
+	Accepted {
+		/// Echo of the policy hash that was accepted.
+		policy_hash: PolicyHash,
+	},
+	/// The enclave rejected the connection.
+	Rejected,
+}
+
+/// Bind the enclave-side bridge-control endpoint.
+///
+/// The returned task owns the listener and every accepted lifecycle lease.
+///
+/// # Errors
+///
+/// Returns an error if the control listener cannot be bound.
+pub fn serve_bridge_control(
+	address: &SocketAddress,
+	server_bridges: &[BridgeConfig],
+	egress_enabled: bool,
+) -> Result<JoinHandle<Result<(), IOError>>, IOError> {
+	let listener = Listener::listen(address)?;
+	let server_bridges = canonicalize_bridge_config(server_bridges);
+	println!("bridge control listening on {}", listener.addr());
+
+	Ok(tokio::spawn(async move {
+		let mut leases = JoinSet::new();
+		loop {
+			tokio::select! {
+				biased;
+				result = leases.join_next(), if !leases.is_empty() => {
+					if let Some(Err(err)) = result {
+						eprintln!("bridge control lease task failed: {err:?}");
+					}
+				}
+				result = listener.accept() => {
+					let stream = result?;
+					leases.spawn(serve_bridge_control_lease(
+						stream,
+						server_bridges.clone(),
+						egress_enabled,
+					));
+				}
+			}
+		}
+	}))
+}
+
+async fn serve_bridge_control_lease(
+	mut stream: Stream,
+	server_bridges: Vec<BridgeConfig>,
+	egress_enabled: bool,
+) {
+	let policy =
+		BridgeControlMessage::Policy { server_bridges, egress_enabled };
+	let Ok(policy) = qos_json::to_vec(&policy) else {
+		return;
+	};
+	if let Err(err) = stream.send(&policy).await {
+		eprintln!("bridge control policy announcement failed: {err:?}");
+		return;
+	}
+
+	// No heartbeat is required. Reading here keeps the control lease alive and
+	// treats EOF or any unexpected message as lease termination.
+	let _ = stream.recv().await;
+}
+
+/// Open a host-side bridge-control lifecycle lease and receive its policy.
+///
+/// # Errors
+///
+/// Returns an error if connection setup, transport, or policy decoding fails.
+pub async fn open_bridge_control(
+	address: &SocketAddress,
+) -> Result<(Stream, Vec<BridgeConfig>, bool), IOError> {
+	let mut stream = Stream::new(address);
+	let admission = async {
+		stream.connect().await?;
+
+		// See https://github.com/rust-vmm/vhost-device/issues/963.
+		#[cfg(feature = "qemu")]
+		tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+		let policy = stream.recv().await?;
+		let policy: BridgeControlMessage =
+			qos_json::from_slice(&policy).map_err(|_| IOError::UnknownError)?;
+		let BridgeControlMessage::Policy { server_bridges, egress_enabled } =
+			policy;
+		if server_bridges
+			.iter()
+			.any(|config| !matches!(config, BridgeConfig::Server { .. }))
+		{
+			return Err(IOError::UnexpectedProxyConnection);
+		}
+		Ok((server_bridges, egress_enabled))
+	};
+
+	let policy = tokio::time::timeout(BRIDGE_ADMISSION_TIMEOUT, admission)
+		.await
+		.map_err(|_| IOError::ConnectTimeout)??;
+	Ok((stream, policy.0, policy.1))
+}
+
+#[cfg(test)]
+mod tests {
+	use std::sync::atomic::{AtomicUsize, Ordering};
+
+	use super::*;
+
+	static NEXT_SOCKET: AtomicUsize = AtomicUsize::new(0);
+
+	fn control_address() -> SocketAddress {
+		let id = NEXT_SOCKET.fetch_add(1, Ordering::Relaxed);
+		SocketAddress::new_unix(format!(
+			"/tmp/qos_bridge_control_{}_{}.sock",
+			std::process::id(),
+			id
+		))
+	}
+
+	fn server(port: u16, host: &str) -> BridgeConfig {
+		BridgeConfig::Server { port, host: host.into() }
+	}
+
+	#[test]
+	fn ingress_hash_is_order_independent_but_tracks_policy_changes() {
+		let original = vec![server(3000, "0.0.0.0"), server(4000, "127.0.0.1")];
+		let reordered =
+			vec![server(4000, "127.0.0.1"), server(3000, "0.0.0.0")];
+
+		assert_eq!(
+			ingress_policy_hash(&original).unwrap(),
+			ingress_policy_hash(&reordered).unwrap()
+		);
+		assert_ne!(
+			ingress_policy_hash(&original).unwrap(),
+			ingress_policy_hash(&[
+				server(3000, "127.0.0.1"),
+				server(4000, "127.0.0.1"),
+			])
+			.unwrap()
+		);
+		assert_ne!(
+			ingress_policy_hash(&original).unwrap(),
+			ingress_policy_hash(&[
+				server(3001, "0.0.0.0"),
+				server(4000, "127.0.0.1"),
+			])
+			.unwrap()
+		);
+		assert_ne!(
+			ingress_policy_hash(&original).unwrap(),
+			ingress_policy_hash(&[server(3000, "0.0.0.0")]).unwrap()
+		);
+	}
+
+	#[test]
+	fn bridge_messages_use_qos_json() {
+		let control_message = BridgeControlMessage::Policy {
+			server_bridges: vec![server(3000, "0.0.0.0")],
+			egress_enabled: true,
+		};
+		let encoded = qos_json::to_vec(&control_message).unwrap();
+		assert_eq!(
+			qos_json::from_slice::<BridgeControlMessage>(&encoded).unwrap(),
+			control_message
+		);
+
+		let data_message = BridgeDataMessage::Accepted {
+			policy_hash: PolicyHash::new([0xab; 32]),
+		};
+		let encoded = qos_json::to_vec(&data_message).unwrap();
+		assert_eq!(
+			qos_json::from_slice::<BridgeDataMessage>(&encoded).unwrap(),
+			data_message
+		);
+	}
+
+	#[tokio::test]
+	async fn control_announces_policy_and_closes_with_server() {
+		let address = control_address();
+		let server_bridges = vec![server(3000, "0.0.0.0")];
+		let server =
+			serve_bridge_control(&address, &server_bridges, true).unwrap();
+		let (mut lease, received, egress_enabled) =
+			open_bridge_control(&address).await.unwrap();
+		assert_eq!(received, server_bridges);
+		assert!(egress_enabled);
+
+		server.abort();
+		let _ = server.await;
+		let closed = tokio::time::timeout(
+			std::time::Duration::from_secs(1),
+			lease.recv(),
+		)
+		.await;
+		assert!(closed.is_ok(), "control lease did not close");
+		assert!(closed.unwrap().is_err());
+	}
+
+	#[tokio::test]
+	async fn control_rejects_client_entries_in_server_policy() {
+		let address = control_address();
+		let server = serve_bridge_control(
+			&address,
+			&[BridgeConfig::Client { port: 443, host: None }],
+			false,
+		)
+		.unwrap();
+
+		assert!(open_bridge_control(&address).await.is_err());
+		server.abort();
+		let _ = server.await;
+	}
+}

--- a/src/qos_core/src/io/host_bridge.rs
+++ b/src/qos_core/src/io/host_bridge.rs
@@ -4,10 +4,14 @@ use futures::future::join_all;
 use tokio::{
 	io::copy_bidirectional,
 	net::{TcpListener, TcpStream},
+	sync::mpsc,
 	task::JoinHandle,
+	task::JoinSet,
 };
 
+#[cfg(test)]
 use crate::io::SocketAddress;
+use crate::io::{BRIDGE_ADMISSION_TIMEOUT, BridgeDataMessage, PolicyHash};
 
 use super::{IOError, Listener, Stream, StreamPool};
 
@@ -33,25 +37,55 @@ impl HostBridge {
 		Self { stream_pool, host_addr }
 	}
 
-	/// Create a TCP to VSOCK bridge using the provided `StreamPool` and `SocketAddr` from constructor.
-	/// This consumes the `HostBridge` instance and starts background tasks that only return on unrecoverable errors.
-	/// NOTE: this spawns a standalone tasks and *DOES NOT WAIT* for completion.
-	pub fn tcp_to_vsock(self) {
-		println!("starting tcp to vsock host bridge @ {}", self.host_addr);
-		tokio::spawn(async move {
-			let streams = self.stream_pool.to_streams();
-			let mut tasks = Vec::new();
-			let mut host_addr = self.host_addr;
+	/// Bind a policy-admitted TCP-to-VSOCK bridge.
+	///
+	/// Binding completes before this function returns. The returned task owns
+	/// all listeners and accepted relays. Aborting it closes both. Admission
+	/// failures notify `stale_tx` so the caller can revoke the active policy.
+	///
+	/// # Errors
+	///
+	/// Returns an error if any host TCP listener cannot be bound.
+	pub async fn tcp_to_vsock(
+		self,
+		policy_hash: PolicyHash,
+		stale_tx: mpsc::UnboundedSender<()>,
+	) -> Result<JoinHandle<Result<(), IOError>>, IOError> {
+		let streams = self.stream_pool.to_streams();
+		let mut bound = Vec::with_capacity(streams.len());
+		let mut host_addr = self.host_addr;
 
-			for stream in streams {
+		for stream in streams {
+			let listener = TcpListener::bind(host_addr).await?;
+			bound.push((stream, listener, host_addr));
+			host_addr.set_port(host_addr.port() + 1);
+		}
+
+		Ok(tokio::spawn(async move {
+			let mut listeners = JoinSet::new();
+			for (stream, listener, host_addr) in bound {
 				println!("tcp to vsock bridge listening on {host_addr}");
-				tasks.push(tokio::spawn(tcp_to_vsock(stream, host_addr)));
-				// bump port by 1 for next listener
-				host_addr.set_port(host_addr.port() + 1);
+				let stale_tx = stale_tx.clone();
+				listeners.spawn(tcp_to_vsock_listener(
+					stream,
+					listener,
+					host_addr,
+					policy_hash,
+					stale_tx,
+				));
 			}
 
-			await_all(tasks).await;
-		});
+			let result = match listeners.join_next().await {
+				Some(Ok(result)) => result,
+				Some(Err(err)) => {
+					eprintln!("admitted listener task failed: {err:?}");
+					Err(IOError::UnknownError)
+				}
+				None => Ok(()),
+			};
+			let _ = stale_tx.send(());
+			result
+		}))
 	}
 
 	/// Create a VSOCK to TCP bridge using the provided `StreamPool` and
@@ -88,6 +122,52 @@ impl HostBridge {
 			await_all(tasks).await;
 		});
 	}
+
+	/// Bind a policy-admitted VSOCK-to-TCP bridge.
+	///
+	/// The returned task owns all VSOCK listeners and accepted relays. A
+	/// connection reaches the pivot only after presenting `policy_hash`.
+	///
+	/// # Errors
+	///
+	/// Returns an error if any enclave-side listener cannot be bound.
+	pub fn vsock_to_tcp_admitted(
+		self,
+		policy_hash: PolicyHash,
+	) -> Result<JoinHandle<Result<(), IOError>>, IOError> {
+		let listeners = self.stream_pool.listen()?;
+		let mut host_addr = self.host_addr;
+		let mut bound = Vec::with_capacity(listeners.len());
+
+		for listener in listeners {
+			println!(
+				"admitted vsock to tcp bridge listening on {}",
+				listener.addr()
+			);
+			bound.push((listener, host_addr));
+			host_addr.set_port(host_addr.port() + 1);
+		}
+
+		Ok(tokio::spawn(async move {
+			let mut listener_tasks = JoinSet::new();
+			for (listener, host_addr) in bound {
+				listener_tasks.spawn(vsock_to_tcp_admitted(
+					listener,
+					host_addr,
+					policy_hash,
+				));
+			}
+
+			match listener_tasks.join_next().await {
+				Some(Ok(result)) => result,
+				Some(Err(err)) => {
+					eprintln!("admitted listener task failed: {err:?}");
+					Err(IOError::UnknownError)
+				}
+				None => Ok(()),
+			}
+		}))
+	}
 }
 
 async fn await_all(tasks: Vec<JoinHandle<Result<(), IOError>>>) {
@@ -106,50 +186,84 @@ async fn await_all(tasks: Vec<JoinHandle<Result<(), IOError>>>) {
 	}
 }
 
-// bridge tcp to vsock in an endless loop with 1s retry on errors
-async fn tcp_to_vsock(
+async fn tcp_to_vsock_listener(
 	enclave_stream: Stream,
+	listener: TcpListener,
 	host_addr: SocketAddr,
+	policy_hash: PolicyHash,
+	stale_tx: mpsc::UnboundedSender<()>,
 ) -> Result<(), IOError> {
-	let listener = match TcpListener::bind(host_addr).await {
-		Ok(value) => value,
-		Err(err) => panic!("error binding to {host_addr}: {err}"),
-	};
+	let mut relays = JoinSet::new();
 
 	loop {
-		let mut tcp_stream = match listener.accept().await {
-			Ok((value, _)) => value,
-			Err(err) => {
-				eprintln!(
-					"error accepting connection on tcp addr {host_addr}: {err:?}"
-				);
-				continue;
+		tokio::select! {
+			biased;
+			result = relays.join_next(), if !relays.is_empty() => {
+				if let Some(Err(err)) = result {
+					eprintln!("tcp to vsock relay task failed: {err:?}");
+				}
 			}
-		};
+			result = listener.accept() => {
+				let (tcp_stream, _) = match result {
+					Ok(value) => value,
+					Err(err) => {
+						eprintln!("error accepting connection on tcp addr {host_addr}: {err:?}");
+						return Err(err.into());
+					}
+				};
 
-		let mut stream = Stream::from(&enclave_stream);
-		tokio::spawn(async move {
-			if let Err(err) = stream.connect().await {
-				eprintln!(
-					"error connecting to VSOCK @ {} error: {err:?}",
-					stream
-						.address()
-						.unwrap_or(&SocketAddress::new_unix("unknown")),
-				);
-				return;
+				let stream = Stream::from(&enclave_stream);
+				let stale_tx = stale_tx.clone();
+				relays.spawn(async move {
+					if let Err(err) = admitted_tcp_relay(
+						tcp_stream,
+						stream,
+						policy_hash,
+					).await {
+						eprintln!("bridge data admission failed: {err:?}");
+						let _ = stale_tx.send(());
+					}
+				});
 			}
-
-			// see https://github.com/rust-vmm/vhost-device/issues/963
-			#[cfg(feature = "qemu")]
-			tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-
-			if let Err(err) =
-				copy_bidirectional(&mut tcp_stream, &mut stream).await
-			{
-				eprintln!("error on tcp to vsock stream bridge: {err:?}");
-			}
-		});
+		}
 	}
+}
+
+async fn admitted_tcp_relay(
+	mut tcp_stream: TcpStream,
+	mut enclave_stream: Stream,
+	policy_hash: PolicyHash,
+) -> Result<(), IOError> {
+	let admission = async {
+		enclave_stream.connect().await?;
+
+		// See https://github.com/rust-vmm/vhost-device/issues/963.
+		#[cfg(feature = "qemu")]
+		tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+		let request =
+			qos_json::to_vec(&BridgeDataMessage::Open { policy_hash })
+				.map_err(|_| IOError::UnknownError)?;
+		enclave_stream.send(&request).await?;
+		let response = enclave_stream.recv().await?;
+		let response: BridgeDataMessage = qos_json::from_slice(&response)
+			.map_err(|_| IOError::UnknownError)?;
+		if response != (BridgeDataMessage::Accepted { policy_hash }) {
+			return Err(IOError::UnexpectedProxyConnection);
+		}
+		Ok(())
+	};
+
+	tokio::time::timeout(BRIDGE_ADMISSION_TIMEOUT, admission)
+		.await
+		.map_err(|_| IOError::ConnectTimeout)??;
+
+	if let Err(err) =
+		copy_bidirectional(&mut tcp_stream, &mut enclave_stream).await
+	{
+		eprintln!("error on admitted tcp to vsock stream bridge: {err:?}");
+	}
+	Ok(())
 }
 
 // bridge vsock to tcp in an endless loop with 1s retry on errors
@@ -183,5 +297,294 @@ async fn vsock_to_tcp(
 				eprintln!("error on vsock to tcp stream bridge: {err:?}");
 			}
 		});
+	}
+}
+
+async fn vsock_to_tcp_admitted(
+	enclave_listener: Listener,
+	host_addr: SocketAddr,
+	policy_hash: PolicyHash,
+) -> Result<(), IOError> {
+	let mut relays = JoinSet::new();
+
+	loop {
+		tokio::select! {
+			biased;
+			result = relays.join_next(), if !relays.is_empty() => {
+				if let Some(Err(err)) = result {
+					eprintln!("vsock to tcp relay task failed: {err:?}");
+				}
+			}
+			result = enclave_listener.accept() => {
+				let stream = match result {
+					Ok(stream) => stream,
+					Err(err) => {
+						eprintln!("error accepting admitted vsock connection: {err:?}");
+						return Err(err);
+					}
+				};
+				relays.spawn(admitted_vsock_relay(stream, host_addr, policy_hash));
+			}
+		}
+	}
+}
+
+async fn admitted_vsock_relay(
+	mut enclave_stream: Stream,
+	host_addr: SocketAddr,
+	policy_hash: PolicyHash,
+) {
+	let admitted = tokio::time::timeout(BRIDGE_ADMISSION_TIMEOUT, async {
+		let request = enclave_stream.recv().await?;
+		let request = qos_json::from_slice::<BridgeDataMessage>(&request)
+			.map_err(|_| IOError::UnknownError)?;
+		let accepted = matches!(
+			request,
+			BridgeDataMessage::Open { policy_hash: supplied }
+				if supplied == policy_hash
+		);
+		let response = if accepted {
+			BridgeDataMessage::Accepted { policy_hash }
+		} else {
+			BridgeDataMessage::Rejected
+		};
+		let response =
+			qos_json::to_vec(&response).map_err(|_| IOError::UnknownError)?;
+		enclave_stream.send(&response).await?;
+		if accepted { Ok(()) } else { Err(IOError::UnexpectedProxyConnection) }
+	})
+	.await;
+
+	match admitted {
+		Ok(Ok(())) => {}
+		Ok(Err(err)) => {
+			eprintln!("rejecting bridge data connection: {err:?}");
+			return;
+		}
+		Err(_) => {
+			eprintln!("timed out waiting for bridge data admission");
+			return;
+		}
+	}
+
+	let mut tcp_stream = match TcpStream::connect(host_addr).await {
+		Ok(value) => value,
+		Err(err) => {
+			eprintln!("error connecting to tcp addr {host_addr}: {err:?}");
+			return;
+		}
+	};
+
+	if let Err(err) =
+		copy_bidirectional(&mut enclave_stream, &mut tcp_stream).await
+	{
+		eprintln!("error on admitted vsock to tcp stream bridge: {err:?}");
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::{
+		net::Ipv4Addr,
+		sync::atomic::{AtomicUsize, Ordering},
+	};
+
+	use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+	use super::*;
+
+	static NEXT_SOCKET: AtomicUsize = AtomicUsize::new(0);
+
+	fn app_address() -> SocketAddress {
+		let id = NEXT_SOCKET.fetch_add(1, Ordering::Relaxed);
+		SocketAddress::new_unix(format!(
+			"/tmp/qos_admitted_bridge_{}_{}.sock",
+			std::process::id(),
+			id
+		))
+	}
+
+	async fn free_tcp_address() -> SocketAddr {
+		let listener =
+			TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+		listener.local_addr().unwrap()
+	}
+
+	async fn echo_server() -> (TcpListener, SocketAddr) {
+		let listener =
+			TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+		let address = listener.local_addr().unwrap();
+		(listener, address)
+	}
+
+	#[tokio::test]
+	async fn admitted_bridge_preserves_application_bytes() {
+		let hash = PolicyHash::new([7; 32]);
+		let app_address = app_address();
+		let (pivot, pivot_address) = echo_server().await;
+		let pivot_task = tokio::spawn(async move {
+			let (mut stream, _) = pivot.accept().await.unwrap();
+			let mut bytes = [0; 9];
+			stream.read_exact(&mut bytes).await.unwrap();
+			stream.write_all(&bytes).await.unwrap();
+		});
+		let enclave_bridge = HostBridge::new(
+			StreamPool::single(app_address.clone()).unwrap(),
+			pivot_address,
+		)
+		.vsock_to_tcp_admitted(hash)
+		.unwrap();
+		let host_address = free_tcp_address().await;
+		let (stale_tx, _stale_rx) = mpsc::unbounded_channel();
+		let host_bridge = HostBridge::new(
+			StreamPool::single(app_address).unwrap(),
+			host_address,
+		)
+		.tcp_to_vsock(hash, stale_tx)
+		.await
+		.unwrap();
+
+		let mut client = TcpStream::connect(host_address).await.unwrap();
+		let tls_like = [0x16, 0x03, 0x03, 0, 4, 1, 2, 3, 4];
+		client.write_all(&tls_like).await.unwrap();
+		let mut reply = [0; 9];
+		client.read_exact(&mut reply).await.unwrap();
+		assert_eq!(reply, tls_like);
+
+		host_bridge.abort();
+		enclave_bridge.abort();
+		let _ = host_bridge.await;
+		let _ = enclave_bridge.await;
+		pivot_task.await.unwrap();
+	}
+
+	#[tokio::test]
+	async fn wrong_hash_never_connects_to_pivot() {
+		let app_address = app_address();
+		let (pivot, pivot_address) = echo_server().await;
+		let enclave_bridge = HostBridge::new(
+			StreamPool::single(app_address.clone()).unwrap(),
+			pivot_address,
+		)
+		.vsock_to_tcp_admitted(PolicyHash::new([1; 32]))
+		.unwrap();
+		let host_address = free_tcp_address().await;
+		let (stale_tx, mut stale_rx) = mpsc::unbounded_channel();
+		let host_bridge = HostBridge::new(
+			StreamPool::single(app_address).unwrap(),
+			host_address,
+		)
+		.tcp_to_vsock(PolicyHash::new([2; 32]), stale_tx)
+		.await
+		.unwrap();
+
+		let mut client = TcpStream::connect(host_address).await.unwrap();
+		client.write_all(b"not authorized").await.unwrap();
+		tokio::time::timeout(
+			std::time::Duration::from_secs(1),
+			stale_rx.recv(),
+		)
+		.await
+		.expect("host did not report stale policy");
+		assert!(
+			tokio::time::timeout(
+				std::time::Duration::from_millis(100),
+				pivot.accept()
+			)
+			.await
+			.is_err(),
+			"rejected data connection reached the pivot"
+		);
+
+		host_bridge.abort();
+		enclave_bridge.abort();
+		let _ = host_bridge.await;
+		let _ = enclave_bridge.await;
+	}
+
+	#[tokio::test]
+	async fn direct_vsock_service_receives_no_client_bytes() {
+		let app_address = app_address();
+		let listener = Listener::listen(&app_address).unwrap();
+		let direct_task = tokio::spawn(async move {
+			let mut stream = listener.accept().await.unwrap();
+			let admission = stream.recv().await.unwrap();
+			assert!(matches!(
+				qos_json::from_slice::<BridgeDataMessage>(&admission).unwrap(),
+				BridgeDataMessage::Open { .. }
+			));
+			let mut byte = [0];
+			assert!(
+				tokio::time::timeout(
+					std::time::Duration::from_millis(200),
+					stream.read_exact(&mut byte)
+				)
+				.await
+				.is_err(),
+				"client bytes arrived before admission"
+			);
+		});
+		let host_address = free_tcp_address().await;
+		let (stale_tx, _stale_rx) = mpsc::unbounded_channel();
+		let host_bridge = HostBridge::new(
+			StreamPool::single(app_address).unwrap(),
+			host_address,
+		)
+		.tcp_to_vsock(PolicyHash::new([3; 32]), stale_tx)
+		.await
+		.unwrap();
+
+		let mut client = TcpStream::connect(host_address).await.unwrap();
+		client.write_all(b"TLS ClientHello").await.unwrap();
+		direct_task.await.unwrap();
+		host_bridge.abort();
+		let _ = host_bridge.await;
+	}
+
+	#[tokio::test]
+	async fn aborting_listener_closes_active_relay() {
+		let hash = PolicyHash::new([4; 32]);
+		let app_address = app_address();
+		let (pivot, pivot_address) = echo_server().await;
+		let pivot_task = tokio::spawn(async move {
+			let (mut stream, _) = pivot.accept().await.unwrap();
+			let mut byte = [0];
+			stream.read_exact(&mut byte).await.unwrap();
+			stream.write_all(&byte).await.unwrap();
+			let _ = stream.read(&mut byte).await;
+		});
+		let enclave_bridge = HostBridge::new(
+			StreamPool::single(app_address.clone()).unwrap(),
+			pivot_address,
+		)
+		.vsock_to_tcp_admitted(hash)
+		.unwrap();
+		let host_address = free_tcp_address().await;
+		let (stale_tx, _stale_rx) = mpsc::unbounded_channel();
+		let host_bridge = HostBridge::new(
+			StreamPool::single(app_address).unwrap(),
+			host_address,
+		)
+		.tcp_to_vsock(hash, stale_tx)
+		.await
+		.unwrap();
+		let mut client = TcpStream::connect(host_address).await.unwrap();
+		client.write_all(&[9]).await.unwrap();
+		let mut reply = [0];
+		client.read_exact(&mut reply).await.unwrap();
+
+		host_bridge.abort();
+		let _ = host_bridge.await;
+		let closed = tokio::time::timeout(
+			std::time::Duration::from_secs(1),
+			client.read(&mut reply),
+		)
+		.await
+		.expect("active external connection did not close")
+		.unwrap();
+		assert_eq!(closed, 0);
+		enclave_bridge.abort();
+		let _ = enclave_bridge.await;
+		pivot_task.await.unwrap();
 	}
 }

--- a/src/qos_core/src/io/mod.rs
+++ b/src/qos_core/src/io/mod.rs
@@ -3,11 +3,13 @@
 //! NOTE TO MAINTAINERS: Interaction with any sys calls should be contained
 //! within this module.
 
+mod bridge_protocol;
 mod host_bridge;
 mod pool;
 mod stream;
 use std::path::Path;
 
+pub use bridge_protocol::*;
 pub use host_bridge::*;
 pub use pool::*;
 pub use stream::*;
@@ -219,6 +221,39 @@ impl SocketAddress {
 
 				path.push(format!(".{port}.appsock"));
 
+				Ok(Self::new_unix(
+					path.to_str().ok_or(IOError::ConnectAddressInvalid)?,
+				))
+			}
+		}
+	}
+
+	/// Return the reserved system socket address for `port`.
+	///
+	/// VSOCK system ports retain the source CID and flags. Unix test sockets
+	/// use a distinct `systemsock` suffix so they cannot collide with app
+	/// sockets derived by [`Self::with_port`].
+	///
+	/// # Errors
+	///
+	/// Returns [`IOError::ConnectAddressInvalid`] if a Unix socket path cannot
+	/// be resolved.
+	pub fn with_system_port(
+		&self,
+		port: u32,
+	) -> Result<SocketAddress, IOError> {
+		match self {
+			#[cfg(not(target_os = "macos"))]
+			Self::Vsock(vsa) => {
+				Ok(Self::new_vsock(vsa.cid(), port, vsock_svm_flags(vsa)))
+			}
+			Self::Unix(ua) => {
+				let mut path = ua
+					.path()
+					.ok_or(IOError::ConnectAddressInvalid)?
+					.as_os_str()
+					.to_owned();
+				path.push(format!(".{port}.systemsock"));
 				Ok(Self::new_unix(
 					path.to_str().ok_or(IOError::ConnectAddressInvalid)?,
 				))

--- a/src/qos_core/src/protocol/services/boot.rs
+++ b/src/qos_core/src/protocol/services/boot.rs
@@ -115,6 +115,8 @@ impl TryFrom<String> for RestartPolicy {
 #[derive(
 	PartialEq,
 	Eq,
+	PartialOrd,
+	Ord,
 	Debug,
 	Clone,
 	serde::Serialize,

--- a/src/qos_core/src/reaper.rs
+++ b/src/qos_core/src/reaper.rs
@@ -16,11 +16,15 @@ use qos_nsm::NsmProvider;
 use tokio::{
 	io::{AsyncBufReadExt, BufReader},
 	process::{Child, Command},
+	task::JoinHandle,
 };
 
 use crate::{
 	handles::Handles,
-	io::{HostBridge, IOError, SocketAddress, StreamPool},
+	io::{
+		BRIDGE_CONTROL_VSOCK_PORT, HostBridge, IOError, SocketAddress,
+		StreamPool, ingress_policy_hash, serve_bridge_control,
+	},
 	protocol::{
 		ProtocolPhase, ProtocolState,
 		processor::ProtocolProcessor,
@@ -75,25 +79,45 @@ async fn run_server(
 fn run_bridges(
 	core_socket: &SocketAddress,
 	bridges: &[BridgeConfig],
-) -> Result<(), IOError> {
-	// do nothing if we're not asked to provide bridging
-	if bridges.is_empty() {
-		println!("skipping host bridge, not configured");
-		return Ok(());
-	}
+) -> Result<Vec<JoinHandle<Result<(), IOError>>>, IOError> {
+	let server_bridges: Vec<BridgeConfig> = bridges
+		.iter()
+		.filter(|config| matches!(config, BridgeConfig::Server { .. }))
+		.cloned()
+		.collect();
+	let policy_hash = ingress_policy_hash(&server_bridges)
+		.map_err(|_| IOError::UnknownError)?;
+	let mut workers = Vec::new();
 
 	let mut egress_enabled = false;
 
 	for bc in bridges {
 		match bc {
 			BridgeConfig::Server { port, host: _ } => {
-				let app_socket = core_socket.with_port(*port)?;
+				let app_socket = match core_socket.with_port(*port) {
+					Ok(socket) => socket,
+					Err(err) => {
+						abort_workers(&workers);
+						return Err(err);
+					}
+				};
 				let host_addr: SocketAddr =
 					SocketAddrV4::new(Ipv4Addr::LOCALHOST, *port).into();
-				let app_pool = StreamPool::single(app_socket)?;
+				let app_pool = match StreamPool::single(app_socket) {
+					Ok(pool) => pool,
+					Err(err) => {
+						abort_workers(&workers);
+						return Err(err);
+					}
+				};
 				let bridge = HostBridge::new(app_pool, host_addr);
-
-				bridge.vsock_to_tcp();
+				match bridge.vsock_to_tcp_admitted(policy_hash) {
+					Ok(worker) => workers.push(worker),
+					Err(err) => {
+						abort_workers(&workers);
+						return Err(err);
+					}
+				}
 			}
 			BridgeConfig::Client { port: _, host: _ } => {
 				// only run one instance as it covers ALL ports, the others are for firewalls
@@ -105,7 +129,33 @@ fn run_bridges(
 		}
 	}
 
-	Ok(())
+	let control_address =
+		match core_socket.with_system_port(BRIDGE_CONTROL_VSOCK_PORT) {
+			Ok(address) => address,
+			Err(err) => {
+				abort_workers(&workers);
+				return Err(err);
+			}
+		};
+	match serve_bridge_control(
+		&control_address,
+		&server_bridges,
+		egress_enabled,
+	) {
+		Ok(worker) => workers.push(worker),
+		Err(err) => {
+			abort_workers(&workers);
+			return Err(err);
+		}
+	}
+
+	Ok(workers)
+}
+
+fn abort_workers(workers: &[JoinHandle<Result<(), IOError>>]) {
+	for worker in workers {
+		worker.abort();
+	}
 }
 
 // dummy placeholder
@@ -240,7 +290,7 @@ impl Reaper {
 		}
 
 		// if the app indicates the need for the VSOCK -> TCP bridge, run it as another task
-		run_bridges(&core_socket, &host_config)
+		let bridge_workers = run_bridges(&core_socket, &host_config)
 			.expect("failed to run ingress/egress bridges");
 
 		let mut pivot = Command::new(handles.pivot_path());
@@ -282,6 +332,11 @@ impl Reaper {
 
 		if let Err(err) = server_worker.await {
 			eprintln!("Reaper::execute server_worker join error: {err:?}");
+		}
+
+		abort_workers(&bridge_workers);
+		for worker in bridge_workers {
+			let _ = worker.await;
 		}
 
 		println!("Reaper exiting ... ");

--- a/src/qos_test_harness/src/docker_qemu.rs
+++ b/src/qos_test_harness/src/docker_qemu.rs
@@ -269,9 +269,6 @@ impl DockerHostQemuNitroRunner {
 		let mut args = self.docker_run_prefix(&self.spec.bridge_run);
 		self.spec.bridge_program.append_program_args(&mut args);
 		args.extend([
-			"--control-url".into(),
-			format!("http://{}:{}/qos", qemu.host_connect_ip, qemu.host_port)
-				.into(),
 			"--cid".into(),
 			qemu.host_cid.to_string().into(),
 			"--host-port-override".into(),
@@ -536,9 +533,6 @@ impl DockerHostQemuNitroRunner {
 	fn append_qos_bridge_args(&self, args: &mut Vec<OsString>) {
 		let qemu = &self.spec.qemu;
 		args.extend([
-			"--control-url".into(),
-			format!("http://{}:{}/qos", qemu.host_connect_ip, qemu.host_port)
-				.into(),
 			"--cid".into(),
 			qemu.host_cid.to_string().into(),
 			"--host-port-override".into(),
@@ -724,15 +718,16 @@ impl DockerHostQemuNitroRunner {
 		]
 	}
 
-	fn vhost_forward_ports(&self, bridge_config: &[BridgeConfig]) -> Vec<u16> {
+	fn vhost_forward_ports(&self, bridge_config: &[BridgeConfig]) -> Vec<u32> {
 		let qemu = &self.spec.qemu;
-		let egress_port = qos_core::EGRESS_VSOCK_PORT
-			.try_into()
-			.expect("QOS egress VSOCK port must fit in u16");
-		let mut ports = vec![qemu.control_vsock_port, egress_port];
+		let mut ports = vec![
+			u32::from(qemu.control_vsock_port),
+			qos_core::EGRESS_VSOCK_PORT,
+			qos_core::io::BRIDGE_CONTROL_VSOCK_PORT,
+		];
 		for bridge in bridge_config {
 			if let BridgeConfig::Server { port, host: _ } = bridge {
-				ports.push(*port);
+				ports.push(u32::from(*port));
 			}
 		}
 		ports.sort_unstable();
@@ -1430,8 +1425,8 @@ const HOST_EGRESS_NFQUEUE_NUM: u16 = 100;
 const HOST_EGRESS_SETUP_SCRIPT: &str =
 	include_str!("../docker/host_egress_setup.sh");
 
-fn format_forward_ports(ports: &[u16]) -> String {
-	ports.iter().map(u16::to_string).collect::<Vec<_>>().join("+")
+fn format_forward_ports(ports: &[u32]) -> String {
+	ports.iter().map(u32::to_string).collect::<Vec<_>>().join("+")
 }
 
 fn sanitize_name(name: &str) -> String {


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)
Don't allow stale bridge configs for obvious reasons see the ticket.
The fix was a little bit more involved. I added a handshake on every TCP connection. I also removed the use of enclave info. I replaced that with a control Vsock, when the control vsock is started the enclave send the bridge the policy it requests, on every TCP connection the bridge sends the policy. It's working with an enclave, acknowledges it this prevents stale configs. I removed using the enclave info and point entirely because it was no longer necessary once we had a control channel.

## How I Tested These Changes

I have not yet

## Pre merge check list

- [x] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
