### PR TITLE
qos_client: re-export the yubikey crate

### DIFF
--- a/src/qos_client/src/lib.rs
+++ b/src/qos_client/src/lib.rs
@@ -4,6 +4,11 @@ pub mod cli;
 #[cfg(feature = "smartcard")]
 pub mod yubikey;
 
+/// Re-export of the [`yubikey`](::yubikey) crate so downstream users can
+/// name its types without a separate, version-matched dependency.
+#[cfg(feature = "smartcard")]
+pub use ::yubikey as yubikey_crate;
+
 /// Host HTTP request helpers.
 pub mod request {
 	use std::io::Read;


### PR DESCRIPTION
Re-export the external `yubikey` crate from `qos_client` as `yubikey_crate`, gated on the `smartcard` feature. Types from that crate (`YubiKey`, `MgmKey`, `TouchPolicy`, ...) already appear in `qos_client::yubikey`'s public API, so downstream consumers currently need their own version-matched `yubikey` dependency. Named `yubikey_crate` because the crate root already has `pub mod yubikey`.

Part of TVC-306.