### PR TITLE
chore: run PR ci post merge on main

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,8 @@
-on: [pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 name: PR
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://github.com/tkhq/qos/blob/main/LICENSE) 
 [![stagex-build Status](https://github.com/tkhq/qos/actions/workflows/stagex.yml/badge.svg)](https://github.com/tkhq/qos/actions/workflows/stagex.yml) 
-[![stagex-build Status](https://github.com/tkhq/qos/actions/workflows/pr.yml/badge.svg)](https://github.com/tkhq/qos/actions/workflows/pr.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/tkhq/qos/pr.yml?branch=main&label=CI)](https://github.com/tkhq/qos/actions/workflows/pr.yml?query=branch%3Amain)
 
 ## About
 


### PR DESCRIPTION
## Summary & Motivation (Problem vs. Solution)

The original badge showed failing because of PRs but we don't want to show that on the main README page. 

## How I Tested These Changes

[On github](https://github.com/tkhq/qos/blob/b7ae9e7337359aae8c2a1e12453aaf25935857c7/README.md)

(no status until this is merged)

## Pre merge check list

- [x] Call out updates and breaking changes via [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Communicate verification flow breaking changes especially thoroughly. If any of the following answers are no, then this is a verification flow breaking change:
    - Can enclaves in a previous QOS version still key forward to this new version?
    - Can previous versions of QOS verify attestations from this new version?
    - Can manifests generated by a previous version still be parsed by this one?
    - Can previous approvals still be verified against a manifest (i.e. is this a non-breaking change to the manifest signing payload)?
    - Can a previous version of QOS still perform a boot standard on an enclave of this version?
