### PR TITLE
Allow executable binaries on /tmp for enclave apps

### DIFF
--- a/src/init/init.rs
+++ b/src/init/init.rs
@@ -18,13 +18,14 @@ fn init_rootfs() {
 	use libc::{MS_NODEV, MS_NOEXEC, MS_NOSUID};
 	let no_dse = MS_NODEV | MS_NOSUID | MS_NOEXEC;
 	let no_se = MS_NOSUID | MS_NOEXEC;
+	let no_ds = MS_NODEV | MS_NOSUID;
 	let args = [
 		("devtmpfs", "/dev", "devtmpfs", no_se, "mode=0755"),
 		("devpts", "/dev/pts", "devpts", no_se, ""),
 		("shm", "/dev/shm", "tmpfs", no_dse, "mode=0755"),
 		("proc", "/proc", "proc", no_dse, "hidepid=2"),
 		("tmpfs", "/run", "tmpfs", no_dse, "mode=0755"),
-		("tmpfs", "/tmp", "tmpfs", no_dse, ""),
+		("tmpfs", "/tmp", "tmpfs", no_ds, ""),
 		("sysfs", "/sys", "sysfs", no_dse, ""),
 		("cgroup_root", "/sys/fs/cgroup", "tmpfs", no_dse, "mode=0755"),
 	];


### PR DESCRIPTION
## Overview

This PR enables executable binaries on the `/tmp` filesystem mount for enclave applications.

## Changes

- Modified `src/init/init.rs` to remove the `MS_NOEXEC` flag from the `/tmp` mount
- The `/tmp` mount now uses `MS_NODEV | MS_NOSUID` instead of `MS_NODEV | MS_NOSUID | MS_NOEXEC`
- Retains security restrictions on device nodes and SUID binaries

## Motivation

Enclave applications may need to execute binaries from `/tmp`, such as:
- Runtime dependencies
- Temporary scripts
- Dynamically generated executables

This change allows these use cases while maintaining security boundaries through the retention of `MS_NODEV` and `MS_NOSUID` flags.

## Security Considerations

- `MS_NODEV`: Still prevents character/block device files on `/tmp`
- `MS_NOSUID`: Still prevents SUID/SGID bits from being respected
- Only `MS_NOEXEC` is removed, enabling executable capability

## Testing

Please verify that:
1. The system boots successfully with this change
2. Enclave applications can execute binaries from `/tmp`